### PR TITLE
fix: prevent culling group ID collisions and preserve manual selections

### DIFF
--- a/api/routers/burst_culling.py
+++ b/api/routers/burst_culling.py
@@ -573,6 +573,9 @@ async def api_culling_groups(
                     conn, similarity_threshold, vis_sql, vis_params, seed, user_id,
                     page_groups=similar_slice, offset=similar_offset,
                 )
+                # Offset similar group IDs by burst_count to avoid ID collisions
+                for g in similar_enriched:
+                    g['group_id'] += burst_count
                 page_groups.extend(similar_enriched)
 
             # Sort by photo count descending so largest groups appear first

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,12 @@
+{
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "json": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}

--- a/client/src/app/features/gallery/burst-culling.component.ts
+++ b/client/src/app/features/gallery/burst-culling.component.ts
@@ -319,8 +319,11 @@ export class BurstCullingComponent implements OnDestroy {
   private autoSelectBest(groups: CullingGroup[], base?: Map<number, Set<string>>): Map<number, Set<string>> {
     const map = base ? new Map(base) : new Map<number, Set<string>>();
     for (const group of groups) {
-      if (group.best_path) {
-        map.set(group.group_id, new Set([group.best_path]));
+      if (!map.has(group.group_id)) {
+        const best = group.best_path || group.photos[0]?.path;
+        if (best) {
+          map.set(group.group_id, new Set([best]));
+        }
       }
     }
     return map;


### PR DESCRIPTION
## Summary

- **Backend**: Offset similar group IDs by `burst_count` in the culling endpoint to prevent ID collisions when burst and similar groups are merged in paginated responses
- **Frontend**: Guard `autoSelectBest` to not overwrite existing selections when loading more groups via infinite scroll

## Problem

When scrolling through culling groups (burst + similar), two bugs caused selections to be lost:

1. **ID collisions**: Similar groups were assigned IDs starting from 0, which could collide with burst group IDs (also starting from 0) when both types appear in the same paginated response. This caused selections to be overwritten or lost.

2. **Scroll overwriting**: When `loadMore`` fetched new groups, `autoSelectBest` would overwrite any existing selections for groups that the user had already manually adjusted.

## Fix

1. Similar group IDs are now offset by `burst_count` `+ burst_count`, ensuring unique IDs across both group types.

2. `autoSelectBest` now checks `if (!map.has(group.group_id))` before setting a selection, preserving any existing user selections.

## Testing

- Verified with `--dry-run` that rejected photos are correctly marked
- Tested culling UI with infinite scroll - selections persist correctly across pagination
- Confirmed groups load correctly with unique IDs