### PR TITLE
Add configurable hidden directory skipping during scanning

### DIFF
--- a/config/scoring_config.py
+++ b/config/scoring_config.py
@@ -394,6 +394,16 @@ class ScoringConfig:
             }
         })
 
+    def get_scanning_settings(self):
+        """Get directory scanning settings.
+
+        Returns settings for directory traversal during photo scanning,
+        including whether to skip hidden directories.
+        """
+        return self.config.get('scanning', {
+            'skip_hidden_directories': True
+        })
+
     def get_exif_adjustments(self):
         """Get EXIF-based scoring adjustment settings."""
         return self.config.get('exif_adjustments', {

--- a/photos.py
+++ b/photos.py
@@ -787,6 +787,10 @@ Configuration:
     extensions = ["*.jpg", "*.jpeg", "*.JPG", "*.JPEG", "*.cr2", "*.CR2", "*.cr3", "*.CR3"]
     valid_suffixes = {'.jpg', '.jpeg', '.cr2', '.cr3'}
     all_files = []
+
+    # Get scanning settings
+    skip_hidden = scorer.config.get_scanning_settings().get('skip_hidden_directories', True)
+
     for path_str in args.photo_paths:
         base_path = Path(path_str).resolve()
         if not base_path.exists():
@@ -799,9 +803,17 @@ Configuration:
             else:
                 print(f"Warning: Unsupported file type: {path_str}")
         else:
-            # Directory - use standard rglob for file discovery
-            for ext in extensions:
-                all_files.extend(list(base_path.rglob(ext)))
+            # Directory - use os.walk to traverse, optionally skipping hidden directories
+            for root, dirs, files in os.walk(base_path):
+                # Prune hidden directories if configured
+                if skip_hidden:
+                    dirs[:] = [d for d in dirs if not d.startswith('.')]
+
+                # Add matching files
+                for f in files:
+                    p = Path(root) / f
+                    if p.suffix.lower() in valid_suffixes:
+                        all_files.append(p)
 
     # Deduplicate (needed for case-insensitive filesystems like Windows)
     all_files = list({f.resolve(): f for f in all_files}.values())

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -1,4 +1,7 @@
 {
+  "scanning": {
+    "skip_hidden_directories": true
+  },
   "categories": [
     {
       "name": "art",


### PR DESCRIPTION
## Summary

Adds a configurable option to skip hidden directories (starting with `.`) during photo scanning. This prevents accidental classification of system cache directories like `.thumbnails`, `.cache`, `.stfolder`, etc.

## Changes

- Add `scanning` section to `scoring_config.json` with `skip_hidden_directories` setting (default: `true`)
- Add `get_scanning_settings()` method to `ScoringConfig` class for retrieving scanning configuration
- Replace `rglob()` traversal with `os.walk()` in `photos.py` to support directory pruning
- Uses standard Python idiom `dirs[:] = [...]` to modify `os.walk` in-place, causing pruned subtrees to be skipped

## Behavior

- **Default (skip_hidden_directories: true)**: Hidden directories are skipped, `.thumbnails/photo.jpg` is ignored
- **Optional (skip_hidden_directories: false)**: All directories are scanned, hidden ones included

## Testing

- ✓ Config validation passes with new `scanning` section
- ✓ Hidden directories correctly skipped by default
- ✓ Hidden directories correctly included when setting is disabled
- ✓ Deduplication and file filtering work correctly

## Notes

The deduplication step (case-insensitive filesystem handling) is retained.