### PR TITLE
fix(form): prevent KMeans thread-pool deadlock in multi-worker scans

### DIFF
--- a/analyzers/form_facet.py
+++ b/analyzers/form_facet.py
@@ -26,10 +26,19 @@ in ``processing.scorer.build_metric_vector``).
 """
 
 import logging
+import threading
 
 import numpy as np
 
 logger = logging.getLogger("facet.form_facet")
+
+# sklearn KMeans lazily initializes OpenMP/BLAS thread pools (via threadpoolctl /
+# libgomp) on its first fit. Doing that init concurrently from several worker
+# threads deadlocks in the native thread-pool synchronization (issue #55). The
+# lock serializes the fit_predict step, and warmup() forces the one-time init to
+# happen single-threaded before any worker pool starts.
+_KM_LOCK = threading.Lock()
+_WARMED = False
 
 FORM_METRIC_COLUMNS = (
     'form_symmetry', 'form_balance', 'form_edge_entropy', 'form_fractal',
@@ -203,7 +212,8 @@ def _color_harmony(hsv):
     from sklearn.cluster import KMeans
 
     km = KMeans(n_clusters=_KMEANS_CLUSTERS, n_init=4, random_state=0)
-    labels = km.fit_predict(points, sample_weight=sample_weights)
+    with _KM_LOCK:
+        labels = km.fit_predict(points, sample_weight=sample_weights)
     centers = km.cluster_centers_
     cluster_hues = np.rad2deg(np.arctan2(centers[:, 1], centers[:, 0])) % 360.0
     cluster_weights = np.array([
@@ -214,6 +224,31 @@ def _color_harmony(hsv):
         return None
     best = _template_fit_distance(cluster_hues[keep], cluster_weights[keep])
     return round(10.0 * (1.0 - min(1.0, best / _MAX_TEMPLATE_DISTANCE_DEG)), 2)
+
+
+def warmup():
+    """Force sklearn KMeans' one-time OpenMP/BLAS init on the calling thread.
+
+    Idempotent and never raises. Call once on the main thread before launching a
+    worker pool that computes form metrics: it runs a tiny real KMeans fit so the
+    native thread-pool init (threadpoolctl / libgomp) completes single-threaded,
+    avoiding the concurrent-init deadlock of issue #55.
+    """
+    global _WARMED
+    with _KM_LOCK:
+        if _WARMED:
+            return
+        try:
+            from sklearn.cluster import KMeans
+
+            angles = np.linspace(0.0, 2.0 * np.pi, 32, endpoint=False)
+            points = np.column_stack([np.cos(angles), np.sin(angles)])
+            KMeans(
+                n_clusters=_KMEANS_CLUSTERS, n_init=4, random_state=0
+            ).fit_predict(points, sample_weight=np.ones(points.shape[0]))
+        except Exception:
+            logger.debug("KMeans warmup failed", exc_info=True)
+        _WARMED = True
 
 
 def compute_form_metrics(pil_image):

--- a/processing/multi_pass.py
+++ b/processing/multi_pass.py
@@ -512,7 +512,7 @@ class ChunkedMultiPassProcessor:
         from pathlib import Path
         from utils import load_image_from_path
         from analyzers import TechnicalAnalyzer, ImageCache
-        from analyzers.form_facet import compute_form_metrics
+        from analyzers.form_facet import compute_form_metrics, warmup
 
         # Get a TechnicalAnalyzer instance (stateless, so we can create one)
         tech_analyzer = TechnicalAnalyzer()
@@ -595,6 +595,9 @@ class ChunkedMultiPassProcessor:
         # bounded separately by the decode semaphore in utils.image_loading
         images = {}
         if self.load_workers > 1 and len(paths) > 1:
+            # Force KMeans' native thread-pool init single-threaded before the
+            # worker pool starts, else concurrent first-time init deadlocks (#55)
+            warmup()
             with ThreadPoolExecutor(
                 max_workers=self.load_workers, thread_name_prefix='imgload'
             ) as pool:

--- a/tests/test_form_facet.py
+++ b/tests/test_form_facet.py
@@ -11,7 +11,9 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from analyzers.form_facet import FORM_METRIC_COLUMNS, compute_form_metrics
+from concurrent.futures import ThreadPoolExecutor
+
+from analyzers.form_facet import FORM_METRIC_COLUMNS, compute_form_metrics, warmup
 
 
 def _to_image(arr):
@@ -135,3 +137,26 @@ def test_working_size_consistency_across_input_resolutions():
     for col in FORM_METRIC_COLUMNS:
         assert large[col] is not None and thumb[col] is not None, col
         assert large[col] == pytest.approx(thumb[col], abs=1.0), col
+
+
+def test_warmup_is_idempotent():
+    warmup()
+    warmup()
+
+
+def test_concurrent_color_harmony_does_not_deadlock():
+    """Regression guard for issue #55.
+
+    Several worker threads compute form metrics (hence KMeans) at once. warmup()
+    pre-initializes the native thread pools and _color_harmony serializes the fit
+    under a lock, so the concurrent KMeans path completes instead of deadlocking
+    in libgomp init. The deadlock is a race, so this is a functional smoke guard
+    (it times out loudly rather than deterministically reproducing the hang).
+    """
+    warmup()
+    images = [_hue_stripes([0, 72, 144, 216, 288]) for _ in range(8)]
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(compute_form_metrics, img) for img in images]
+        results = [f.result(timeout=60) for f in futures]
+    for metrics in results:
+        assert metrics["color_harmony"] is not None


### PR DESCRIPTION
## Summary

Fixes the multi-worker scan deadlock reported in #55.

## Root cause

The shared chunk loader `MultiPassProcessor._load_images` runs `_load_one` across an `imgload` `ThreadPoolExecutor`. Each worker computes form metrics → `_color_harmony` → `KMeans.fit_predict` (`analyzers/form_facet.py`). sklearn lazily initializes its OpenMP/BLAS thread pools (`threadpoolctl` / `libgomp`) on the first fit; running that init **concurrently** from several worker threads deadlocks in the native thread-pool synchronization — every worker parks in `futex_wait`, CPU/GPU idle, stuck at `Multi-pass processing: 0/N`.

Form metrics run in the shared loader (not per pass), so the hang surfaced across every pass (`composition`, `embeddings`, …). `--recompute-form` and single-pass/dry-run are single-threaded and were unaffected — consistent with the `load_workers: 1` workaround.

## Fix

Warm-up **and** lock (belt-and-suspenders), keeping full decode parallelism:

- **`analyzers/form_facet.py`** — new idempotent `warmup()` runs a tiny KMeans fit to force the one-time native init single-threaded; the real `km.fit_predict(...)` is guarded by a module-level `threading.Lock`.
- **`processing/multi_pass.py`** — `warmup()` is called once before the `imgload` pool starts (threaded branch only).
- **`tests/test_form_facet.py`** — `test_warmup_is_idempotent` + `test_concurrent_color_harmony_does_not_deadlock` (8 colorful images across 4 threads, `result(timeout=60)`).

Form metric values are unchanged (same KMeans seed).

## Verification

- `tests/test_form_facet.py` — 11/11 green (incl. 2 new).
- `tests/test_multi_pass.py` — 11/11 green.
- Manual repro (needs real photos): `python facet.py /path --pass composition` with default `load_workers` now progresses past `0/N`.
