### PR TITLE
[database.py] Add command to cleanup deleted photos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,8 @@ python database.py --export-viewer-db --force-export     # Full re-export
 
 # Cleanup and storage migration
 python database.py --cleanup-orphaned-persons    # Delete persons with no assigned faces
+python database.py --cleanup-missing-photos     # Remove photos no longer on disk from the database (cascades & clears cache)
+python database.py --cleanup-missing-photos --dry-run # Preview missing photos without deleting
 python database.py --migrate-storage-fs          # Migrate thumbnails/embeddings from DB to filesystem
 python database.py --migrate-storage-db          # Migrate thumbnails/embeddings from filesystem to DB
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ python database.py --export-viewer-db --force-export     # Full re-export
 python database.py --cleanup-orphaned-persons    # Delete persons with no assigned faces
 python database.py --cleanup-missing-photos     # Remove photos no longer on disk from the database (cascades & clears cache)
 python database.py --cleanup-missing-photos --dry-run # Preview missing photos without deleting
+python database.py --cleanup-missing-photos --force   # Required to proceed when ALL photos look missing (unmounted volume guard)
 python database.py --migrate-storage-fs          # Migrate thumbnails/embeddings from DB to filesystem
 python database.py --migrate-storage-db          # Migrate thumbnails/embeddings from filesystem to DB
 

--- a/database.py
+++ b/database.py
@@ -42,6 +42,7 @@ from db import (
     analyze_database,
     cleanup_orphaned_persons,
     export_viewer_db,
+    cleanup_missing_photos,
 )
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'scoring_config.json')
@@ -198,6 +199,16 @@ def main():
         help='Delete persons with no assigned faces'
     )
     parser.add_argument(
+        '--cleanup-missing-photos',
+        action='store_true',
+        help='Remove deleted files from the database'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview missing files without deleting (use with --cleanup-missing-photos)'
+    )
+    parser.add_argument(
         '--export-viewer-db',
         nargs='?',
         const='photo_scores_viewer.db',
@@ -258,6 +269,9 @@ def main():
 
     args = parser.parse_args()
 
+    if args.dry_run and not args.cleanup_missing_photos:
+        parser.error("--dry-run can only be used with --cleanup-missing-photos")
+
     if args.stats_info:
         # Show stats cache status
         logger.info("Statistics cache status:")
@@ -311,6 +325,8 @@ def main():
         analyze_database(args.db, verbose=True)
     elif args.cleanup_orphaned_persons:
         cleanup_orphaned_persons(args.db, verbose=True)
+    elif args.cleanup_missing_photos:
+        cleanup_missing_photos(args.db, dry_run=args.dry_run, verbose=True)
     elif args.export_viewer_db:
         export_viewer_db(args.db, output_path=args.export_viewer_db, verbose=True, force=args.force_export)
     elif args.add_user:

--- a/database.py
+++ b/database.py
@@ -209,6 +209,11 @@ def main():
         help='Preview missing files without deleting (use with --cleanup-missing-photos)'
     )
     parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Delete even if every photo appears missing (use with --cleanup-missing-photos)'
+    )
+    parser.add_argument(
         '--export-viewer-db',
         nargs='?',
         const='photo_scores_viewer.db',
@@ -326,7 +331,7 @@ def main():
     elif args.cleanup_orphaned_persons:
         cleanup_orphaned_persons(args.db, verbose=True)
     elif args.cleanup_missing_photos:
-        cleanup_missing_photos(args.db, dry_run=args.dry_run, verbose=True)
+        cleanup_missing_photos(args.db, dry_run=args.dry_run, force=args.force, verbose=True)
     elif args.export_viewer_db:
         export_viewer_db(args.db, output_path=args.export_viewer_db, verbose=True, force=args.force_export)
     elif args.add_user:

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -18,7 +18,7 @@ from db.schema import (
     INDEXES,
     _build_create_table_sql, _migrate_add_missing_columns,
 )
-from db.maintenance import vacuum_database, analyze_database, optimize_database, cleanup_orphaned_persons, export_viewer_db
+from db.maintenance import vacuum_database, analyze_database, optimize_database, cleanup_orphaned_persons, export_viewer_db, cleanup_missing_photos
 from db.stats_cache import (
     refresh_stats_cache, get_cached_stat, get_stats_cache_info,
 )

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -80,6 +80,73 @@ def optimize_database(db_path='photo_scores_pro.db', verbose=True):
         logger.info("Database optimization complete.")
 
 
+def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, verbose=True):
+    """Delete photos from the database that are no longer on disk.
+
+    Args:
+        db_path: Path to SQLite database
+        dry_run: If True, only preview what would be deleted
+        verbose: If True, print progress
+
+    Returns:
+        Number of photos deleted
+    """
+    if verbose:
+        logger.info("Checking for missing photos in %s...", db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT path FROM photos")
+    all_paths = [row[0] for row in cursor.fetchall()]
+
+    if verbose:
+        logger.info("Found %d photos in the database. Checking filesystem...", len(all_paths))
+
+    deleted_paths = []
+    for path in all_paths:
+        if not os.path.exists(path):
+            deleted_paths.append(path)
+
+    if not deleted_paths:
+        if verbose:
+            logger.info("No missing files found. The database is up to date.")
+        conn.close()
+        return 0
+
+    if verbose:
+        logger.info("Found %d photos in the database that are missing on disk.", len(deleted_paths))
+
+    if dry_run:
+        if verbose:
+            logger.info("DRY RUN: The following files would be removed:")
+            for p in deleted_paths[:10]:
+                logger.info("  - %s", p)
+            if len(deleted_paths) > 10:
+                logger.info("  ... and %d more.", len(deleted_paths) - 10)
+    else:
+        if verbose:
+            logger.info("Removing missing files from the database (cascading deletes will clean up faces, tags, etc.)...")
+        
+        batch_size = 500
+        for i in range(0, len(deleted_paths), batch_size):
+            batch = [(p,) for p in deleted_paths[i:i+batch_size]]
+            cursor.executemany("DELETE FROM photos WHERE path = ?", batch)
+        
+        # Invalidate stats cache since photo counts and details have changed
+        try:
+            cursor.execute("DELETE FROM stats_cache")
+        except sqlite3.OperationalError:
+            pass
+
+        conn.commit()
+        if verbose:
+            logger.info("Successfully removed %d missing files from the database.", len(deleted_paths))
+
+    conn.close()
+    return len(deleted_paths)
+
 def cleanup_orphaned_persons(db_path='photo_scores_pro.db', verbose=True):
     """Delete persons with no assigned faces.
 

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -80,17 +80,28 @@ def optimize_database(db_path='photo_scores_pro.db', verbose=True):
         logger.info("Database optimization complete.")
 
 
-def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, verbose=True):
+def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, force=False, verbose=True):
     """Delete photos from the database that are no longer on disk.
+
+    Cascading foreign keys clean up faces, tags, comparisons, learned scores
+    and per-user preferences. Stores without a cascade are cleaned explicitly
+    so no orphans remain: album memberships (album_photos), album covers, and
+    the sqlite-vec index (photos_vec).
 
     Args:
         db_path: Path to SQLite database
         dry_run: If True, only preview what would be deleted
+        force: If True, delete even when every photo appears missing. Off by
+            default so a temporarily unmounted volume (e.g. a NAS share) cannot
+            wipe the whole database.
         verbose: If True, print progress
 
     Returns:
-        Number of photos deleted
+        Number of photos deleted (or that would be deleted in dry-run)
     """
+    if not os.path.exists(db_path):
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
     if verbose:
         logger.info("Checking for missing photos in %s...", db_path)
 
@@ -104,10 +115,7 @@ def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, verbose
     if verbose:
         logger.info("Found %d photos in the database. Checking filesystem...", len(all_paths))
 
-    deleted_paths = []
-    for path in all_paths:
-        if not os.path.exists(path):
-            deleted_paths.append(path)
+    deleted_paths = [path for path in all_paths if not os.path.exists(path)]
 
     if not deleted_paths:
         if verbose:
@@ -125,24 +133,68 @@ def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, verbose
                 logger.info("  - %s", p)
             if len(deleted_paths) > 10:
                 logger.info("  ... and %d more.", len(deleted_paths) - 10)
-    else:
-        if verbose:
-            logger.info("Removing missing files from the database (cascading deletes will clean up faces, tags, etc.)...")
-        
-        batch_size = 500
-        for i in range(0, len(deleted_paths), batch_size):
-            batch = [(p,) for p in deleted_paths[i:i+batch_size]]
-            cursor.executemany("DELETE FROM photos WHERE path = ?", batch)
-        
-        # Invalidate stats cache since photo counts and details have changed
-        try:
-            cursor.execute("DELETE FROM stats_cache")
-        except sqlite3.OperationalError:
-            pass
+        conn.close()
+        return len(deleted_paths)
 
-        conn.commit()
-        if verbose:
-            logger.info("Successfully removed %d missing files from the database.", len(deleted_paths))
+    if len(deleted_paths) == len(all_paths) and not force:
+        conn.close()
+        raise RuntimeError(
+            f"All {len(all_paths)} photos appear missing on disk — refusing to wipe the "
+            "database. Check that the photo volume is mounted, preview with --dry-run, "
+            "then re-run with --force if this is intended."
+        )
+
+    if verbose:
+        logger.info("Removing missing files from the database (cascading deletes will clean up faces, tags, etc.)...")
+
+    batch_size = 500
+    for i in range(0, len(deleted_paths), batch_size):
+        params = [(p,) for p in deleted_paths[i:i + batch_size]]
+        cursor.executemany("DELETE FROM photos WHERE path = ?", params)
+        # album_photos.photo_path has no ON DELETE CASCADE — drop memberships explicitly.
+        cursor.executemany("DELETE FROM album_photos WHERE photo_path = ?", params)
+        # An album cover may point at a now-deleted photo.
+        cursor.executemany("UPDATE albums SET cover_photo_path = NULL WHERE cover_photo_path = ?", params)
+
+    # Faces were cascade-deleted; refresh person face counts so the viewer stays accurate.
+    cursor.execute(
+        "UPDATE persons SET face_count = "
+        "(SELECT COUNT(*) FROM faces WHERE faces.person_id = persons.id)"
+    )
+    emptied_persons = cursor.execute(
+        "SELECT COUNT(*) FROM persons WHERE face_count = 0"
+    ).fetchone()[0]
+
+    # Invalidate stats cache since photo counts and details have changed
+    try:
+        cursor.execute("DELETE FROM stats_cache")
+    except sqlite3.OperationalError:
+        pass
+
+    conn.commit()
+
+    # photos_vec (sqlite-vec) has no FK or trigger. Clean it best-effort after the
+    # main delete commits — the vector index is derived and rebuildable.
+    from db.connection import HAS_SQLITE_VEC, load_sqlite_vec
+    from db.vec import _vec_table_exists
+    load_sqlite_vec(conn)
+    if HAS_SQLITE_VEC and _vec_table_exists(conn):
+        try:
+            for i in range(0, len(deleted_paths), batch_size):
+                chunk = deleted_paths[i:i + batch_size]
+                placeholders = ','.join('?' * len(chunk))
+                cursor.execute(f"DELETE FROM photos_vec WHERE path IN ({placeholders})", chunk)
+            conn.commit()
+        except sqlite3.Error as ex:
+            logger.warning("Could not clean photos_vec entries (rebuild with --populate-vec): %s", ex)
+
+    if verbose:
+        logger.info("Successfully removed %d missing files from the database.", len(deleted_paths))
+        if emptied_persons:
+            logger.info(
+                "%d person(s) now have no faces — run --cleanup-orphaned-persons to remove them.",
+                emptied_persons,
+            )
 
     conn.close()
     return len(deleted_paths)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -233,8 +233,9 @@ Checks: Score ranges, face metrics, BLOB corruption, embedding sizes, orphaned f
 | `python database.py --export-viewer-db` | Export/update lightweight database for NAS deployment (incremental if output exists) |
 | `python database.py --export-viewer-db --force-export` | Force full re-export, even if viewer DB already exists |
 | `python database.py --cleanup-orphaned-persons` | Remove persons with no associated faces |
-| `python database.py --cleanup-missing-photos` | Remove photos no longer on disk from the database (cascading deletes clean up tags, detected faces, etc. and invalidate stats cache) |
+| `python database.py --cleanup-missing-photos` | Remove photos no longer on disk from the database (cascading deletes clean up tags, detected faces, etc.; also clears album memberships, the vector index, and invalidates stats cache) |
 | `python database.py --cleanup-missing-photos --dry-run` | Preview missing files without deleting |
+| `python database.py --cleanup-missing-photos --force` | Proceed even when every photo appears missing (guard against deleting everything when a volume is unmounted) |
 | `python database.py --migrate-storage-fs` | Migrate thumbnails and embeddings from database BLOBs to filesystem |
 | `python database.py --migrate-storage-db` | Migrate thumbnails and embeddings from filesystem back to database |
 | `python database.py --add-user alice --role admin` | Add a user (prompts for password) |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -233,6 +233,8 @@ Checks: Score ranges, face metrics, BLOB corruption, embedding sizes, orphaned f
 | `python database.py --export-viewer-db` | Export/update lightweight database for NAS deployment (incremental if output exists) |
 | `python database.py --export-viewer-db --force-export` | Force full re-export, even if viewer DB already exists |
 | `python database.py --cleanup-orphaned-persons` | Remove persons with no associated faces |
+| `python database.py --cleanup-missing-photos` | Remove photos no longer on disk from the database (cascading deletes clean up tags, detected faces, etc. and invalidate stats cache) |
+| `python database.py --cleanup-missing-photos --dry-run` | Preview missing files without deleting |
 | `python database.py --migrate-storage-fs` | Migrate thumbnails and embeddings from database BLOBs to filesystem |
 | `python database.py --migrate-storage-db` | Migrate thumbnails and embeddings from filesystem back to database |
 | `python database.py --add-user alice --role admin` | Add a user (prompts for password) |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,7 +222,7 @@ class TestDatabaseCli:
     def test_cleanup_missing_photos_execution(self, seeded_db):
         # Refresh stats cache first so we can verify invalidation
         _run(DATABASE, '--db', seeded_db, '--refresh-stats')
-        
+
         # Verify stats cache has entries
         conn = sqlite3.connect(seeded_db)
         stats_count = conn.execute("SELECT COUNT(*) FROM stats_cache").fetchone()[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,7 +229,8 @@ class TestDatabaseCli:
         assert stats_count > 0
         conn.close()
 
-        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos')
+        # Both seeded photos are missing → all-missing guard requires --force.
+        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos', '--force')
         assert result.returncode == 0
         combined = result.stdout + result.stderr
         assert 'Successfully removed 2 missing files from the database.' in combined
@@ -241,6 +242,45 @@ class TestDatabaseCli:
         conn.close()
         assert count == 0
         assert stats_count == 0
+
+    def test_cleanup_missing_photos_all_missing_refused_without_force(self, seeded_db):
+        # Every photo missing looks like an unmounted volume → refuse to wipe.
+        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos')
+        assert result.returncode != 0
+        assert 'refusing to wipe' in (result.stdout + result.stderr)
+        conn = sqlite3.connect(seeded_db)
+        count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+        conn.close()
+        assert count == 2  # nothing deleted
+
+    def test_cleanup_missing_photos_cascades_and_cleans_orphans(self, seeded_db, tmp_path):
+        # Point /a.jpg at a real file so it survives; /b.jpg stays missing. This
+        # also keeps us under the all-missing guard without needing --force.
+        present = tmp_path / 'present.jpg'
+        present.write_bytes(b'x')
+        conn = sqlite3.connect(seeded_db)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("UPDATE photos SET path = ? WHERE path = '/a.jpg'", (str(present),))
+        # Dependent rows for the missing photo: cascaded (faces, photo_tags) and
+        # non-cascaded (album_photos, album cover).
+        conn.execute("INSERT INTO faces(photo_path, face_index, embedding) VALUES ('/b.jpg', 0, X'00')")
+        conn.execute("INSERT INTO photo_tags(photo_path, tag) VALUES ('/b.jpg', 'beach')")
+        conn.execute("INSERT INTO albums(name, cover_photo_path) VALUES ('A', '/b.jpg')")
+        album_id = conn.execute("SELECT id FROM albums").fetchone()[0]
+        conn.execute("INSERT INTO album_photos(album_id, photo_path) VALUES (?, '/b.jpg')", (album_id,))
+        conn.commit()
+        conn.close()
+
+        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos')
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(seeded_db)
+        assert conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0] == 1  # present.jpg remains
+        assert conn.execute("SELECT COUNT(*) FROM faces WHERE photo_path = '/b.jpg'").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM photo_tags WHERE photo_path = '/b.jpg'").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM album_photos WHERE photo_path = '/b.jpg'").fetchone()[0] == 0
+        assert conn.execute("SELECT cover_photo_path FROM albums WHERE id = ?", (album_id,)).fetchone()[0] is None
+        conn.close()
 
     def test_dry_run_alone_errors(self, seeded_db):
         result = _run(DATABASE, '--db', seeded_db, '--dry-run')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,6 +207,46 @@ class TestDatabaseCli:
         result = _run(DATABASE, '--db', seeded_db, '--cleanup-orphaned-persons')
         assert result.returncode == 0
 
+    def test_cleanup_missing_photos_dry_run(self, seeded_db):
+        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos', '--dry-run')
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert 'Found 2 photos in the database that are missing on disk.' in combined
+        assert 'DRY RUN' in combined
+        # Check that photos were not deleted
+        conn = sqlite3.connect(seeded_db)
+        count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+        conn.close()
+        assert count == 2
+
+    def test_cleanup_missing_photos_execution(self, seeded_db):
+        # Refresh stats cache first so we can verify invalidation
+        _run(DATABASE, '--db', seeded_db, '--refresh-stats')
+        
+        # Verify stats cache has entries
+        conn = sqlite3.connect(seeded_db)
+        stats_count = conn.execute("SELECT COUNT(*) FROM stats_cache").fetchone()[0]
+        assert stats_count > 0
+        conn.close()
+
+        result = _run(DATABASE, '--db', seeded_db, '--cleanup-missing-photos')
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert 'Successfully removed 2 missing files from the database.' in combined
+
+        # Check that photos were deleted and stats_cache was cleared
+        conn = sqlite3.connect(seeded_db)
+        count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+        stats_count = conn.execute("SELECT COUNT(*) FROM stats_cache").fetchone()[0]
+        conn.close()
+        assert count == 0
+        assert stats_count == 0
+
+    def test_dry_run_alone_errors(self, seeded_db):
+        result = _run(DATABASE, '--db', seeded_db, '--dry-run')
+        assert result.returncode != 0
+        assert 'can only be used with --cleanup-missing-photos' in (result.stdout + result.stderr)
+
 
 # ---------------------------------------------------------------------------
 # facet.py — read-only entry points


### PR DESCRIPTION
Show list of photos no longer on disk without deleting
```python database.py --cleanup-missing-photos```
Remove photos no longer on disk from the database (cascades & clears cache)
```python database.py --cleanup-missing-photos --dry-run```

**P.S.** Since tool is CLI-heavy, I think it makes sense to switch to "Command-Subcommand" pattern at some point:
```
command subcommand --flag-for-subcommand 
```
so that would be:
```
python database.py cleanup-missing-photos --dry-run
```