### PR TITLE
Fix Python version conflicts

### DIFF
--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -64,7 +64,7 @@ Markdown==3.10.2
 matplotlib==3.11.0
 mdurl==0.1.2
 ml_dtypes==0.5.4
-mpmath==1.4.1
+mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 narwhals==2.24.0
@@ -87,7 +87,7 @@ propcache==0.5.2
 protobuf==7.35.1
 pyarrow==24.0.0
 pydantic==2.13.4
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 pyiqa==0.1.16
 PyJWT==2.13.0
 pyparsing==3.3.2
@@ -120,7 +120,7 @@ tensorboard==2.21.0
 threadpoolctl==3.6.0
 tifffile==2026.3.3
 timm==1.0.28
-tokenizers==0.23.1
+tokenizers==0.23.0rc0
 transformers==5.2.0
 typer-slim==0.24.0
 typer==0.27.0


### PR DESCRIPTION
Hello, 

Here is a PR that closes the version conflicts mentioned in #53 blocking Docker build. 

fixes #53  

## Notes

- tokenizer==0.23.0 does not exist. Therefore using the `rc0` version