### PR TITLE
feat(docker): persist model cache; use same DB location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ client/package-lock.json
 
 # ML model cache
 .fastembed_cache/
+model-cache/
 
 # Misc
 output.log
@@ -70,3 +71,4 @@ photos_all/
 # Benchmark results — keep dir via .gitkeep, ignore generated JSON
 bench/results/*.json
 .claude/loop/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - ./data:/app/data
       - ./scoring_config.json:/app/scoring_config.json
       - ./storage:/app/storage
+      - ./model-cache/huggingface:/root/.cache/huggingface
+      - ./model-cache/insightface:/root/.insightface
+      - ./model-cache/pretrained:/app/pretrained_models
     environment:
       - FACET_LOG_LEVEL=INFO
       - DB_PATH=/app/data/photo_scores_pro.db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - ./data:/app/data
       - ./scoring_config.json:/app/scoring_config.json
       - ./storage:/app/storage
-      - ./model-cache/huggingface:/root/.cache/huggingface
-      - ./model-cache/insightface:/root/.insightface
+      - ./model-cache/huggingface:/home/facet/.cache/huggingface
+      - ./model-cache/insightface:/home/facet/.insightface
       - ./model-cache/pretrained:/app/pretrained_models
     environment:
       - FACET_LOG_LEVEL=INFO

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,11 +7,13 @@ set -e
 # take ownership of the writable mounts, then drop privileges to "facet". When
 # already running unprivileged (a `user:` override in compose), just exec.
 if [ "$(id -u)" = '0' ]; then
-    mkdir -p /app/data /app/storage
+    mkdir -p /app/data /app/storage /app/pretrained_models \
+        /home/facet/.cache/huggingface /home/facet/.insightface
     # Best-effort: on read-only / NFS root_squash / already-correct mounts the
     # chown may fail harmlessly — don't abort startup over it (set -e). A real
     # permission problem still surfaces with a clear error when SQLite opens.
-    chown facet:facet /app/data /app/storage 2>/dev/null || true
+    chown facet:facet /app/data /app/storage /app/pretrained_models \
+        /home/facet/.cache/huggingface /home/facet/.insightface 2>/dev/null || true
     exec gosu facet "$@"
 fi
 

--- a/facet.py
+++ b/facet.py
@@ -36,7 +36,7 @@ if _script_dir not in sys.path:
 import json
 from pathlib import Path
 from datetime import datetime
-from db import init_database, get_connection
+from db import DEFAULT_DB_PATH, init_database, get_connection
 
 try:
     from tqdm import tqdm
@@ -115,6 +115,29 @@ def _get_photo_column_count(db_path: str) -> int:
             return len(list(conn.execute("PRAGMA table_info(photos)")))
     except sqlite3.Error:
         return 0
+
+
+def _log_scan_db_destination(db_path: str):
+    """Log the exact SQLite file written by the scan."""
+    raw_path = str(db_path)
+    resolved_path = os.path.realpath(raw_path)
+
+    try:
+        with get_connection(raw_path, row_factory=False) as conn:
+            photo_count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+        size_bytes = os.path.getsize(resolved_path)
+        size_mb = size_bytes / (1024 * 1024)
+        summary = f"{photo_count} photos, {size_mb:.1f} MiB"
+    except Exception as e:
+        summary = f"summary unavailable ({e})"
+
+    if raw_path == resolved_path:
+        logger.info("Scan database file: %s (%s)", resolved_path, summary)
+    else:
+        logger.info(
+            "Scan database file: %s (resolved to %s, %s)",
+            raw_path, resolved_path, summary,
+        )
 
 
 def main():
@@ -351,8 +374,8 @@ Configuration:
     config_group = parser.add_argument_group('Configuration')
     config_group.add_argument('--config', type=str, default=None,
                         help='Path to custom scoring config JSON file')
-    config_group.add_argument('--db', type=str, default='photo_scores_pro.db',
-                        help='Path to database file (default: photo_scores_pro.db)')
+    config_group.add_argument('--db', type=str, default=DEFAULT_DB_PATH,
+                        help=f'Path to database file (default: {DEFAULT_DB_PATH})')
     config_group.add_argument('--validate-categories', action='store_true',
                         help='Validate category configurations')
 
@@ -605,7 +628,6 @@ Configuration:
 
         # Step 0: schema migration FIRST so subsequent steps can read/write
         # any new columns added since the DB was last initialised.
-        from db import DEFAULT_DB_PATH
         db_path = args.db or DEFAULT_DB_PATH
         logger.info("--- Schema migration (init_database) ---")
         before_cols = _get_photo_column_count(db_path)
@@ -1312,6 +1334,7 @@ Configuration:
     # since multi-pass loads its own models per pass via ModelManager
     use_multi_pass = not (args.dry_run or args.single_pass)
     scorer = Facet(db_path=args.db, config_path=args.config, multi_pass=use_multi_pass)
+    _log_scan_db_destination(scorer.db_path)
 
     # Initialise plugin manager for scoring events
     from plugins import init_global_plugin_manager
@@ -1630,6 +1653,7 @@ Configuration:
     except Exception:
         logger.warning("Auto-populate of photos_vec failed (non-fatal)", exc_info=True)
 
+    _log_scan_db_destination(scorer.db_path)
     emit_progress('done', force=True)
     logger.info("All tasks complete.")
 


### PR DESCRIPTION
Hi, I discovered this project yesterday and I was very impressed. I really like the functionality of the rating and culling. Also the UI seems to be very detailed.

I stumbled across two issues when testing the containerized setup. This PR would help to make this much more smooth.

## Summary

- **Docker model cache volumes**: Mount `./model-cache/huggingface`, `./model-cache/insightface`, and `./model-cache/pretrained_models` in `docker-compose.yml` so that HuggingFace, InsightFace, and pretrained model files are persisted on the host. Without this, models are re-downloaded from scratch every time the container is recreated, which can take several minutes and consume significant bandwidth.
- **`.gitignore`**: Add `model-cache/` so the local model cache directory is never accidentally committed.
- **default DB path fix**: Otherwise, the scan would write the DB into a location which is not considered by the web UI.
- **DB path logging** (`facet.py`): Add `_log_scan_db_destination()` that logs the resolved SQLite file path, photo count, and size at scan start and end. Useful when `DB_PATH` is a symlink or a relative path — the log makes it unambiguous which file is actually being written.

## Test plan

- [ ] Run `docker compose up` on a fresh clone — confirm models download into `./model-cache/` on the host
- [ ] Stop and recreate the container (`docker compose down && docker compose up`) — confirm models are **not** re-downloaded
- [ ] Run a scan and check the log output contains `Scan database file: <path> (<N> photos, <X> MiB)`
- [ ] Verify `model-cache/` does not appear in `git status` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)