### PR TITLE
Fix 56 defects from whole-codebase bug hunt

### DIFF
--- a/analyzers/capsule_generator.py
+++ b/analyzers/capsule_generator.py
@@ -100,12 +100,30 @@ def _pick_cover_photo(paths, capsule_id, top_n=5, freshness_seconds=86400, capsu
     if not paths:
         return ""
     candidates = paths[:min(top_n, len(paths))]
-    if capsule_config and capsule_config.get("_shuffle"):
+    if (capsule_config and capsule_config.get("_shuffle")) or freshness_seconds <= 0:
         rng = random.Random()
     else:
         rotation_seed = int(time.time() // freshness_seconds)
         rng = random.Random(f"{rotation_seed}:{capsule_id}")
     return rng.choice(candidates)
+
+
+def _apply_date_range(vis_sql, vis_params, capsule_config, date_column):
+    """Extend a visibility clause with the requested date range, if any.
+
+    Mirrors the date filtering `generate_all_capsules` applies to the shared
+    `vis` clause, for generators that must rebuild their own aliased clause.
+    """
+    from api.db_helpers import to_exif_date
+    date_from = capsule_config.get("_date_from")
+    date_to = capsule_config.get("_date_to")
+    if date_from:
+        vis_sql += f" AND {date_column} >= ?"
+        vis_params.append(to_exif_date(date_from))
+    if date_to:
+        vis_sql += f" AND {date_column} <= ?"
+        vis_params.append(to_exif_date(date_to) + " 23:59:59")
+    return vis_sql, vis_params
 
 
 def _init_geocode_cache(conn):
@@ -298,7 +316,7 @@ def generate_all_capsules(conn, config=None, user_id=None, date_from=None, date_
     """
     if config is None:
         config = {}
-    capsule_config = {**config.get("capsules", {}), "_shuffle": shuffle}
+    capsule_config = {**config.get("capsules", {}), "_shuffle": shuffle, "_date_from": date_from, "_date_to": date_to}
     min_aggregate = capsule_config.get("min_aggregate", 6.0)
 
     # Initialize geocoding cache if enabled
@@ -632,6 +650,7 @@ def _generate_faces_of(conn, capsule_config, min_aggregate, vis, user_id):
     vis_sql += (" AND (ph.is_burst_lead = 1 OR ph.is_burst_lead IS NULL)"
                 " AND (ph.is_duplicate_lead = 1 OR ph.is_duplicate_lead IS NULL"
                 " OR ph.duplicate_group_id IS NULL)")
+    vis_sql, vis_params = _apply_date_range(vis_sql, vis_params, capsule_config, "ph.date_taken")
 
     rows = conn.execute(
         f"""SELECT p.id, p.name, p.face_count,
@@ -1084,6 +1103,7 @@ def _generate_person_pairs(conn, capsule_config, min_aggregate, vis, user_id):
     vis_sql += (" AND (ph.is_burst_lead = 1 OR ph.is_burst_lead IS NULL)"
                 " AND (ph.is_duplicate_lead = 1 OR ph.is_duplicate_lead IS NULL"
                 " OR ph.duplicate_group_id IS NULL)")
+    vis_sql, vis_params = _apply_date_range(vis_sql, vis_params, capsule_config, "ph.date_taken")
 
     pairs = _fetch_person_pairs(conn, min_aggregate, vis_sql, vis_params, max_photos)
 
@@ -1129,7 +1149,7 @@ def _generate_seeded(conn, capsule_config, min_aggregate, vis, user_id):
         seed_lifetime_minutes = freshness_hours * 60
 
     # Local RNG with time-bucketed seed for stability (avoids mutating global state)
-    if capsule_config.get("_shuffle"):
+    if capsule_config.get("_shuffle") or seed_lifetime_minutes <= 0:
         rng = random.Random()
     else:
         rng = random.Random(int(time.time() // (seed_lifetime_minutes * 60)))
@@ -1533,6 +1553,7 @@ def _generate_rare_pairs(conn, capsule_config, min_aggregate, vis, user_id):
     vis_sql += (" AND (ph.is_burst_lead = 1 OR ph.is_burst_lead IS NULL)"
                 " AND (ph.is_duplicate_lead = 1 OR ph.is_duplicate_lead IS NULL"
                 " OR ph.duplicate_group_id IS NULL)")
+    vis_sql, vis_params = _apply_date_range(vis_sql, vis_params, capsule_config, "ph.date_taken")
 
     pairs = _fetch_person_pairs(conn, min_score, vis_sql, vis_params, max_photos)
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -295,7 +295,7 @@ def verify_legacy_password(candidate: str, stored: str) -> bool:
         return False
     if _is_hashed(stored):
         return verify_password(candidate, stored)
-    return hmac.compare_digest(candidate, stored)
+    return hmac.compare_digest(candidate.encode('utf-8'), stored.encode('utf-8'))
 
 
 def upgrade_legacy_password(config_key: str, plaintext: str):

--- a/api/db_helpers.py
+++ b/api/db_helpers.py
@@ -522,6 +522,40 @@ def update_person_face_count(conn, person_id):
     """, (person_id, person_id))
 
 
+def repair_stale_representative(conn, person_id):
+    """Replace a person's representative face when it no longer belongs to them.
+
+    Moving a face away from its person leaves that person's representative_face_id
+    and face_thumbnail pointing at a face now owned by someone else. Pick the
+    highest-confidence remaining face as the new representative, or clear both
+    columns when the person has no faces left.
+    """
+    person = conn.execute(
+        "SELECT representative_face_id FROM persons WHERE id = ?", (person_id,)
+    ).fetchone()
+    if not person:
+        return
+    rep_id = person['representative_face_id']
+    if rep_id is not None and conn.execute(
+        "SELECT 1 FROM faces WHERE id = ? AND person_id = ?", (rep_id, person_id)
+    ).fetchone():
+        return
+    replacement = conn.execute(
+        "SELECT id, face_thumbnail FROM faces WHERE person_id = ? ORDER BY confidence DESC LIMIT 1",
+        (person_id,)
+    ).fetchone()
+    if replacement:
+        conn.execute(
+            "UPDATE persons SET representative_face_id = ?, face_thumbnail = ? WHERE id = ?",
+            (replacement['id'], replacement['face_thumbnail'], person_id)
+        )
+    else:
+        conn.execute(
+            "UPDATE persons SET representative_face_id = NULL, face_thumbnail = NULL WHERE id = ?",
+            (person_id,)
+        )
+
+
 def reassign_faces_to_person(conn, person_id, face_ids):
     """Reassign a set of faces to ``person_id``; auto-delete emptied old persons.
 
@@ -569,6 +603,8 @@ def reassign_faces_to_person(conn, person_id, face_ids):
         if row and row[0] == 0:
             conn.execute("DELETE FROM persons WHERE id = ?", (old_id,))
             deleted_persons.append(old_id)
+        else:
+            repair_stale_representative(conn, old_id)
 
     row = conn.execute(
         "SELECT face_count FROM persons WHERE id = ?", (person_id,)

--- a/api/raw_processing.py
+++ b/api/raw_processing.py
@@ -7,12 +7,12 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import logging
 import os
 import shutil
 import subprocess
 import tempfile
+import time
 from io import BytesIO
 from pathlib import Path
 
@@ -81,13 +81,24 @@ async def convert_raw_darktable_async(file_path: str, profile_name: str, quality
     return await _convert_darktable_async(file_path, quality, dt_config, profile)
 
 
-@functools.lru_cache(maxsize=1)
+_DARKTABLE_AVAILABLE_TTL_SECONDS = 60
+_darktable_available_cache: tuple[float, str, bool] | None = None
+
+
 def is_darktable_available() -> bool:
     """Check whether the configured darktable-cli executable exists."""
+    global _darktable_available_cache
     dt_config = _get_raw_config().get('darktable', {})
     executable = dt_config.get('executable', 'darktable-cli')
+    now = time.monotonic()
+    if (_darktable_available_cache is not None
+            and _darktable_available_cache[1] == executable
+            and (now - _darktable_available_cache[0]) < _DARKTABLE_AVAILABLE_TTL_SECONDS):
+        return _darktable_available_cache[2]
     resolved = shutil.which(executable) if not os.path.isabs(executable) else executable
-    return bool(resolved and os.path.isfile(resolved))
+    available = bool(resolved and os.path.isfile(resolved))
+    _darktable_available_cache = (now, executable, available)
+    return available
 
 
 def get_darktable_profiles() -> list[str]:

--- a/api/routers/caption.py
+++ b/api/routers/caption.py
@@ -183,11 +183,13 @@ def _generate_caption(photo_path: str) -> Optional[str]:
     disk_path = resolve_photo_disk_path(photo_path)
 
     try:
-        from PIL import Image
+        from utils.image_loading import load_image_from_path
 
         tagger = get_or_load_vlm_tagger(vlm_config)
 
-        img = Image.open(disk_path).convert('RGB')
+        img, _ = load_image_from_path(disk_path, use_thumbnail=True)
+        if img is None:
+            return None
         img.thumbnail((640, 640))
 
         with vlm_generate_lock:

--- a/api/routers/faces.py
+++ b/api/routers/faces.py
@@ -16,7 +16,7 @@ from api.config import is_multi_user_enabled, _stats_cache
 from api.database import get_async_db, get_db
 from api.db_helpers import (
     update_person_face_count, trigger_auto_retrain, get_visibility_clause,
-    assert_faces_visible, assert_photo_visible,
+    assert_faces_visible, assert_photo_visible, repair_stale_representative,
 )
 from api.types import JUNK_NOT_JUNK
 
@@ -166,6 +166,7 @@ def api_assign_face(
 
             if old_person_id:
                 update_person_face_count(conn, old_person_id)
+                repair_stale_representative(conn, old_person_id)
             update_person_face_count(conn, body.person_id)
 
             conn.commit()

--- a/api/routers/gallery.py
+++ b/api/routers/gallery.py
@@ -290,10 +290,9 @@ def _apply_color_quality_filters(where_clauses, sql_params, params):
 
 def _apply_visibility_and_hide_filters(where_clauses, sql_params, params, user_id):
     """Apply visibility, top picks, aggregate minimum, and hide blinks/bursts/duplicates."""
-    if user_id:
-        vis_sql, vis_params = get_visibility_clause(user_id)
-        where_clauses.append(vis_sql)
-        sql_params.extend(vis_params)
+    vis_sql, vis_params = get_visibility_clause(user_id)
+    where_clauses.append(vis_sql)
+    sql_params.extend(vis_params)
 
     if params.get('min_aggregate'):
         try:

--- a/api/routers/persons.py
+++ b/api/routers/persons.py
@@ -70,6 +70,50 @@ class SplitPersonRequest(BaseModel):
     name: Optional[str] = None
 
 
+# --- Visibility guard ---
+
+def _assert_person_visible(conn, user_id, person_id):
+    """Raise 404 when ``person_id`` has no face on a photo the caller may see.
+
+    A no-op outside multi-user mode. In multi-user mode it enforces the same
+    per-directory isolation as the persons read surface so a directory-scoped
+    edition user cannot rename, merge, delete or hide a person whose faces all
+    live outside their directories. Returns 404 (never 403) so it never leaks
+    the existence of an out-of-scope person, matching the read endpoints.
+    """
+    fragment, params = person_visibility_exists(user_id, 'p.id')
+    if not fragment:
+        return
+    row = conn.execute(
+        f"SELECT 1 FROM persons p WHERE p.id = ? AND {fragment}",
+        [person_id, *params],
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+
+def _assert_person_assignable(conn, user_id, person_id):
+    """Guard an assign *target*: allow an empty person (one being populated), but
+    reject a non-empty person with no face in the caller's directories, so a
+    directory-scoped edition user cannot inject faces into a cluster they cannot
+    see. A no-op outside multi-user mode. Returns 404 (never 403) to avoid leaking
+    the existence of an out-of-scope person.
+    """
+    fragment, params = person_visibility_exists(user_id, 'p.id')
+    if not fragment:
+        return
+    if not conn.execute(
+        "SELECT 1 FROM faces WHERE person_id = ? LIMIT 1", (person_id,)
+    ).fetchone():
+        return
+    row = conn.execute(
+        f"SELECT 1 FROM persons p WHERE p.id = ? AND {fragment}",
+        [person_id, *params],
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+
 # --- Endpoints ---
 
 @router.get("/api/persons")
@@ -144,6 +188,7 @@ def rename_person(
     """Rename a person (set or update their name)."""
     name = body.name.strip()
     with get_db() as conn:
+        _assert_person_visible(conn, user.user_id if user else None, person_id)
         conn.execute("UPDATE persons SET name = ? WHERE id = ?", (name or None, person_id))
         conn.commit()
     invalidate_stats_cache()
@@ -156,7 +201,7 @@ def merge_persons_json(
     user: CurrentUser = Depends(require_edition),
 ):
     """Merge source person into target person (JSON body)."""
-    return _do_merge(body.source_id, body.target_id)
+    return _do_merge(body.source_id, body.target_id, user.user_id if user else None)
 
 
 @router.post("/api/persons/merge/{source_id}/{target_id}")
@@ -166,16 +211,18 @@ def merge_persons(
     user: CurrentUser = Depends(require_edition),
 ):
     """Merge source person into target person (path params)."""
-    return _do_merge(source_id, target_id)
+    return _do_merge(source_id, target_id, user.user_id if user else None)
 
 
-def _do_merge(source_id: int, target_id: int):
+def _do_merge(source_id: int, target_id: int, user_id):
     """Shared merge logic."""
     if source_id == target_id:
         raise HTTPException(status_code=400, detail="Cannot merge a person into itself")
 
     with get_db() as conn:
         try:
+            _assert_person_visible(conn, user_id, source_id)
+            _assert_person_visible(conn, user_id, target_id)
             # 1. Move all faces from source to target
             conn.execute("UPDATE faces SET person_id = ? WHERE person_id = ?",
                          (target_id, source_id))
@@ -245,8 +292,13 @@ def merge_persons_batch(
     if not groups:
         raise HTTPException(status_code=400, detail="No valid merges")
 
+    user_id = user.user_id if user else None
     with get_db() as conn:
         try:
+            for target_id, source_ids in groups.items():
+                _assert_person_visible(conn, user_id, target_id)
+                for source_id in source_ids:
+                    _assert_person_visible(conn, user_id, source_id)
             merged_total = 0
             for target_id, source_ids in groups.items():
                 ids = sorted(source_ids)
@@ -315,6 +367,7 @@ def delete_person(
     """Delete a person and unassign all their faces."""
     with get_db() as conn:
         try:
+            _assert_person_visible(conn, user.user_id if user else None, person_id)
             # 1. Unassign all faces from this person (set person_id to NULL)
             conn.execute("UPDATE faces SET person_id = NULL WHERE person_id = ?", (person_id,))
 
@@ -340,8 +393,11 @@ def delete_persons_batch(
     if not body.person_ids:
         raise HTTPException(status_code=400, detail="No person_ids provided")
 
+    user_id = user.user_id if user else None
     with get_db() as conn:
         try:
+            for person_id in body.person_ids:
+                _assert_person_visible(conn, user_id, person_id)
             placeholders = ",".join("?" * len(body.person_ids))
             # 1. Unassign all faces from these persons
             conn.execute(
@@ -450,6 +506,7 @@ def api_assign_faces_batch(
             if not target:
                 raise HTTPException(status_code=404, detail="Target person not found")
 
+            _assert_person_assignable(conn, user.user_id if user else None, person_id)
             assert_faces_visible(conn, user.user_id if user else None, body.face_ids)
             result = reassign_faces_to_person(conn, person_id, body.face_ids)
             face_count = result["face_count"]
@@ -493,6 +550,7 @@ def api_split_person(
 
     with get_db() as conn:
         try:
+            _assert_person_visible(conn, user.user_id if user else None, person_id)
             placeholders = ",".join("?" * len(face_ids))
             rows = conn.execute(
                 f"SELECT id FROM faces WHERE id IN ({placeholders}) AND person_id = ?",
@@ -550,7 +608,7 @@ def api_hide_person(
     user: CurrentUser = Depends(require_edition),
 ):
     """Hide a person cluster from the persons list, filters, and merge suggestions."""
-    return _set_person_hidden(person_id, True)
+    return _set_person_hidden(person_id, True, user.user_id if user else None)
 
 
 @router.post("/api/persons/{person_id}/unhide")
@@ -559,13 +617,14 @@ def api_unhide_person(
     user: CurrentUser = Depends(require_edition),
 ):
     """Unhide a previously hidden person cluster."""
-    return _set_person_hidden(person_id, False)
+    return _set_person_hidden(person_id, False, user.user_id if user else None)
 
 
-def _set_person_hidden(person_id: int, hidden: bool):
+def _set_person_hidden(person_id: int, hidden: bool, user_id):
     """Shared hide/unhide logic: flip the is_hidden flag on a person row."""
     with get_db() as conn:
         try:
+            _assert_person_visible(conn, user_id, person_id)
             conn.execute(
                 "UPDATE persons SET is_hidden = ? WHERE id = ?",
                 (1 if hidden else 0, person_id),

--- a/api/routers/stats.py
+++ b/api/routers/stats.py
@@ -76,12 +76,12 @@ _WEIGHT_COLUMNS = {
 def _vis_where(user: Optional[CurrentUser]):
     """Return (where_clause_with_AND_prefix, params) for visibility filtering.
 
-    Returns ('', []) in legacy mode. In multi-user mode returns
-    (' AND <visibility>', [params...]) suitable for appending to an existing WHERE.
+    Returns ('', []) on a fully open install. On an access-controlled deployment
+    (multi-user, or a single-user viewer password) an unauthenticated request
+    resolves to (' AND 0=1', []) so it sees nothing; ``get_visibility_clause``
+    owns that carve-out, so this must never short-circuit before calling it.
     """
     user_id = user.user_id if user else None
-    if not user_id:
-        return '', []
     vis_sql, vis_params = get_visibility_clause(user_id)
     if vis_sql == '1=1':
         return '', []

--- a/api/routers/webdav.py
+++ b/api/routers/webdav.py
@@ -265,6 +265,8 @@ async def dav_move(request: Request, subpath: str = ""):
     dest = _resolve(root, _parse_destination(request.headers.get("destination", "")))
     if dest == root:
         raise HTTPException(status_code=403, detail="Invalid destination")
+    if dest == src:
+        raise HTTPException(status_code=403, detail="Source and destination are the same")
     if not os.path.isdir(os.path.dirname(dest)):
         raise HTTPException(status_code=409, detail="Destination parent missing")
     dest_existed = os.path.exists(dest)

--- a/calibrate.py
+++ b/calibrate.py
@@ -404,7 +404,8 @@ def build_metric_matrix(rows: list[dict]) -> tuple[np.ndarray, np.ndarray, list[
         if non_null / len(vals) >= 0.5:
             available_cols.append(col)
 
-    X = np.array([[r.get(col) or 5.0 for col in available_cols] for r in rows], dtype=np.float64)
+    default_value = 5.0
+    X = np.array([[r.get(col) if r.get(col) is not None else default_value for col in available_cols] for r in rows], dtype=np.float64)
     y = np.array([r['mos'] for r in rows], dtype=np.float64)
     return X, y, available_cols
 

--- a/client/src/app/features/comparison/comparison-ab-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-ab-tab.component.ts
@@ -344,6 +344,7 @@ export class ComparisonAbTabComponent {
       const data = await firstValueFrom(
         this.api.get<PairResponse>('/comparison/next_pair', { category: cat, strategy: this.strategy() }),
       );
+      if (this.compareFilters.selectedCategory() !== cat) return;
       if (data.error) {
         this.pairA.set(null);
         this.pairB.set(null);

--- a/client/src/app/features/comparison/comparison-suggestions-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-suggestions-tab.component.ts
@@ -202,6 +202,7 @@ export class ComparisonSuggestionsTabComponent {
         firstValueFrom(this.api.get<CategoryWeights>('/comparison/category_weights', { category })),
         this.fetchTopPhotos(category),
       ]);
+      if (this.compareFilters.selectedCategory() !== category) return;
       this.learnedWeights.set(lw);
       this.categoryConfig.set(config);
       this.topBefore.set(top);

--- a/client/src/app/features/comparison/comparison-weights-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-weights-tab.component.ts
@@ -535,6 +535,7 @@ export class ComparisonWeightsTabComponent {
       const data = await firstValueFrom(
         this.api.get<CategoryWeights>('/comparison/category_weights', { category: cat }),
       );
+      if (this.compareFilters.selectedCategory() !== cat) return;
       this.weights.set({ ...data.weights });
       this.savedWeights.set({ ...data.weights });
       this.modifiers.set({ ...(data.modifiers ?? {}) });

--- a/client/src/app/features/comparison/comparison.component.ts
+++ b/client/src/app/features/comparison/comparison.component.ts
@@ -123,7 +123,7 @@ Chart.register(...registerables);
               <mat-icon class="mr-2">bookmark</mat-icon>
               {{ I18N.comparison.snapshots | translate }}
             </ng-template>
-            <app-comparison-snapshots-tab #snapshotsTabEl (restored)="weightsTab()?.loadWeights()" />
+            <app-comparison-snapshots-tab #snapshotsTabEl (restored)="onSnapshotRestored()" />
           </mat-tab>
 
           <!-- A/B Compare tab -->
@@ -243,5 +243,12 @@ export class ComparisonComponent {
   protected onWeightsApplied(merged: Record<string, number>): void {
     const tab = this.weightsTab();
     if (tab) tab.weights.set(merged);
+  }
+
+  protected onSnapshotRestored(): void {
+    const tab = this.weightsTab();
+    if (!tab) return;
+    void tab.loadWeights();
+    void tab.loadWeightImpact();
   }
 }

--- a/client/src/app/features/gallery/burst-culling.component.spec.ts
+++ b/client/src/app/features/gallery/burst-culling.component.spec.ts
@@ -233,11 +233,11 @@ describe('BurstCullingComponent', () => {
       expect(mockApi.post).not.toHaveBeenCalled();
     });
 
-    it('commits the selected paths and hides the group after the cooldown', () => {
+    it('commits the selected paths and hides the group after the cooldown', async () => {
       const group = component['groups']()[0];
       component['confirmGroup'](group);
 
-      vi.advanceTimersByTime(7000);
+      await vi.advanceTimersByTimeAsync(7000);
 
       expect(mockApi.post).toHaveBeenCalledWith('/culling-groups/confirm', {
         group_id: 1,

--- a/client/src/app/features/gallery/burst-culling.component.ts
+++ b/client/src/app/features/gallery/burst-culling.component.ts
@@ -1182,12 +1182,28 @@ export class BurstCullingComponent implements OnDestroy {
     void this.loadCullProfiles();
     void this.refreshComparisonStats();
     void this.refreshRankerStatus();
-    // Keep the keyboard selection in bounds as groups load / get hidden.
+    // Keep the keyboard selection in bounds as groups load / get hidden, preserving
+    // the identity of the highlighted group when an earlier one drops out of the list.
+    let previousVisibleKeys: string[] = [];
     effect(() => {
-      const count = this.visibleGroups().length;
-      if (count === 0) return;
-      const clamped = Math.min(this.selectedGroupIndex(), count - 1);
-      if (clamped !== this.selectedGroupIndex()) this.selectedGroupIndex.set(clamped);
+      const groups = this.visibleGroups();
+      const count = groups.length;
+      if (count === 0) { previousVisibleKeys = []; return; }
+      const idx = this.selectedGroupIndex();
+      const currentKeys = groups.map(g => this.groupKey(g));
+      const groupsChanged = currentKeys.length !== previousVisibleKeys.length
+        || currentKeys.some((k, i) => k !== previousVisibleKeys[i]);
+      if (groupsChanged && previousVisibleKeys[idx] !== undefined) {
+        const newIdx = currentKeys.indexOf(previousVisibleKeys[idx]);
+        if (newIdx >= 0 && newIdx !== idx) {
+          previousVisibleKeys = currentKeys;
+          this.selectedGroupIndex.set(newIdx);
+          return;
+        }
+      }
+      previousVisibleKeys = currentKeys;
+      const clamped = Math.min(idx, count - 1);
+      if (clamped !== idx) this.selectedGroupIndex.set(clamped);
     });
     // Scroll the keyboard-selected group into view (mirrors gallery.focusCard).
     effect(() => {
@@ -1826,8 +1842,8 @@ export class BurstCullingComponent implements OnDestroy {
     if (group) {
       // Darkroom: confirm the open group and jump into the next one.
       event.preventDefault();
+      if (!this.confirmGroup(group)) return;
       const next = this.nextUnconfirmedGroupAfter(group);
-      this.confirmGroup(group);
       if (next) {
         this.openLightbox(next, 0);
         this.lightboxDialog()?.nativeElement.focus();
@@ -1841,8 +1857,8 @@ export class BurstCullingComponent implements OnDestroy {
     const selected = this.visibleGroups()[this.selectedGroupIndex()];
     if (!selected) return;
     event.preventDefault();
+    if (!this.confirmGroup(selected)) return;
     const next = this.nextUnconfirmedGroupAfter(selected);
-    void this.confirmGroup(selected);
     if (next) {
       const gi = this.visibleGroups().findIndex(g => this.groupKey(g) === this.groupKey(next));
       if (gi >= 0) this.selectedGroupIndex.set(gi);
@@ -1952,9 +1968,9 @@ export class BurstCullingComponent implements OnDestroy {
     this.updateMapSignal(this.selectionsMap, group.group_id, new Set([path]));
   }
 
-  protected confirmGroup(group: CullingGroup): void {
+  protected confirmGroup(group: CullingGroup): boolean {
     const kept = this.selectionsMap().get(group.group_id);
-    if (!kept || kept.size === 0) return;
+    if (!kept || kept.size === 0) return false;
 
     // Grey the group and start the cancellable cooldown; the commit + close only
     // happen when it elapses, so Cancel within the window fully reverts it.
@@ -1968,13 +1984,17 @@ export class BurstCullingComponent implements OnDestroy {
         paths: group.photos.map(p => p.path),
         keep_paths: keepPaths,
       }))
-        .then(() => { void this.refreshComparisonStats(); void this.refreshRankerStatus(); })
+        .then(() => {
+          this.addToSetSignal(this.hiddenGroups, key);
+          void this.refreshComparisonStats();
+          void this.refreshRankerStatus();
+        })
         .catch(() => {
           this.unconfirmGroup(key);
           this.snackBar.open(this.i18n.t(I18N.culling.error_confirming), '', { duration: 2000, horizontalPosition: 'right', verticalPosition: 'bottom' });
         });
-      this.addToSetSignal(this.hiddenGroups, key);
     }, true);
+    return true;
   }
 
   private unconfirmGroup(key: string): void {
@@ -2084,11 +2104,17 @@ export class BurstCullingComponent implements OnDestroy {
             keep_paths: [...kept],
           }));
         }));
+        this.confirmedGroups.update(s => {
+          const next = new Set(s);
+          for (const g of batch) next.add(this.groupKey(g));
+          return next;
+        });
       }
 
+      const skipped = remaining.filter(g => !toConfirm.includes(g));
       this.confirmedGroups.update(s => {
         const next = new Set(s);
-        for (const g of remaining) next.add(this.groupKey(g));
+        for (const g of skipped) next.add(this.groupKey(g));
         return next;
       });
       this.snackBar.open(this.i18n.t(I18N.culling.confirmed), '', { duration: 2000, horizontalPosition: 'right', verticalPosition: 'bottom' });

--- a/client/src/app/features/gallery/cull-dialog.component.ts
+++ b/client/src/app/features/gallery/cull-dialog.component.ts
@@ -13,6 +13,14 @@ import { I18N } from '../../core/i18n/keys';
 
 type CullAction = 'copy_keeps' | 'trash_rejects' | 'move_rejects';
 
+interface CullRequest {
+  paths: string[];
+  action: CullAction;
+  target_dir: string | null;
+  include_companions: boolean;
+  dry_run: boolean;
+}
+
 interface CullResponse {
   would_copy?: string[];
   would_move?: string[];
@@ -116,7 +124,7 @@ export class CullDialogComponent {
     this.preview.set(null);
   }
 
-  private body(dryRun: boolean) {
+  private body(dryRun: boolean): CullRequest {
     return {
       paths: this.data.paths,
       action: this.action(),
@@ -126,10 +134,21 @@ export class CullDialogComponent {
     };
   }
 
+  private matchesCurrentForm(requested: CullRequest): boolean {
+    const current = this.body(true);
+    return requested.action === current.action
+      && requested.target_dir === current.target_dir
+      && requested.include_companions === current.include_companions;
+  }
+
   async runPreview(): Promise<void> {
     this.busy.set(true);
+    const requested = this.body(true);
     try {
-      const res = await firstValueFrom(this.api.post<CullResponse>('/cull/apply', this.body(true)));
+      const res = await firstValueFrom(this.api.post<CullResponse>('/cull/apply', requested));
+      if (!this.matchesCurrentForm(requested)) {
+        return;
+      }
       const affected = res.would_copy ?? res.would_move ?? res.would_trash ?? [];
       this.preview.set({ affected, skipped: res.skipped ?? [], excluded: res.excluded_by_state ?? 0 });
     } catch {

--- a/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
+++ b/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, DestroyRef, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, effect, ElementRef, inject, signal, viewChild } from '@angular/core';
 import { DecimalPipe, NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
@@ -928,16 +928,24 @@ export class GalleryFilterSidebarComponent {
   }
 
   private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+  private albumsLoaded = false;
 
   constructor() {
-    if (this.store.config()?.features?.show_albums) {
-      firstValueFrom(this.albumService.list()).then(res =>
-        this.albums.set(res.albums),
-      ).catch(() => {});
-    }
+    effect(() => {
+      if (this.store.config()?.features?.show_albums && !this.albumsLoaded) {
+        this.albumsLoaded = true;
+        this.refreshAlbums();
+      }
+    });
     inject(DestroyRef).onDestroy(() => {
       if (this.searchTimeout) clearTimeout(this.searchTimeout);
     });
+  }
+
+  private refreshAlbums(): void {
+    firstValueFrom(this.albumService.list()).then(res =>
+      this.albums.set(res.albums),
+    ).catch(() => {});
   }
 
   onSidebarSearchChange(event: Event): void {
@@ -994,9 +1002,7 @@ export class GalleryFilterSidebarComponent {
     });
     ref.afterClosed().subscribe(result => {
       if (result) {
-        firstValueFrom(this.albumService.list()).then(res =>
-          this.albums.set(res.albums),
-        ).catch(() => {});
+        this.refreshAlbums();
       }
     });
   }

--- a/client/src/app/features/gallery/gallery-filters.util.ts
+++ b/client/src/app/features/gallery/gallery-filters.util.ts
@@ -160,7 +160,7 @@ export interface FilterDefaults {
 /** Keys excluded when building smart album filter JSON (display-only, ephemeral, or handled separately). */
 export const SMART_ALBUM_EXCLUDE_KEYS = new Set([
   'page', 'per_page', 'semanticQuery', 'album_id',
-  'similarity_mode', 'min_similarity',
+  'similar_to', 'similarity_mode', 'min_similarity',
   'hide_details', 'tooltip_mode', 'hide_blinks', 'hide_bursts',
   'hide_duplicates', 'hide_rejected',
   'gps_lat', 'gps_lng', 'gps_radius_km',

--- a/client/src/app/features/gallery/gallery.store.ts
+++ b/client/src/app/features/gallery/gallery.store.ts
@@ -237,16 +237,25 @@ export class GalleryStore {
     return f.gps_lat && f.gps_lng ? `${f.gps_lat},${f.gps_lng}` : '';
   });
 
+  private _gpsLocationSeq = 0;
+
   private gpsLocationEffect = effect(() => {
     const coords = this.gpsCoords();
+    const seq = ++this._gpsLocationSeq;
     if (!coords) {
       this.gpsLocationName.set('');
       return;
     }
     const [lat, lng] = coords.split(',');
     firstValueFrom(this.api.get<{ display_name: string }>('/filter_options/location_name', { lat, lng }))
-      .then(res => this.gpsLocationName.set(res.display_name || `${(+lat).toFixed(2)}, ${(+lng).toFixed(2)}`))
-      .catch(() => this.gpsLocationName.set(`${(+lat).toFixed(2)}, ${(+lng).toFixed(2)}`));
+      .then(res => {
+        if (seq !== this._gpsLocationSeq) return;
+        this.gpsLocationName.set(res.display_name || `${(+lat).toFixed(2)}, ${(+lng).toFixed(2)}`);
+      })
+      .catch(() => {
+        if (seq !== this._gpsLocationSeq) return;
+        this.gpsLocationName.set(`${(+lat).toFixed(2)}, ${(+lng).toFixed(2)}`);
+      });
   });
 
   // --- Computed ---
@@ -452,12 +461,15 @@ export class GalleryStore {
     if (key === 'favorites_only' && value) extra.hide_rejected = false;
     // Reload person dropdown when person filter is cleared (was seeded with filtered subset)
     const wasPersonFiltered = !!this.filters().person_id;
-    this.filters.update(current => ({ ...current, [key]: value, ...extra, page: 1 }));
+    const isDisplayOnly = GalleryStore.DISPLAY_ONLY_KEYS.has(key);
+    this.filters.update(current => ({
+      ...current, [key]: value, ...extra, ...(isDisplayOnly ? {} : { page: 1 }),
+    }));
     if ((DISPLAY_OPTION_KEYS as string[]).includes(key as string)) {
       saveDisplayOptionsToStorage(this.filters());
     }
     this.syncUrl();
-    if (!GalleryStore.DISPLAY_ONLY_KEYS.has(key)) {
+    if (!isDisplayOnly) {
       this.cancelRangeLoad();
       await this.loadPhotos();
     }
@@ -766,7 +778,12 @@ export class GalleryStore {
   async selectBottomPercent(
     keepPercent: number,
   ): Promise<{ total: number; keep: number; cut: number; truncated: boolean; paths: string[] } | null> {
-    const params = buildApiParams(this.filters(), this.currentAlbum()?.is_smart ?? false);
+    const f = this.filters();
+    if (f.similar_to || f.semanticQuery) {
+      this.notifyActionFailed();
+      return null;
+    }
+    const params = buildApiParams(f, this.currentAlbum()?.is_smart ?? false);
     try {
       const res = await firstValueFrom(
         this.api.get<{ total: number; keep: number; cut: number; truncated: boolean; paths: string[] }>(

--- a/client/src/app/features/gallery/slideshow.component.ts
+++ b/client/src/app/features/gallery/slideshow.component.ts
@@ -368,6 +368,9 @@ export class SlideshowComponent implements OnDestroy {
   /** Track the previous maxPortraitsPerSlide to detect regrouping. */
   private prevMaxPortraits = 0;
 
+  /** True once ngOnDestroy has run — guards pending async work from mutating a destroyed component. */
+  private destroyed = false;
+
   constructor() {
     // Watch for slides to become available (handles async photo loading)
     effect(() => {
@@ -380,6 +383,11 @@ export class SlideshowComponent implements OnDestroy {
         this.layerASlide.set(slide);
         this.layerAOpacity.set(1);
         this.frontLayer.set('a');
+        untracked(() => {
+          const kbPatterns = this.pickKenBurnsPatterns(slide.photos.length);
+          this.initKenBurns(this.layerAImgTransforms, this.layerAImgTransitions, kbPatterns);
+          this.animateKenBurns(this.layerAImgTransforms, this.layerAImgTransitions, kbPatterns);
+        });
       }
     });
 
@@ -485,6 +493,8 @@ export class SlideshowComponent implements OnDestroy {
     if (this.boundOrientationHandler) {
       screen.orientation?.removeEventListener('change', this.boundOrientationHandler);
     }
+    this.destroyed = true;
+    this.store.slideshowActive.set(false);
   }
 
   private updateViewportDimensions(): void {
@@ -591,6 +601,7 @@ export class SlideshowComponent implements OnDestroy {
     );
 
     Promise.all(preloadPromises).then(() => {
+      if (this.destroyed) return;
       this.currentSlideIndex.set(slideIndex);
       this.slideIndexChanged.emit(slideIndex);
       this.crossfadeTo(slide).then(() => {

--- a/client/src/app/features/map/map.component.ts
+++ b/client/src/app/features/map/map.component.ts
@@ -118,6 +118,7 @@ export class MapComponent implements OnInit, OnDestroy {
   private moveEndHandler: (() => void) | null = null;
   private initTimeout: ReturnType<typeof setTimeout> | null = null;
   private moveEndDebounce: ReturnType<typeof setTimeout> | null = null;
+  private loadMarkersRequestId = 0;
 
   // Reload markers when date filters change
   private dateFilterEffect = effect(() => {
@@ -181,6 +182,8 @@ export class MapComponent implements OnInit, OnDestroy {
   private async loadMarkers(): Promise<void> {
     if (!this.map) return;
 
+    const requestId = ++this.loadMarkersRequestId;
+
     const bounds = this.map.getBounds();
     const zoom = this.map.getZoom();
     const boundsStr = [
@@ -202,6 +205,8 @@ export class MapComponent implements OnInit, OnDestroy {
       const data = await firstValueFrom(
         this.api.get<MapResponse>('/photos/map', params),
       );
+
+      if (requestId !== this.loadMarkersRequestId) return;
 
       this.markersLayer.clearLayers();
 
@@ -274,7 +279,9 @@ export class MapComponent implements OnInit, OnDestroy {
     } catch (err) {
       console.error('Failed to load map data', err);
     } finally {
-      this.loading.set(false);
+      if (requestId === this.loadMarkersRequestId) {
+        this.loading.set(false);
+      }
     }
   }
 }

--- a/client/src/app/features/photo-detail/gps-edit-dialog.component.ts
+++ b/client/src/app/features/photo-detail/gps-edit-dialog.component.ts
@@ -92,9 +92,10 @@ export class GpsEditDialogComponent {
     }
 
     this.map.on('click', (e: L.LeafletMouseEvent) => {
-      this.selectedLat.set(e.latlng.lat);
-      this.selectedLng.set(e.latlng.lng);
-      this.placeMarker(e.latlng.lat, e.latlng.lng);
+      const wrapped = e.latlng.wrap();
+      this.selectedLat.set(wrapped.lat);
+      this.selectedLng.set(wrapped.lng);
+      this.placeMarker(wrapped.lat, wrapped.lng);
     });
   }
 

--- a/client/src/app/features/photo-detail/photo-detail.component.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.ts
@@ -28,6 +28,7 @@ import { GalleryStore } from '../gallery/gallery.store';
 import * as L from 'leaflet';
 import { createLeafletMap } from '../../shared/leaflet';
 import { I18N } from '../../core/i18n/keys';
+import { isTypingContext } from '../../shared/utils/keyboard';
 
 const SOCIAL_SOURCE_KEYS: Record<string, string> = {
   saliency: I18N.social_export.source.saliency,
@@ -513,9 +514,10 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
       this.downloadOptions.set([{ type: 'original', label: 'original' }]);
       return;
     }
-    firstValueFrom(this.api.get<{ options: DownloadOption[] }>('/download/options', { path: p.path }))
-      .then(res => this.downloadOptions.set(res.options))
-      .catch(() => this.downloadOptions.set([{ type: 'original', label: 'original' }]));
+    const requestedPath = p.path;
+    firstValueFrom(this.api.get<{ options: DownloadOption[] }>('/download/options', { path: requestedPath }))
+      .then(res => { if (this.photo()?.path === requestedPath) this.downloadOptions.set(res.options); })
+      .catch(() => { if (this.photo()?.path === requestedPath) this.downloadOptions.set([{ type: 'original', label: 'original' }]); });
   });
 
   // Social-export crop presets (from viewer config) + which signal frames the crop
@@ -561,11 +563,12 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
       this.locationName.set('');
       return;
     }
+    const requestedPath = p.path;
     firstValueFrom(this.api.get<{ display_name: string }>('/filter_options/location_name', {
       lat: String(p.gps_latitude), lng: String(p.gps_longitude),
     }))
-      .then(res => this.locationName.set(res.display_name || ''))
-      .catch(() => this.locationName.set(''));
+      .then(res => { if (this.photo()?.path === requestedPath) this.locationName.set(res.display_name || ''); })
+      .catch(() => { if (this.photo()?.path === requestedPath) this.locationName.set(''); });
   });
 
   private readonly locationMapContainer = viewChild<ElementRef<HTMLDivElement>>('locationMapContainer');
@@ -651,13 +654,15 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
     this.location.back();
   }
 
-  @HostListener('document:keydown.arrowleft')
-  protected prevPhoto(): void {
+  @HostListener('document:keydown.arrowleft', ['$event'])
+  protected prevPhoto(event: Event): void {
+    if (isTypingContext(event)) return;
     this.navigateAdjacentPhoto(-1);
   }
 
-  @HostListener('document:keydown.arrowright')
-  protected nextPhoto(): void {
+  @HostListener('document:keydown.arrowright', ['$event'])
+  protected nextPhoto(event: Event): void {
+    if (isTypingContext(event)) return;
     this.navigateAdjacentPhoto(1);
   }
 

--- a/client/src/app/features/stats/stats.component.ts
+++ b/client/src/app/features/stats/stats.component.ts
@@ -292,7 +292,6 @@ export class StatsComponent {
   private chartRefs = new Map<string, ElementRef<HTMLCanvasElement>>();
 
   // Canvas refs
-  protected readonly categoriesCanvas = viewChild<ElementRef<HTMLCanvasElement>>('categoriesCanvas');
   protected readonly scoreCanvas = viewChild<ElementRef<HTMLCanvasElement>>('scoreCanvas');
   protected readonly categoryScoreProfileCanvas = viewChild<ElementRef<HTMLCanvasElement>>('categoryScoreProfileCanvas');
   protected readonly categoryMetricCanvas = viewChild<ElementRef<HTMLCanvasElement>>('categoryMetricCanvas');
@@ -359,10 +358,7 @@ export class StatsComponent {
       const from = this.statsFilters.dateFrom();
       const to = this.statsFilters.dateTo();
        
-      const qp: any = {};
-      if (cat) qp.category = cat;
-      if (from) qp.date_from = from;
-      if (to) qp.date_to = to;
+      const qp: any = { category: cat || null, date_from: from || null, date_to: to || null };
       this.router.navigate([], { queryParams: qp, queryParamsHandling: 'merge', replaceUrl: true });
     });
 
@@ -385,11 +381,6 @@ export class StatsComponent {
     });
 
     // Chart effects — canvas refs must be tracked so charts render on tab switch
-    effect(() => {
-      const cats = this.categoryStats();
-      const color = this.themeService.complementaryColor();
-      this.buildHorizontalBar('categories', this.categoriesCanvas(), cats.map(c => this.translateCategory(c.category)), cats.map(c => c.count), color);
-    });
     effect(() => {
       const bins = this.scoreBins();
       const accent = this.themeService.accentColor();
@@ -427,13 +418,18 @@ export class StatsComponent {
     return params;
   }
 
+  private readonly loadSeq: Record<string, number> = {};
+  private nextLoadSeq(key: string): number { return (this.loadSeq[key] = (this.loadSeq[key] ?? 0) + 1); }
+  private isLatestLoadSeq(key: string, seq: number): boolean { return this.loadSeq[key] === seq; }
+
   async loadAll(): Promise<void> {
+    const seq = this.nextLoadSeq('overview');
     this.loading.set(true);
     try {
       const overview = await firstValueFrom(this.api.get<StatsOverviewData>('/stats/overview', this.filterParams));
-      this.statsFilters.overview.set(overview);
+      if (this.isLatestLoadSeq('overview', seq)) this.statsFilters.overview.set(overview);
     } catch { /* empty */ }
-    finally { this.loading.set(false); }
+    finally { if (this.isLatestLoadSeq('overview', seq)) this.loading.set(false); }
 
     this.loadGear();
     this.loadCategories();
@@ -461,38 +457,44 @@ export class StatsComponent {
   }
 
   async loadGear(): Promise<void> {
+    const seq = this.nextLoadSeq('gear');
     this.gearLoading.set(true);
     try {
       const data = await firstValueFrom(this.api.get<GearApiResponse>('/stats/gear', this.filterParams));
-      this.cameras.set((data.cameras ?? []).map(c => this.mapGearItem(c as unknown as Record<string, unknown>)));
-      this.lenses.set((data.lenses ?? []).map(l => this.mapGearItem(l as unknown as Record<string, unknown>)));
-      this.combos.set((data.combos ?? []).map(c => this.mapGearItem(c as unknown as Record<string, unknown>)));
+      if (this.isLatestLoadSeq('gear', seq)) {
+        this.cameras.set((data.cameras ?? []).map(c => this.mapGearItem(c as unknown as Record<string, unknown>)));
+        this.lenses.set((data.lenses ?? []).map(l => this.mapGearItem(l as unknown as Record<string, unknown>)));
+        this.combos.set((data.combos ?? []).map(c => this.mapGearItem(c as unknown as Record<string, unknown>)));
+      }
     } catch { /* empty */ }
-    finally { this.gearLoading.set(false); }
+    finally { if (this.isLatestLoadSeq('gear', seq)) this.gearLoading.set(false); }
   }
 
   async loadCategories(): Promise<void> {
+    const seq = this.nextLoadSeq('categories');
     this.categoriesLoading.set(true);
     try {
       const data = await firstValueFrom(this.api.get<CategoryStat[]>('/stats/categories', this.filterParams));
-      this.categoryStats.set(data);
+      if (this.isLatestLoadSeq('categories', seq)) this.categoryStats.set(data);
     } catch { /* empty */ }
-    finally { this.categoriesLoading.set(false); }
+    finally { if (this.isLatestLoadSeq('categories', seq)) this.categoriesLoading.set(false); }
   }
 
   async loadScoreDistribution(): Promise<void> {
+    const seq = this.nextLoadSeq('scoreDistribution');
     this.scoreLoading.set(true);
     try {
       const data = await firstValueFrom(this.api.get<ScoreBin[]>('/stats/score_distribution', this.filterParams));
-      this.scoreBins.set(data);
+      if (this.isLatestLoadSeq('scoreDistribution', seq)) this.scoreBins.set(data);
     } catch { /* empty */ }
-    finally { this.scoreLoading.set(false); }
+    finally { if (this.isLatestLoadSeq('scoreDistribution', seq)) this.scoreLoading.set(false); }
   }
 
   async loadTopCameras(): Promise<void> {
+    const seq = this.nextLoadSeq('topCameras');
     try {
       const data = await firstValueFrom(this.api.get<TopCamera[]>('/stats/top_cameras', this.filterParams));
-      this.topCameras.set(data);
+      if (this.isLatestLoadSeq('topCameras', seq)) this.topCameras.set(data);
     } catch { /* empty */ }
   }
 
@@ -513,7 +515,7 @@ export class StatsComponent {
   }
 
   private buildHorizontalBar(id: string, ref: ElementRef<HTMLCanvasElement> | undefined, labels: string[], data: number[], color: string): void {
-    if (!ref || data.length === 0) return;
+    if (!ref || data.length === 0) { this.destroyChart(id); return; }
     // Skip rebuild if same canvas ref and chart already exists — just update data
     const existing = this.charts.get(id);
     if (existing && this.chartRefs.get(id) === ref) {
@@ -556,7 +558,7 @@ export class StatsComponent {
     labels: string[],
     datasets: { label: string; data: number[]; color: string }[],
   ): void {
-    if (!ref || labels.length === 0) return;
+    if (!ref || labels.length === 0) { this.destroyChart(id); return; }
     const existing = this.charts.get(id);
     if (existing && this.chartRefs.get(id) === ref) {
       existing.data.labels = labels;
@@ -600,7 +602,7 @@ export class StatsComponent {
   }
 
   private buildVerticalBar(id: string, ref: ElementRef<HTMLCanvasElement> | undefined, labels: string[], data: number[], color: string): void {
-    if (!ref || data.length === 0) return;
+    if (!ref || data.length === 0) { this.destroyChart(id); return; }
     const existing = this.charts.get(id);
     if (existing && this.chartRefs.get(id) === ref) {
       existing.data.labels = labels;

--- a/client/src/app/shared/directives/photo-detail-base.directive.ts
+++ b/client/src/app/shared/directives/photo-detail-base.directive.ts
@@ -48,16 +48,23 @@ export abstract class PhotoDetailBase {
       return;
     }
     this.translatingCaption.set(true);
+    const requestPath = p.path;
+    const isStale = () => this.photo()?.path !== requestPath || this.i18n.locale() !== locale;
     firstValueFrom(this.api.get<{ caption: string; lang?: string }>('/caption', { path: p.path, lang: locale }))
       .then(res => {
+        if (isStale()) return;
         if (res.lang) {
           this.translatedCaption.set(res.caption);
         } else {
           this.translatedCaption.set(null);
         }
       })
-      .catch(() => this.translatedCaption.set(null))
-      .finally(() => this.translatingCaption.set(false));
+      .catch(() => {
+        if (!isStale()) this.translatedCaption.set(null);
+      })
+      .finally(() => {
+        if (!isStale()) this.translatingCaption.set(false);
+      });
   });
 
   protected onFullImageLoad(): void {

--- a/config/scoring_config.py
+++ b/config/scoring_config.py
@@ -540,8 +540,7 @@ class ScoringConfig:
             'clustering_algorithm': 'boruvka_balltree',
             'leaf_size': 40,
             'use_gpu': 'auto',
-            'merge_threshold': 0.6,
-            'chunk_size': 10000
+            'merge_threshold': 0.6
         })
 
     def get_face_processing_settings(self):

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -18,6 +18,8 @@ _PATH_PRESENT = 'present'
 _PATH_DELETED = 'deleted'
 _PATH_INACCESSIBLE = 'inaccessible'
 
+_MIN_BACKUPS_TO_KEEP = 1
+
 
 def _classify_missing_path(path):
     """Classify a stored photo path as present, genuinely deleted, or merely
@@ -172,6 +174,12 @@ def backup_database(db_path='photo_scores_pro.db', keep=3, dest_dir=None, verbos
     if not os.path.exists(db_path):
         raise FileNotFoundError(f"Database not found: {db_path}")
 
+    if keep < _MIN_BACKUPS_TO_KEEP:
+        raise ValueError(
+            f"keep must be at least {_MIN_BACKUPS_TO_KEEP} (got {keep}); a lower value "
+            "would rotate away the snapshot this call just wrote"
+        )
+
     source_size = os.path.getsize(db_path)
     base_dir = dest_dir or os.path.dirname(os.path.abspath(db_path))
     os.makedirs(base_dir, exist_ok=True)
@@ -216,8 +224,9 @@ def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, force=F
 
     Cascading foreign keys clean up faces, tags, comparisons, learned scores
     and per-user preferences. Stores without a cascade are cleaned explicitly
-    so no orphans remain: album memberships (album_photos), album covers, and
-    the sqlite-vec index (photos_vec).
+    so no orphans remain: album memberships (album_photos), client proofing
+    picks (album_client_picks), album covers, and the sqlite-vec index
+    (photos_vec).
 
     Args:
         db_path: Path to SQLite database
@@ -310,6 +319,8 @@ def cleanup_missing_photos(db_path='photo_scores_pro.db', dry_run=False, force=F
         cursor.executemany("DELETE FROM photos WHERE path = ?", params)
         # album_photos.photo_path has no ON DELETE CASCADE — drop memberships explicitly.
         cursor.executemany("DELETE FROM album_photos WHERE photo_path = ?", params)
+        # album_client_picks cascades on album_id only, not photo_path — drop picks explicitly.
+        cursor.executemany("DELETE FROM album_client_picks WHERE photo_path = ?", params)
         # An album cover may point at a now-deleted photo.
         cursor.executemany("UPDATE albums SET cover_photo_path = NULL WHERE cover_photo_path = ?", params)
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -919,6 +919,7 @@ def init_database(db_path='photo_scores_pro.db'):
         # narrower schema is detected (caption+tags only), drop it so the
         # CREATE below installs the covering schema. The FTS data is then
         # repopulated by db.fts.rebuild_fts (or whoever rebuilds next).
+        fts_existed = _table_exists(conn, 'photos_fts')
         fts_recreated = False
         if not fts_schema_is_current(conn):
             logger.info("photos_fts schema outdated — dropping for recreate")
@@ -930,10 +931,12 @@ def init_database(db_path='photo_scores_pro.db'):
         for trigger_sql in PHOTOS_FTS_TRIGGERS:
             conn.execute(trigger_sql)
 
-        # The recreated external-content index starts empty; without this,
-        # text search silently returns nothing for every pre-upgrade photo
-        # until a manual --rebuild-fts. Repopulate it from the photos table.
-        if fts_recreated and not is_fresh:
+        # A freshly created external-content index starts empty — whether it was
+        # dropped for a schema upgrade or created for the first time on a DB that
+        # predates FTS. Without a rebuild, text search silently returns nothing
+        # for every existing photo until a manual --rebuild-fts. Repopulate it
+        # from the photos table.
+        if (fts_recreated or not fts_existed) and not is_fresh:
             try:
                 conn.execute("INSERT INTO photos_fts(photos_fts) VALUES('rebuild')")
             except sqlite3.DatabaseError:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -795,8 +795,7 @@ HDBSCAN clustering for face recognition.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -811,7 +810,6 @@ HDBSCAN clustering for face recognition.
 | `leaf_size` | `40` | Tree leaf size (CPU only) |
 | `use_gpu` | `"auto"` | GPU mode: `auto`, `always`, `never` (see notes below) |
 | `merge_threshold` | `0.6` | Centroid similarity for matching |
-| `chunk_size` | `10000` | Processing chunk size |
 
 **GPU clustering notes (`use_gpu`):**
 

--- a/docs/FACE_RECOGNITION.md
+++ b/docs/FACE_RECOGNITION.md
@@ -95,8 +95,7 @@ See [Viewer Integration](#viewer-integration) for the full UI reference.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/docs/de/CONFIGURATION.md
+++ b/docs/de/CONFIGURATION.md
@@ -787,8 +787,7 @@ HDBSCAN-Clustering für die Gesichtserkennung.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -803,7 +802,6 @@ HDBSCAN-Clustering für die Gesichtserkennung.
 | `leaf_size` | `40` | Blattgröße des Baums (nur CPU) |
 | `use_gpu` | `"auto"` | GPU-Modus: `auto`, `always`, `never` |
 | `merge_threshold` | `0.6` | Zentroid-Ähnlichkeit für die Zuordnung |
-| `chunk_size` | `10000` | Chunkgröße der Verarbeitung |
 
 **Clustering-Algorithmen:**
 

--- a/docs/de/FACE_RECOGNITION.md
+++ b/docs/de/FACE_RECOGNITION.md
@@ -106,8 +106,7 @@ Im Web-Viewer:
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/docs/es/CONFIGURATION.md
+++ b/docs/es/CONFIGURATION.md
@@ -787,8 +787,7 @@ Agrupación HDBSCAN para el reconocimiento de rostros.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -803,7 +802,6 @@ Agrupación HDBSCAN para el reconocimiento de rostros.
 | `leaf_size` | `40` | Tamaño de hoja del árbol (solo CPU) |
 | `use_gpu` | `"auto"` | Modo GPU: `auto`, `always`, `never` |
 | `merge_threshold` | `0.6` | Similitud de centroide para emparejar |
-| `chunk_size` | `10000` | Tamaño del fragmento de procesamiento |
 
 **Algoritmos de agrupación:**
 

--- a/docs/es/FACE_RECOGNITION.md
+++ b/docs/es/FACE_RECOGNITION.md
@@ -106,8 +106,7 @@ En la galería web:
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/docs/fr/CONFIGURATION.md
+++ b/docs/fr/CONFIGURATION.md
@@ -787,8 +787,7 @@ Regroupement HDBSCAN pour la reconnaissance des visages.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -803,7 +802,6 @@ Regroupement HDBSCAN pour la reconnaissance des visages.
 | `leaf_size` | `40` | Taille des feuilles de l'arbre (CPU uniquement) |
 | `use_gpu` | `"auto"` | Mode GPU : `auto`, `always`, `never` |
 | `merge_threshold` | `0.6` | Similarité de centroïde pour la correspondance |
-| `chunk_size` | `10000` | Taille des blocs de traitement |
 
 **Algorithmes de regroupement :**
 

--- a/docs/fr/FACE_RECOGNITION.md
+++ b/docs/fr/FACE_RECOGNITION.md
@@ -106,8 +106,7 @@ Dans la galerie web :
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/docs/it/CONFIGURATION.md
+++ b/docs/it/CONFIGURATION.md
@@ -787,8 +787,7 @@ Clustering HDBSCAN per il riconoscimento dei volti.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -803,7 +802,6 @@ Clustering HDBSCAN per il riconoscimento dei volti.
 | `leaf_size` | `40` | Dimensione delle foglie dell'albero (solo CPU) |
 | `use_gpu` | `"auto"` | Modalità GPU: `auto`, `always`, `never` |
 | `merge_threshold` | `0.6` | Similarità del centroide per la corrispondenza |
-| `chunk_size` | `10000` | Dimensione del blocco di elaborazione |
 
 **Algoritmi di clustering:**
 

--- a/docs/it/FACE_RECOGNITION.md
+++ b/docs/it/FACE_RECOGNITION.md
@@ -106,8 +106,7 @@ Nel visualizzatore web:
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/docs/pt/CONFIGURATION.md
+++ b/docs/pt/CONFIGURATION.md
@@ -787,8 +787,7 @@ Agrupamento HDBSCAN para reconhecimento de faces.
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```
@@ -803,7 +802,6 @@ Agrupamento HDBSCAN para reconhecimento de faces.
 | `leaf_size` | `40` | Tamanho da folha da árvore (apenas CPU) |
 | `use_gpu` | `"auto"` | Modo de GPU: `auto`, `always`, `never` |
 | `merge_threshold` | `0.6` | Similaridade de centroide para correspondência |
-| `chunk_size` | `10000` | Tamanho do bloco de processamento |
 
 **Algoritmos de agrupamento:**
 

--- a/docs/pt/FACE_RECOGNITION.md
+++ b/docs/pt/FACE_RECOGNITION.md
@@ -95,8 +95,7 @@ Consulte [Integração com o visualizador](#viewer-integration) para a referênc
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   }
 }
 ```

--- a/faces/clusterer.py
+++ b/faces/clusterer.py
@@ -60,7 +60,7 @@ class FaceClusterer:
     def __init__(self, db_path, min_faces=2, min_samples=None, auto_merge_distance=0.15,
                  algorithm='boruvka_balltree', leaf_size=40, use_gpu='auto',
                  merge_threshold=0.6,
-                 use_db_thumbnails=True, chunk_size=10000,
+                 use_db_thumbnails=True,
                  face_thumbnail_size=128, face_thumbnail_quality=85):
         """
         Initialize the face clusterer.
@@ -77,7 +77,6 @@ class FaceClusterer:
             use_gpu: GPU clustering mode - 'auto' (use if available), 'always', or 'never'
             use_db_thumbnails: If True, use cached thumbnails from database instead of loading
                               original images when generating fallback thumbnails (faster for RAW/NFS)
-            chunk_size: Number of faces to process per chunk for memory efficiency (default 10000)
             face_thumbnail_size: Size for face thumbnails (default 128)
             face_thumbnail_quality: JPEG quality for face thumbnails (default 85)
         """
@@ -93,7 +92,6 @@ class FaceClusterer:
         self.use_gpu = use_gpu
         self.merge_threshold = merge_threshold
         self.use_db_thumbnails = use_db_thumbnails
-        self.chunk_size = chunk_size
         self.face_thumbnail_size = face_thumbnail_size
         self.face_thumbnail_quality = face_thumbnail_quality
         self._cuml_available = None  # Lazy check
@@ -344,6 +342,38 @@ class FaceClusterer:
             logger.info("  Preserving %s named person(s)", len(existing_persons))
         return existing_persons
 
+    def _preserved_face_assignments(self, conn, existing_persons):
+        """Capture the current face->person map for faces of preserved persons.
+
+        Incremental and named-only clustering clear every face's ``person_id``
+        before rebuilding clusters. Faces that HDBSCAN relabels as noise (-1)
+        this run are never placed in any cluster, so without this snapshot they
+        would be silently orphaned from a person that is otherwise being kept.
+        """
+        if not existing_persons:
+            return {}
+        preserved_ids = set(existing_persons.keys())
+        rows = conn.execute(
+            "SELECT id, person_id FROM faces WHERE person_id IS NOT NULL"
+        ).fetchall()
+        return {face_id: person_id for face_id, person_id in rows if person_id in preserved_ids}
+
+    def _restore_noise_faces(self, conn, face_to_cluster, preserved_assignments):
+        """Re-attach noise (label -1) faces to their previously preserved person.
+
+        Returns the number of faces restored.
+        """
+        if not preserved_assignments:
+            return 0
+        restored = 0
+        for face_id, label in face_to_cluster.items():
+            if label < 0:
+                person_id = preserved_assignments.get(face_id)
+                if person_id is not None:
+                    conn.execute("UPDATE faces SET person_id = ? WHERE id = ?", (person_id, face_id))
+                    restored += 1
+        return restored
+
     def _update_person_centroids(self, conn, person_ids):
         """Recompute face counts and centroids for existing persons.
 
@@ -397,6 +427,7 @@ class FaceClusterer:
 
             # Load existing persons based on mode
             existing_persons = self._load_existing_persons(conn, force, preserve_named_only)
+            preserved_assignments = self._preserved_face_assignments(conn, existing_persons)
 
             if force:
                 # Full reset - delete everything
@@ -517,6 +548,10 @@ class FaceClusterer:
                     # Commit every 10% to allow interruption
                     if (j + 1) % thumb_chunk_size == 0:
                         conn.commit()
+
+            restored_noise = self._restore_noise_faces(conn, face_to_cluster, preserved_assignments)
+            if restored_noise:
+                logger.info("  Restored %s face(s) reclassified as noise to their preserved person(s)", restored_noise)
 
             # Update face counts and centroids for existing persons
             if existing_persons:
@@ -720,7 +755,6 @@ def run_face_clustering(db_path, config, force=False, preserve_named_only=False)
         use_gpu=use_gpu,
         merge_threshold=cluster_settings.get('merge_threshold', 0.6),
         use_db_thumbnails=face_processing.get('use_db_thumbnails', True),
-        chunk_size=cluster_settings.get('chunk_size', 10000),
         face_thumbnail_size=face_processing.get('face_thumbnail_size', 128),
         face_thumbnail_quality=face_processing.get('face_thumbnail_quality', 85)
     )

--- a/facet.py
+++ b/facet.py
@@ -1305,7 +1305,7 @@ Configuration:
             logger.info("Upgrade complete — all %d steps succeeded.", len(steps))
         logger.info("Captions and VLM tags are NOT part of --upgrade-db (heavy).")
         logger.info("Run them explicitly with --generate-captions / --recompute-tags-vlm if desired.")
-        exit()
+        sys.exit(1 if failures else 0)
 
     # Extract faces mode (needs GPU for face analysis)
     if args.extract_faces_gpu_incremental or args.extract_faces_gpu_force:
@@ -1855,7 +1855,7 @@ Configuration:
         exit()
 
     # Backfill GPS coordinates from EXIF
-    if args.extract_gps:
+    if args.extract_gps or args.rescan_gps:
         from exiftool.exiftool_batch import get_exif_batch
 
         with get_connection(args.db) as conn:
@@ -1864,17 +1864,20 @@ Configuration:
                 print("Error: GPS columns not found. Run 'python database.py' to migrate the schema first.")
                 sys.exit(1)
 
-            # Re-scans photos without GPS each run (idempotent). Photos lacking
-            # GPS EXIF data remain NULL and will be re-checked on subsequent runs,
-            # but the exiftool lookup is fast and this command is run manually.
-            rows = conn.execute(
-                "SELECT path FROM photos WHERE gps_latitude IS NULL"
-            ).fetchall()
+            if args.rescan_gps:
+                rows = conn.execute("SELECT path FROM photos").fetchall()
+            else:
+                # Re-scans photos without GPS each run (idempotent). Photos lacking
+                # GPS EXIF data remain NULL and will be re-checked on subsequent runs,
+                # but the exiftool lookup is fast and this command is run manually.
+                rows = conn.execute(
+                    "SELECT path FROM photos WHERE gps_latitude IS NULL"
+                ).fetchall()
             paths = [r['path'] for r in rows]
-            logger.info("Extracting GPS for %d photos...", len(paths))
+            logger.info("%s GPS for %d photos...", "Rescanning" if args.rescan_gps else "Extracting", len(paths))
             exif_data = get_exif_batch(paths)
             updated = 0
-            for path, exif in tqdm(exif_data.items(), desc="GPS extraction"):
+            for path, exif in tqdm(exif_data.items(), desc="GPS rescan" if args.rescan_gps else "GPS extraction"):
                 lat = exif.get('gps_latitude')
                 lng = exif.get('gps_longitude')
                 if lat is not None and lng is not None:
@@ -2716,6 +2719,15 @@ Configuration:
         raise
     else:
         scan_run.finish('completed')
+        if args.retry_failed and todo_list:
+            retried_paths = [str(f.resolve()) for f in todo_list]
+            with get_connection(scorer.db_path) as conn:
+                placeholders = ','.join('?' * len(retried_paths))
+                conn.execute(
+                    f"DELETE FROM scan_failures WHERE path IN ({placeholders}) AND scan_run_id != ?",
+                    retried_paths + [scan_run.run_id],
+                )
+                conn.commit()
 
     # 3. Finalization
     scorer.commit()

--- a/models/vlm_tagger.py
+++ b/models/vlm_tagger.py
@@ -453,12 +453,17 @@ Tags:"""
             )
             texts.append(text)
 
-        inputs = self.processor(
-            text=texts,
-            images=images,
-            return_tensors="pt",
-            padding=True,
-        )
+        original_padding_side = self.processor.tokenizer.padding_side
+        self.processor.tokenizer.padding_side = "left"
+        try:
+            inputs = self.processor(
+                text=texts,
+                images=images,
+                return_tensors="pt",
+                padding=True,
+            )
+        finally:
+            self.processor.tokenizer.padding_side = original_padding_side
         inputs = {k: v.to(self.model.device) if hasattr(v, 'to') else v
                   for k, v in inputs.items()}
 

--- a/optimization/auto_retrain.py
+++ b/optimization/auto_retrain.py
@@ -178,7 +178,7 @@ def maybe_retrain(db_path, user_id, added: int = 1, threshold: int = RETRAIN_THR
                     _write_counter(conn, scope, 0)
                 else:
                     _write_counter(conn, scope, pending)
-            conn.commit()
+                conn.commit()
 
             if not dispatch:
                 return False

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -407,7 +407,11 @@ class PluginManager:
             raise ValueError("No hostname in URL")
 
         resolved_ip: str | None = None
-        for info in socket.getaddrinfo(hostname, parsed.port or 80):
+        try:
+            addr_infos = socket.getaddrinfo(hostname, parsed.port or 80)
+        except socket.gaierror as exc:
+            raise ValueError("DNS resolution failed") from exc
+        for info in addr_infos:
             addr = ipaddress.ip_address(info[4][0])
             if addr.is_private or addr.is_loopback or addr.is_link_local:
                 raise ValueError(f"URL resolves to private address: {addr}")

--- a/processing/batch_processor.py
+++ b/processing/batch_processor.py
@@ -450,6 +450,14 @@ class BatchProcessor:
                     'scoring_model': scoring_model,
                     # SAMP-Net composition pattern
                     'composition_pattern': composition_pattern,
+                    'topiq_score': None,
+                    'aesthetic_iaa': None,
+                    'face_quality_iqa': None,
+                    'liqe_score': None,
+                    'subject_sharpness': None,
+                    'subject_prominence': None,
+                    'subject_placement': None,
+                    'bg_separation': None,
                     # Face details for face recognition (stored by save_photo)
                     'face_details': face_res.get('face_details', []),
                 }

--- a/processing/multi_pass.py
+++ b/processing/multi_pass.py
@@ -417,20 +417,17 @@ class ChunkedMultiPassProcessor:
                     # Reuse scorer's face_analyzer to avoid loading a duplicate (~2GB)
                     loaded_models[model_name] = self.scorer.face_analyzer
                     continue
-                try:
-                    model = self.model_manager.load_model_only(model_name)
-                    if model is None:
-                        if model_name in supplementary:
-                            logger.warning("Supplementary model '%s' failed to load, skipping.", model_name)
-                            continue
-                        raise RuntimeError(
-                            f"Required model '{model_name}' failed to load. "
-                            f"Cannot continue processing."
-                        )
-                    loaded_models[model_name] = model
-                except torch.cuda.OutOfMemoryError:
-                    logger.error("OOM loading %s, trying fallback...", model_name)
-                    self._handle_oom(model_name)
+                model = self.model_manager.load_model_only(model_name)
+                if model is None:
+                    if model_name in supplementary:
+                        logger.warning("Supplementary model '%s' failed to load, skipping.", model_name)
+                        continue
+                    logger.error(
+                        "Required model '%s' failed to load (likely OOM); recording "
+                        "chunk for retry via --retry-failed instead of aborting.", model_name)
+                    failed_stages.append(model_name)
+                    continue
+                loaded_models[model_name] = model
 
             self.metrics['model_load_time'] += time.time() - load_start
 
@@ -1147,30 +1144,6 @@ class ChunkedMultiPassProcessor:
         if batch:
             self.scorer.save_photos_partial(batch, refresh_faces)
             self.scorer.commit()
-
-    def _handle_oom(self, model_name: str):
-        """Handle out-of-memory error by trying fallback models."""
-        fallbacks = {
-            'vlm_tagger': 'qwen3_vl_tagger',
-            'qwen3_vl_tagger': 'clip',
-            'qwen3_5_4b_tagger': 'qwen3_5_tagger',
-            'qwen3_5_tagger': 'clip',
-            'clipiqa+': 'topiq',      # CLIP-IQA+ -> TOPIQ
-            'musiq': 'topiq',
-            'hyperiqa': 'topiq',
-            'dbcnn': 'topiq',
-            'topiq': 'clip_aesthetic',  # Final fallback
-        }
-
-        if model_name in fallbacks:
-            fallback = fallbacks[model_name]
-            logger.warning("Falling back to %s", fallback)
-            # Update pass groups to use fallback
-            for group in self.pass_groups:
-                if model_name in group:
-                    idx = group.index(model_name)
-                    group[idx] = fallback
-                    break
 
     def _print_summary(self):
         """Print processing summary."""

--- a/processing/resource_monitor.py
+++ b/processing/resource_monitor.py
@@ -107,6 +107,9 @@ class ResourceMonitor:
     - RAM chunk size (multi-pass): Reduced when system RAM exceeds limit
     """
 
+    MAX_MEMORY_WAIT_SECONDS = 10
+    MEMORY_RECOVERY_TARGET_PERCENT = 75
+
     def __init__(self, batch_processor, config=None, multi_pass_processor=None):
         """
         Initialize the resource monitor.
@@ -331,12 +334,11 @@ class ResourceMonitor:
             self.processor.batch_size = new_batch
             logger.warning("Batch size reduced: %d -> %d", current_batch, new_batch)
 
-        # Wait for memory to drop
         wait_count = 0
-        while wait_count < 10:  # Max 10 seconds wait
-            time.sleep(1)
-            mem = psutil.virtual_memory()
-            if mem.percent < 75:
+        while wait_count < self.MAX_MEMORY_WAIT_SECONDS:
+            if self.stop_event.wait(1):
+                return
+            if psutil.virtual_memory().percent < self.MEMORY_RECOVERY_TARGET_PERCENT:
                 break
             wait_count += 1
 

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -3023,8 +3023,7 @@
     "clustering_algorithm": "best",
     "leaf_size": 40,
     "use_gpu": "auto",
-    "merge_threshold": 0.6,
-    "chunk_size": 10000
+    "merge_threshold": 0.6
   },
   "face_processing": {
     "crop_padding": 0.3,

--- a/tests/test_assign_visibility.py
+++ b/tests/test_assign_visibility.py
@@ -250,3 +250,76 @@ class TestAssignFacesBatchVisibility:
             assert body["face_count"] == 2
         finally:
             _cleanup([9503])
+
+    def test_foreign_person_target_denied(self, edition_client):
+        try:
+            conn = _db()
+            _seed_person(conn, 9504, "Foreign")
+            _seed_faces(conn, [FOREIGN_PREFIX + "e.jpg"], person_id=9504)
+            own = _seed_faces(conn, [OWN_PREFIX + "e.jpg"])
+            conn.commit()
+            conn.close()
+
+            resp = _post_as_scoped_user(
+                edition_client,
+                "/api/persons/9504/assign_faces",
+                {"face_ids": own},
+            )
+
+            assert resp.status_code == 404
+            conn = _db()
+            owner = conn.execute(
+                "SELECT person_id FROM faces WHERE id = ?", (own[0],)
+            ).fetchone()["person_id"]
+            conn.close()
+            assert owner is None
+        finally:
+            _cleanup([9504])
+
+
+class TestSplitPersonVisibility:
+    def test_foreign_source_denied(self, edition_client):
+        try:
+            conn = _db()
+            _seed_person(conn, 9505, "Foreign")
+            foreign = _seed_faces(conn, [FOREIGN_PREFIX + "s.jpg"], person_id=9505)
+            conn.commit()
+            conn.close()
+
+            resp = _post_as_scoped_user(
+                edition_client,
+                "/api/persons/9505/split",
+                {"face_ids": foreign},
+            )
+
+            assert resp.status_code == 404
+            conn = _db()
+            owner = conn.execute(
+                "SELECT person_id FROM faces WHERE id = ?", (foreign[0],)
+            ).fetchone()["person_id"]
+            conn.close()
+            assert owner == 9505
+        finally:
+            _cleanup([9505])
+
+    def test_own_source_allowed(self, edition_client):
+        new_id = None
+        try:
+            conn = _db()
+            _seed_person(conn, 9506, "Owned")
+            own = _seed_faces(
+                conn, [OWN_PREFIX + "s1.jpg", OWN_PREFIX + "s2.jpg"], person_id=9506
+            )
+            conn.commit()
+            conn.close()
+
+            resp = _post_as_scoped_user(
+                edition_client,
+                "/api/persons/9506/split",
+                {"face_ids": [own[0]], "name": "Split"},
+            )
+
+            assert resp.status_code == 200, resp.text
+            new_id = resp.json()["new_person_id"]
+        finally:
+            _cleanup([9506, new_id] if new_id else [9506])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -95,6 +95,12 @@ class TestVerifyLegacyPassword:
     def test_empty_stored_returns_false(self):
         assert not verify_legacy_password("anything", "")
 
+    def test_non_ascii_plaintext_match(self):
+        assert verify_legacy_password("café123", "café123")
+
+    def test_non_ascii_plaintext_no_match(self):
+        assert not verify_legacy_password("wrongpass", "café123")
+
     def test_is_hashed_detection(self):
         h = hash_password("test")
         assert _is_hashed(h)

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -62,6 +62,16 @@ class TestBackupDatabase:
         with pytest.raises(FileNotFoundError):
             backup_database(str(tmp_path / "nope.db"), verbose=False)
 
+    def test_keep_below_one_is_rejected_and_leaves_no_backup(self, tmp_path):
+        db = tmp_path / "photo_scores_pro.db"
+        _make_db(str(db), 4)
+
+        with pytest.raises(ValueError, match="keep must be at least"):
+            backup_database(str(db), keep=0, verbose=False)
+
+        assert glob.glob(str(db) + ".backup-*") == []
+        assert os.path.exists(db)
+
     def test_refuses_when_insufficient_space(self, tmp_path):
         db = tmp_path / "photo_scores_pro.db"
         _make_db(str(db), 3)

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -79,3 +79,79 @@ class TestConstructorArgs:
     def test_config_none_is_accepted(self):
         bp = _make_processor(config=None)
         assert bp.config is None
+
+
+SUPPLEMENTARY_RESULT_KEYS = (
+    "topiq_score",
+    "aesthetic_iaa",
+    "face_quality_iqa",
+    "liqe_score",
+    "subject_sharpness",
+    "subject_prominence",
+    "subject_placement",
+    "bg_separation",
+)
+
+
+def _configure_scorer_mock(scorer):
+    scorer.device = "cpu"
+    scorer.tagger = None
+    scorer.get_aesthetic_and_quality_batch.return_value = [(5.0, b"emb", None, "topiq")]
+    scorer.tech_analyzer.get_sharpness_data.return_value = {"normalized": 5.0, "raw_variance": 1.0}
+    scorer.tech_analyzer.get_color_harmony_data.return_value = {"normalized": 5.0, "raw_entropy": 1.0}
+    scorer.tech_analyzer.get_histogram_data.return_value = {
+        "exposure_score": 5.0, "spread": 1.0, "mean_luminance": 0.5, "bimodality": 0.0,
+        "shadow_clipped": 0, "highlight_clipped": 0, "histogram_bytes": b"",
+    }
+    scorer.tech_analyzer.detect_monochrome.return_value = {"is_monochrome": 0, "mean_saturation": 0.5}
+    scorer.tech_analyzer.get_dynamic_range.return_value = {"dynamic_range_stops": 8.0}
+    scorer.tech_analyzer.get_noise_estimate.return_value = {"noise_sigma": 1.0}
+    scorer.tech_analyzer.get_contrast_score.return_value = {"contrast_score": 5.0}
+    scorer.config.get_monochrome_settings.return_value = {"saturation_threshold_percent": 10}
+    scorer.config.version_hash = "v1"
+    scorer.face_analyzer.analyze_faces.return_value = {
+        "face_count": 0, "face_quality": 0.0, "eye_sharpness": 0.0, "face_sharpness": 0.0,
+        "face_area": 0, "bbox": None, "face_details": [],
+    }
+    scorer.get_composition_scores.return_value = ("rule_of_thirds", None)
+    scorer.calculate_aggregate_logic.return_value = (7.0, "landscape")
+
+
+def test_process_batch_result_covers_supplementary_db_columns():
+    import numpy as np
+    from pathlib import Path
+    from unittest import mock
+
+    bp = _make_processor(batch_size=1)
+    _configure_scorer_mock(bp.scorer)
+
+    path = "/tmp/facet-test-photo.jpg"
+    exif_keys = {
+        "date_taken": None, "camera_model": None, "lens_model": None, "iso": None,
+        "f_stop": None, "shutter_speed": None, "focal_length": None,
+        "focal_length_35mm": None, "gps_latitude": None, "gps_longitude": None,
+    }
+    bp._exif_cache[str(Path(path).resolve())] = dict(exif_keys)
+
+    item = {
+        "path": path,
+        "pil_img": mock.MagicMock(),
+        "img_cv": np.zeros((10, 10, 3), dtype=np.uint8),
+        "clip_input": None,
+    }
+
+    with mock.patch("processing.batch_processor.ImageCache"), \
+         mock.patch("processing.batch_processor.CompositionAnalyzer") as comp, \
+         mock.patch("processing.batch_processor.detect_silhouette", return_value=0), \
+         mock.patch("processing.batch_processor.imagehash") as phash_mod:
+        comp.get_placement_data.return_value = {"score": 5.0, "power_point_score": 1.0}
+        comp.detect_leading_lines.return_value = {"leading_lines_score": 0}
+        phash_mod.phash.return_value = "hash"
+        bp._process_batch([item])
+
+    queued = bp.result_queue.get_nowait()
+    assert "result" in queued, queued
+    res = queued["result"]
+    for key in SUPPLEMENTARY_RESULT_KEYS:
+        assert key in res, f"missing DB column {key} required by save_photos_batch INSERT"
+        assert res[key] is None

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from calibrate import METRIC_COLUMNS, build_metric_matrix
+
+
+def test_build_metric_matrix_preserves_genuine_zero_scores():
+    col = next(iter(METRIC_COLUMNS.keys()))
+    rows = [{col: 0.0, 'mos': 5.0} for _ in range(10)]
+
+    X, y, col_names = build_metric_matrix(rows)
+
+    assert col in col_names
+    idx = col_names.index(col)
+    assert np.all(X[:, idx] == 0.0)

--- a/tests/test_capsule_generator.py
+++ b/tests/test_capsule_generator.py
@@ -98,6 +98,10 @@ class TestPickCoverPhoto:
         paths = ["a", "b", "c", "d", "e"]
         assert _pick_cover_photo(paths, "cap1") == _pick_cover_photo(paths, "cap1")
 
+    def test_zero_freshness_seconds_does_not_raise(self):
+        paths = ["a", "b", "c", "d", "e"]
+        assert _pick_cover_photo(paths, "cap1", freshness_seconds=0) in paths
+
 
 class TestSortCapsules:
     def test_preserves_all_capsules(self):

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -310,3 +310,26 @@ class TestGenerateCaption:
         ):
             result = _generate_caption("/photos/test.jpg")
         assert result is None
+
+    def test_decodes_raw_via_shared_loader(self):
+        from PIL import Image
+        from api.routers.caption import _generate_caption
+
+        cfg = {"models": {"vram_profile": "16gb",
+                          "profiles": {"16gb": {"tagging_model": "qwen3.5-2b"}},
+                          "qwen3_5_2b": {"model_path": "Qwen/Qwen3.5-2B"}}}
+        raw_img = Image.new("RGB", (800, 600))
+        tagger = mock.Mock()
+        tagger.generate.return_value = "  A serene mountain lake  "
+        with (
+            mock.patch("api.config._FULL_CONFIG", cfg),
+            mock.patch("api.routers.caption.resolve_photo_disk_path",
+                       return_value="/photos/test.cr2"),
+            mock.patch("api.routers.caption.get_or_load_vlm_tagger",
+                       return_value=tagger),
+            mock.patch("utils.image_loading.load_image_from_path",
+                       return_value=(raw_img, None)) as mock_load,
+        ):
+            result = _generate_caption("/photos/test.cr2")
+        assert result == "A serene mountain lake"
+        mock_load.assert_called_once()

--- a/tests/test_cleanup_missing_photos.py
+++ b/tests/test_cleanup_missing_photos.py
@@ -87,5 +87,32 @@ def test_force_removes_inaccessible_paths(tmp_path):
     assert _paths_in_db(db) == set()
 
 
+def test_client_picks_removed_for_deleted_photo(tmp_path):
+    present = tmp_path / 'present.jpg'
+    present.write_bytes(b'x')
+    deleted = tmp_path / 'deleted.jpg'
+    db = str(tmp_path / 'scores.db')
+    _make_db(db, [str(present), str(deleted)])
+
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO albums (name) VALUES ('proof')")
+    album_id = conn.execute("SELECT id FROM albums").fetchone()[0]
+    conn.executemany(
+        "INSERT INTO album_client_picks (album_id, photo_path) VALUES (?, ?)",
+        [(album_id, str(present)), (album_id, str(deleted))],
+    )
+    conn.commit()
+    conn.close()
+
+    removed = cleanup_missing_photos(db, dry_run=False, force=False, verbose=False)
+
+    conn = sqlite3.connect(db)
+    remaining_picks = {r[0] for r in conn.execute("SELECT photo_path FROM album_client_picks").fetchall()}
+    conn.close()
+    assert removed == 1
+    assert str(deleted) not in remaining_picks
+    assert str(present) in remaining_picks
+
+
 if __name__ == '__main__':
     raise SystemExit(pytest.main([__file__, '-v']))

--- a/tests/test_cull_preview.py
+++ b/tests/test_cull_preview.py
@@ -85,9 +85,9 @@ def dt_config(monkeypatch):
         }
     }
     monkeypatch.setitem(config.VIEWER_CONFIG, "raw_processor", cfg)
-    raw_processing.is_darktable_available.cache_clear()
+    raw_processing._darktable_available_cache = None
     yield cfg
-    raw_processing.is_darktable_available.cache_clear()
+    raw_processing._darktable_available_cache = None
 
 
 def _fake_dt_run(recorder):

--- a/tests/test_face_embedding_space.py
+++ b/tests/test_face_embedding_space.py
@@ -85,6 +85,58 @@ def test_load_embeddings_warns_on_mixed_space(tmp_path, caplog):
     assert any("adaface_test" in m for m in messages)
 
 
+def _unit_embedding():
+    vec = np.zeros(512, dtype=np.float32)
+    vec[0] = 1.0
+    return vec
+
+
+def test_incremental_noise_face_stays_with_named_person(tmp_path):
+    """A named person's face relabelled as HDBSCAN noise is not orphaned."""
+    db = str(tmp_path / "noise.db")
+    init_database(db)
+    conn = sqlite3.connect(db)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("INSERT INTO photos(path) VALUES ('p/alice.jpg')")
+    vec = _unit_embedding()
+    emb = vec.tobytes()
+    cur = conn.execute(
+        "INSERT INTO persons(name, face_count, centroid, auto_clustered) "
+        "VALUES ('Alice', 2, ?, 0)",
+        (emb,),
+    )
+    alice_id = cur.lastrowid
+    face_ids = []
+    for idx in range(2):
+        c = conn.execute(
+            "INSERT INTO faces(photo_path, face_index, embedding, embedding_model, person_id) "
+            "VALUES ('p/alice.jpg', ?, ?, ?, ?)",
+            (idx, emb, ACTIVE_EMBEDDING_MODEL, alice_id),
+        )
+        face_ids.append(c.lastrowid)
+    conn.execute(
+        "UPDATE persons SET representative_face_id = ? WHERE id = ?",
+        (face_ids[0], alice_id),
+    )
+    conn.commit()
+    conn.close()
+
+    clusterer = FaceClusterer(db)
+    embeddings = np.array([vec, vec], dtype=np.float32)
+    face_to_cluster = {face_ids[0]: 0, face_ids[1]: -1}
+    clusterer._update_database(face_to_cluster, embeddings, face_ids, force=False)
+
+    conn = sqlite3.connect(db)
+    rows = dict(conn.execute("SELECT id, person_id FROM faces").fetchall())
+    face_count = conn.execute(
+        "SELECT face_count FROM persons WHERE id = ?", (alice_id,)
+    ).fetchone()[0]
+    conn.close()
+    assert rows[face_ids[1]] == alice_id
+    assert rows[face_ids[0]] == alice_id
+    assert face_count == 2
+
+
 def test_migration_backfills_existing_faces(tmp_path):
     """Adding embedding_model to an old faces table backfills rows to the default."""
     db = str(tmp_path / "m.db")

--- a/tests/test_faces.py
+++ b/tests/test_faces.py
@@ -356,3 +356,53 @@ class TestAssignFace:
         assert resp.status_code == 200
         data = resp.json()
         assert data["success"] is True
+
+    def test_assign_face_repairs_stale_representative(self, tmp_path):
+        db = str(tmp_path / "assign_rep.db")
+        conn = sqlite3.connect(db, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE photos (path TEXT PRIMARY KEY);
+            CREATE TABLE persons (
+                id INTEGER PRIMARY KEY, name TEXT,
+                representative_face_id INTEGER, face_thumbnail BLOB, face_count INTEGER
+            );
+            CREATE TABLE faces (
+                id INTEGER PRIMARY KEY, photo_path TEXT, person_id INTEGER,
+                confidence REAL, face_thumbnail BLOB
+            );
+        """)
+        conn.execute("INSERT INTO photos (path) VALUES ('/a.jpg')")
+        conn.execute(
+            "INSERT INTO persons (id, name, representative_face_id, face_thumbnail, face_count) "
+            "VALUES (1, 'Alice', 10, ?, 2)", (b'F1thumb',)
+        )
+        conn.execute("INSERT INTO persons (id, name, face_count) VALUES (2, 'Bob', 0)")
+        conn.execute(
+            "INSERT INTO faces (id, photo_path, person_id, confidence, face_thumbnail) "
+            "VALUES (10, '/a.jpg', 1, 0.9, ?)", (b'F1thumb',)
+        )
+        conn.execute(
+            "INSERT INTO faces (id, photo_path, person_id, confidence, face_thumbnail) "
+            "VALUES (11, '/a.jpg', 1, 0.8, ?)", (b'F2thumb',)
+        )
+        conn.commit()
+
+        with (
+            mock.patch(f"{_AUTH_MODULE}.VIEWER_CONFIG", {"password": "", "edition_password": "", "features": {}}),
+            mock.patch(f"{_AUTH_MODULE}.is_multi_user_enabled", return_value=False),
+            mock.patch("api.routers.faces.is_multi_user_enabled", return_value=False),
+        ):
+            app, client = _make_app_and_client()
+            user = CurrentUser(user_id="u1", role="admin", edition_authenticated=True)
+            _override_auth_user(app, user)
+            with mock.patch("api.routers.faces.get_db", _cm(conn)):
+                resp = client.post("/api/face/10/assign", json={"person_id": 2})
+
+        assert resp.status_code == 200
+        alice = conn.execute(
+            "SELECT representative_face_id, face_thumbnail FROM persons WHERE id = 1"
+        ).fetchone()
+        assert alice["representative_face_id"] == 11
+        assert alice["face_thumbnail"] == b'F2thumb'
+        conn.close()

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -178,6 +178,26 @@ class TestGalleryPhotos:
         assert data["total"] == 5
         assert data["has_more"] is True
 
+    def test_anonymous_on_access_controlled_install_sees_no_photos(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        photos = [_photo(f"/p{i}.jpg", "2024:06:15 12:00:00") for i in range(5)]
+        _make_db(db_path, photos)
+        app = _create_app_no_auth()
+        with (
+            mock.patch("api.routers.gallery.get_db", _conn_factory(db_path)),
+            mock.patch("api.routers.gallery.get_async_db", _async_conn_factory(db_path)),
+            mock.patch("api.routers.gallery.VIEWER_CONFIG", _VIEWER_CONFIG),
+            mock.patch("api.db_helpers._existing_columns_cache", _TEST_PHOTOS_COLUMNS),
+            mock.patch("api.db_helpers.VIEWER_CONFIG", {"password": "secret"}),
+            mock.patch("api.db_helpers.is_multi_user_enabled", lambda: False),
+            mock.patch.dict("api.config._count_cache", {}, clear=True),
+        ):
+            resp = TestClient(app).get("/api/photos?page=1&per_page=50")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["photos"] == []
+        assert data["total"] == 0
+
     def test_sort_by_aesthetic_desc(self, tmp_path):
         db_path = str(tmp_path / "test.db")
         _make_db(db_path, [

--- a/tests/test_image_loading.py
+++ b/tests/test_image_loading.py
@@ -140,6 +140,27 @@ class TestDecodeTimeout:
         with pytest.raises(RuntimeError, match="storage likely stalled"):
             load_image_from_path(str(raw_path))
 
+    def test_queue_wait_excluded_from_timeout(self, tmp_path, monkeypatch):
+        raw_path = tmp_path / "queued.cr2"
+        raw_path.write_bytes(b"fake")
+        monkeypatch.setitem(sys.modules, "rawpy", _stub_rawpy(delay=0.3))
+        image_loading._abandoned_decodes = 0
+        configure_raw_decoding(concurrency=1, timeout_seconds=0.5)
+
+        results = {}
+
+        def _load(key):
+            results[key] = load_image_from_path(str(raw_path))
+
+        threads = [threading.Thread(target=_load, args=(k,)) for k in ("a", "b")]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results["a"][0] is not None and results["b"][0] is not None
+        assert image_loading._abandoned_decodes == 0
+
     def test_fast_decode_succeeds_within_timeout(self, tmp_path, monkeypatch):
         raw_path = tmp_path / "fast.arw"
         raw_path.write_bytes(b"fake")

--- a/tests/test_multi_pass_pass_failure.py
+++ b/tests/test_multi_pass_pass_failure.py
@@ -93,3 +93,34 @@ def test_required_pass_failure_records_and_excludes(tmp_path, monkeypatch):
     # The chunk's photos are recorded and retryable via --retry-failed.
     failed = set(get_failed_paths(db_path, "last"))
     assert failed == set(paths)
+
+
+@pytest.mark.timeout(30)
+def test_required_model_load_failure_records_instead_of_aborting(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scan.db")
+    init_database(db_path)
+    scan_run = ScanRun.start(db_path, "multi-pass", {"directories": []}, 2)
+
+    scorer = _StubScorer()
+
+    class _OomModelManager(_StubModelManager):
+        def load_model_only(self, name):
+            return None if name == "clip" else object()
+
+    proc = ChunkedMultiPassProcessor(scorer, _OomModelManager(), {},
+                                     on_error=scan_run.record_failure)
+    proc.pass_groups = [["insightface"], ["clip"]]
+
+    paths = [str(tmp_path / "a.jpg"), str(tmp_path / "b.jpg")]
+
+    monkeypatch.setattr(proc, "_load_images", lambda p: {x: _img_data() for x in p})
+    monkeypatch.setattr(proc, "_run_model_pass", lambda *a, **k: None)
+
+    proc._process_chunk(paths, 0, 1)  # a real OOM surfaces as load returning None
+    scan_run.finish("interrupted")
+
+    # Load failure of a required model degrades to a retryable failure, never a
+    # RuntimeError that aborts the whole scan, and never a neutral-default save.
+    assert scorer.saved == []
+    failed = set(get_failed_paths(db_path, "last"))
+    assert failed == set(paths)

--- a/tests/test_persons_visibility.py
+++ b/tests/test_persons_visibility.py
@@ -7,7 +7,7 @@ photo within the caller's directories.
 """
 
 import sqlite3
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from unittest import mock
 
 import aiosqlite
@@ -15,7 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api import create_app
-from api.auth import CurrentUser, require_authenticated
+from api.auth import CurrentUser, require_authenticated, require_edition
 
 _HELPERS = "api.db_helpers"
 
@@ -113,6 +113,93 @@ class TestPersonsListIsolation:
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()["persons"]}
         assert ids == {2, 4}
+
+
+def _sync_factory(db_path):
+    @contextmanager
+    def factory():
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            yield c
+        finally:
+            c.close()
+    return factory
+
+
+def _write_client(db_path, user):
+    dirs = {"alice": ["/photos/alice"], "bob": ["/photos/bob"]}
+    app = create_app()
+    app.dependency_overrides[require_edition] = lambda: user
+    patches = [
+        mock.patch("api.routers.persons.get_db", _sync_factory(db_path)),
+        mock.patch(f"{_HELPERS}.is_multi_user_enabled", return_value=True),
+        mock.patch(f"{_HELPERS}.get_user_directories",
+                   side_effect=lambda uid: dirs.get(uid, [])),
+    ]
+    for p in patches:
+        p.start()
+    return TestClient(app), app, patches
+
+
+def _person_exists(db_path, person_id):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT 1 FROM persons WHERE id = ?", (person_id,)).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+class TestPersonsWriteIsolation:
+    def test_alice_cannot_delete_bobs_person(self, db_path):
+        alice = CurrentUser(user_id="alice", role="admin")
+        client, app, patches = _write_client(db_path, alice)
+        try:
+            resp = client.post("/api/persons/2/delete")
+        finally:
+            _teardown(app, patches)
+        assert resp.status_code == 404
+        assert _person_exists(db_path, 2)
+
+    def test_alice_can_delete_own_person(self, db_path):
+        alice = CurrentUser(user_id="alice", role="admin")
+        client, app, patches = _write_client(db_path, alice)
+        try:
+            resp = client.post("/api/persons/1/delete")
+        finally:
+            _teardown(app, patches)
+        assert resp.status_code == 200
+        assert not _person_exists(db_path, 1)
+
+    def test_alice_cannot_rename_bobs_person(self, db_path):
+        alice = CurrentUser(user_id="alice", role="admin")
+        client, app, patches = _write_client(db_path, alice)
+        try:
+            resp = client.post("/api/persons/2/rename", json={"name": "Mallory"})
+        finally:
+            _teardown(app, patches)
+        assert resp.status_code == 404
+
+    def test_alice_cannot_merge_across_directories(self, db_path):
+        alice = CurrentUser(user_id="alice", role="admin")
+        client, app, patches = _write_client(db_path, alice)
+        try:
+            resp = client.post("/api/persons/merge/1/2")
+        finally:
+            _teardown(app, patches)
+        assert resp.status_code == 404
+        assert _person_exists(db_path, 1)
+        assert _person_exists(db_path, 2)
+
+    def test_alice_cannot_hide_bobs_person(self, db_path):
+        alice = CurrentUser(user_id="alice", role="admin")
+        client, app, patches = _write_client(db_path, alice)
+        try:
+            resp = client.post("/api/persons/2/hide")
+        finally:
+            _teardown(app, patches)
+        assert resp.status_code == 404
 
 
 class TestNeedsNamingIsolation:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -214,6 +214,19 @@ class TestPluginManagerTestWebhook:
         assert result["ok"] is False
         assert "scheme" in result["error"].lower()
 
+    def test_dns_resolution_failure_returns_error_dict(self):
+        import socket
+        from unittest import mock
+
+        mgr = PluginManager(config=None)
+        with mock.patch(
+            "socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            result = mgr.test_webhook("http://no-such-host.example.invalid/hook")
+        assert result["ok"] is False
+        assert "resolve" in result["error"].lower()
+
 
 class TestPluginManagerDiscovery:
     def test_discovers_plugin_with_event_handler(self, tmp_path):

--- a/tests/test_raw_processing.py
+++ b/tests/test_raw_processing.py
@@ -5,6 +5,9 @@ needed — so the profile flags (style, apply-custom-presets, sizing) are verifi
 deterministically in CI.
 """
 
+import sys
+
+from api import raw_processing
 from api.raw_processing import _build_darktable_cmd
 
 
@@ -60,3 +63,30 @@ class TestBuildDarktableCmd:
         cmd = _build_darktable_cmd("/usr/bin/darktable-cli", "in.cr2", "", "out.jpg", 96, {})
         assert cmd[:3] == ["/usr/bin/darktable-cli", "in.cr2", "out.jpg"]
         assert "" not in cmd
+
+
+class TestIsDarktableAvailable:
+    def setup_method(self):
+        raw_processing._darktable_available_cache = None
+
+    def teardown_method(self):
+        raw_processing._darktable_available_cache = None
+
+    def test_reflects_executable_change_without_restart(self, monkeypatch):
+        monkeypatch.setitem(
+            raw_processing.VIEWER_CONFIG, "raw_processor",
+            {"darktable": {"executable": "/no/such/darktable-cli"}})
+        assert raw_processing.is_darktable_available() is False
+
+        monkeypatch.setitem(
+            raw_processing.VIEWER_CONFIG, "raw_processor",
+            {"darktable": {"executable": sys.executable}})
+        assert raw_processing.is_darktable_available() is True
+
+    def test_ttl_expiry_picks_up_config_fix_on_same_executable(self, monkeypatch):
+        monkeypatch.setitem(
+            raw_processing.VIEWER_CONFIG, "raw_processor",
+            {"darktable": {"executable": sys.executable}})
+        import time
+        raw_processing._darktable_available_cache = (time.monotonic() - 1000, sys.executable, False)
+        assert raw_processing.is_darktable_available() is True

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -3,7 +3,12 @@ import time
 from types import SimpleNamespace
 from unittest import mock
 
-from processing.resource_monitor import ResourceMonitor
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("psutil")
+
+from processing.resource_monitor import ResourceMonitor  # noqa: E402
 
 
 class _FakeMemory:

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -1,0 +1,31 @@
+import threading
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+from processing.resource_monitor import ResourceMonitor
+
+
+class _FakeMemory:
+    def __init__(self, percent):
+        self.percent = percent
+
+
+def _make_monitor():
+    processor = SimpleNamespace(batch_size=16, get_metrics=lambda: {})
+    return ResourceMonitor(processor, config={}, multi_pass_processor=None)
+
+
+def test_graceful_reduction_returns_promptly_on_stop():
+    monitor = _make_monitor()
+    high_memory = _FakeMemory(99.0)
+    with mock.patch(
+        "processing.resource_monitor.psutil.virtual_memory",
+        return_value=high_memory,
+    ):
+        threading.Timer(0.2, monitor.stop_event.set).start()
+        started = time.time()
+        monitor._graceful_memory_reduction(99.0)
+        elapsed = time.time() - started
+    assert elapsed < ResourceMonitor.MAX_MEMORY_WAIT_SECONDS
+    assert monitor.stop_event.is_set()

--- a/tests/test_retry_failed_cleanup.py
+++ b/tests/test_retry_failed_cleanup.py
@@ -1,0 +1,87 @@
+"""--retry-failed must clear stale scan_failures rows for photos that now succeed.
+
+Before the fix, a successful retry never removed the old scan_failures row, so
+a later `--retry-failed` (scope defaults to 'last') kept resolving to the
+stale run and reprocessing already-fixed photos indefinitely. This drives
+`facet.main` end-to-end with the heavy pieces stubbed (mirrors
+test_scan_interrupt.py), forces the retried file to "succeed" this run, and
+asserts its old scan_failures row is gone.
+"""
+
+import sys
+
+import pytest
+from PIL import Image
+
+import facet
+from config import ScoringConfig
+from db import get_connection
+from db.schema import init_database
+
+
+class _FakeFacet:
+    def __init__(self, db_path=None, config_path=None, multi_pass=False):
+        self.db_path = db_path
+        self.config = ScoringConfig(config_path)
+        self.model_manager = None
+
+    def filter_unscanned_paths(self, paths):
+        return set(paths)
+
+    def commit(self):
+        pass
+
+
+class _SucceedingProcessor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def process_directory(self, paths):
+        pass
+
+
+@pytest.mark.timeout(30)
+def test_retry_failed_clears_stale_failure_row(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scan.db")
+    init_database(db_path)
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    photo_path = photo_dir / "a.jpg"
+    Image.new("RGB", (8, 8), (120, 120, 120)).save(photo_path, "JPEG")
+    resolved_path = str(photo_path.resolve())
+
+    with get_connection(db_path, row_factory=False) as conn:
+        conn.execute(
+            "INSERT INTO scan_runs (mode, args_json, total_files, status, finished_at) "
+            "VALUES ('multi-pass', '{}', 1, 'completed', datetime('now'))"
+        )
+        conn.execute(
+            "INSERT INTO scan_failures (scan_run_id, path, stage, error) "
+            "VALUES (1, ?, 'score', 'boom')",
+            (resolved_path,),
+        )
+        conn.commit()
+
+    monkeypatch.setattr("processing.scorer.Facet", _FakeFacet)
+    monkeypatch.setattr("processing.multi_pass.ChunkedMultiPassProcessor", _SucceedingProcessor)
+    monkeypatch.setattr("models.model_manager.ModelManager", lambda *a, **k: object())
+    monkeypatch.setattr("plugins.init_global_plugin_manager", lambda *a, **k: None)
+
+    monkeypatch.setattr("processing.scorer.process_bursts", lambda *a, **k: None)
+    monkeypatch.setattr("tag_existing.run_tagging", lambda *a, **k: 0)
+    monkeypatch.setattr("tag_existing.resolve_scan_tagger", lambda *a, **k: None)
+    monkeypatch.setattr("db.vec.populate_vec_table", lambda *a, **k: None)
+    monkeypatch.setattr(facet, "run_moment_detection", lambda *a, **k: {})
+    monkeypatch.setattr(facet, "run_junk_detection", lambda *a, **k: {})
+    monkeypatch.setattr(facet, "_print_scan_summary", lambda *a, **k: None)
+
+    monkeypatch.setattr(sys, "argv", ["facet.py", "--retry-failed", "--db", db_path])
+
+    facet.main()
+
+    with get_connection(db_path, row_factory=False) as conn:
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM scan_failures WHERE path = ?", (resolved_path,)
+        ).fetchone()[0]
+    assert remaining == 0

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -59,3 +59,29 @@ class TestSchemaMigrationLadder:
         first = _user_version(db)
         init_database(db)
         assert first == _user_version(db) == SCHEMA_VERSION
+
+    def test_pre_fts_db_gets_fts_rebuilt_on_init(self, tmp_path):
+        db = str(tmp_path / "prefts.db")
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE photos (path TEXT PRIMARY KEY, filename TEXT, "
+            "caption TEXT, aesthetic REAL, aggregate REAL)"
+        )
+        conn.execute(
+            "INSERT INTO photos (path, filename, caption, aesthetic, aggregate) "
+            "VALUES ('/a.jpg', 'a.jpg', 'a red bicycle', 5.0, 6.0)"
+        )
+        conn.execute("PRAGMA user_version = 0")
+        conn.commit()
+        conn.close()
+
+        init_database(db)
+
+        conn = sqlite3.connect(db)
+        try:
+            matched = conn.execute(
+                "SELECT path FROM photos_fts WHERE photos_fts MATCH 'bicycle'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert matched == [('/a.jpg',)]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -396,6 +396,19 @@ class TestOverview:
         data = resp.json()
         assert data["total_photos"] == 0
 
+    def test_overview_anonymous_sees_nothing_on_protected_install(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        _make_stats_db(db_path, [
+            _photo("/a.jpg", aggregate=8.0),
+            _photo("/b.jpg", aggregate=6.0),
+        ])
+        app = _create_app_no_auth()
+        with _stats_mocks(db_path), \
+                mock.patch.dict("api.db_helpers.VIEWER_CONFIG", {"password": "secret"}):
+            resp = TestClient(app).get("/api/stats/overview")
+        assert resp.status_code == 200
+        assert resp.json()["total_photos"] == 0
+
 
 # ---------------------------------------------------------------------------
 # TestGear / TestSettings / TestTimeline

--- a/tests/test_vlm_backend.py
+++ b/tests/test_vlm_backend.py
@@ -242,3 +242,65 @@ class TestResolveVlmConfigUngate:
         with mock.patch("api.config._FULL_CONFIG", _LEGACY_REMOTE), \
                 mock.patch("api.model_cache._resolved_profile", None):
             assert resolve_vlm_config()
+
+
+# --- Qwen2.5-VL batched generation must left-pad for correct decoding ------
+
+class _FakeTokenizer:
+    def __init__(self):
+        self.pad_token_id = 0
+        self.padding_side = "right"
+
+
+class _FakeQwen25Processor:
+    def __init__(self, captured_padding_sides, seq_len, batch_size):
+        self.tokenizer = _FakeTokenizer()
+        self._captured = captured_padding_sides
+        self._seq_len = seq_len
+        self._batch_size = batch_size
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        return "prompt text"
+
+    def __call__(self, text, images, return_tensors, padding):
+        import torch
+        self._captured.append(self.tokenizer.padding_side)
+        return {
+            "input_ids": torch.zeros((self._batch_size, self._seq_len), dtype=torch.long),
+            "attention_mask": torch.ones((self._batch_size, self._seq_len), dtype=torch.long),
+        }
+
+    def decode(self, ids, skip_special_tokens=True):
+        return "cat, dog"
+
+
+class _FakeQwen25Model:
+    device = "cpu"
+
+    def __init__(self, seq_len, batch_size, new_tokens):
+        self._seq_len = seq_len
+        self._batch_size = batch_size
+        self._new_tokens = new_tokens
+
+    def generate(self, **kwargs):
+        import torch
+        return torch.zeros((self._batch_size, self._seq_len + self._new_tokens), dtype=torch.long)
+
+
+class TestBatchQwen25Padding:
+    def test_batches_with_left_padding(self):
+        from models.vlm_tagger import VLMTagger, _ensure_imports
+
+        _ensure_imports()
+        captured_padding_sides = []
+        seq_len, batch_size, new_tokens = 8, 2, 3
+        tagger = VLMTagger({"family": "qwen2_5"}, None)
+        tagger.processor = _FakeQwen25Processor(captured_padding_sides, seq_len, batch_size)
+        tagger.model = _FakeQwen25Model(seq_len, batch_size, new_tokens)
+
+        results = tagger._batch_qwen2_5(
+            [_image(), _image()], prompt="Tags:", max_new_tokens=new_tokens, max_tags=5)
+
+        assert captured_padding_sides == ["left"]
+        assert tagger.processor.tokenizer.padding_side == "right"
+        assert results == [["cat", "dog"], ["cat", "dog"]]

--- a/tests/test_vlm_backend.py
+++ b/tests/test_vlm_backend.py
@@ -289,6 +289,7 @@ class _FakeQwen25Model:
 
 class TestBatchQwen25Padding:
     def test_batches_with_left_padding(self):
+        pytest.importorskip("torch")
         from models.vlm_tagger import VLMTagger, _ensure_imports
 
         _ensure_imports()

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -271,6 +271,15 @@ class TestMove:
         assert resp.status_code == 400
         assert (inbox / "src.jpg").exists()
 
+    def test_move_to_same_path_refused_403(self, client, inbox):
+        client.request("PUT", "/dav/src.jpg", auth=AUTH, content=b"payload")
+        resp = client.request(
+            "MOVE", "/dav/src.jpg", auth=AUTH,
+            headers={"Destination": "http://testserver/dav/src.jpg"},
+        )
+        assert resp.status_code == 403
+        assert (inbox / "src.jpg").read_bytes() == b"payload"
+
 
 # --- DELETE ----------------------------------------------------------------
 

--- a/utils/image_loading.py
+++ b/utils/image_loading.py
@@ -53,9 +53,11 @@ def _auto_decode_concurrency():
     return limit
 
 
-# Hung RAW decodes (stalled NAS I/O) cannot be killed; timed-out decode
-# threads are abandoned and keep their semaphore slot until they finish.
-# After _ABANDON_BUDGET abandonments the scan fails fast instead of wedging.
+# Hung RAW decodes (stalled NAS I/O) cannot be killed; a decode that exceeds
+# the timeout after it has actually started is abandoned and keeps its
+# semaphore slot until it finishes. When every slot is wedged by such hung
+# decodes the scan fails fast instead of blocking forever. _ABANDON_BUDGET is
+# the extra executor headroom that lets fresh decodes run past lingering ones.
 _ABANDON_BUDGET = 2
 
 _decode_concurrency = _auto_decode_concurrency()
@@ -63,6 +65,7 @@ _raw_semaphore = threading.BoundedSemaphore(_decode_concurrency)
 _decode_timeout = 0.0  # 0 = disabled; scanners opt in via configure_raw_decoding()
 _decode_executor = None
 _abandoned_decodes = 0
+_hung_decodes = 0
 _state_lock = threading.Lock()
 
 
@@ -75,11 +78,12 @@ def configure_raw_decoding(concurrency=None, timeout_seconds=None):
         timeout_seconds: Abandon a decode after this many seconds
                          (None = keep current, 0 = disabled)
     """
-    global _decode_concurrency, _raw_semaphore, _decode_timeout, _decode_executor
+    global _decode_concurrency, _raw_semaphore, _decode_timeout, _decode_executor, _hung_decodes
     with _state_lock:
         if concurrency:
             _decode_concurrency = max(1, int(concurrency))
             _raw_semaphore = threading.BoundedSemaphore(_decode_concurrency)
+            _hung_decodes = 0
             if _decode_executor is not None:
                 _decode_executor.shutdown(wait=False)
                 _decode_executor = None
@@ -102,12 +106,18 @@ def _get_decode_executor():
         return _decode_executor
 
 
-def _decode_raw(photo, use_thumbnail):
-    """Decode a RAW file to a PIL image. Runs under the decode semaphore."""
+def _decode_raw(photo, use_thumbnail, started_event=None):
+    """Decode a RAW file to a PIL image. Runs under the decode semaphore.
+
+    started_event, when supplied, is set the moment the semaphore is acquired
+    so the caller can time only the decode, never the queue wait for a slot.
+    """
     import rawpy
     Image, ImageOps = _ensure_pil()
     pil_img = None
     with _raw_semaphore:
+        if started_event is not None:
+            started_event.set()
         if use_thumbnail:
             # Try thumbnail extraction first (faster, lower quality)
             with rawpy.imread(str(photo)) as raw:
@@ -134,29 +144,47 @@ def _decode_raw(photo, use_thumbnail):
     return pil_img
 
 
-def _decode_raw_with_timeout(photo, use_thumbnail):
-    """Decode a RAW file, abandoning the attempt after the configured timeout.
+def _on_hung_decode_done(_future):
+    """Drop the hung-slot count once an abandoned decode finally returns."""
+    global _hung_decodes
+    with _state_lock:
+        _hung_decodes = max(0, _hung_decodes - 1)
 
-    Raises RuntimeError once the abandonment budget is exhausted - at that
-    point the storage is almost certainly stalled and continuing would wedge
-    every decode slot.
+
+def _decode_raw_with_timeout(photo, use_thumbnail):
+    """Decode a RAW file, timing only the decode itself.
+
+    The wait for a free decode slot (semaphore/executor queueing) is excluded
+    from the timeout, so legitimate congestion is never mistaken for a stall.
+    Once a decode has started it must finish within the timeout or it is
+    abandoned, keeping its slot until it eventually returns. When every slot is
+    wedged by such hung decodes the scan fails fast instead of blocking forever.
     """
-    global _abandoned_decodes
-    future = _get_decode_executor().submit(_decode_raw, photo, use_thumbnail)
+    global _abandoned_decodes, _hung_decodes
+    started = threading.Event()
+    future = _get_decode_executor().submit(_decode_raw, photo, use_thumbnail, started)
+    while not started.wait(timeout=_decode_timeout):
+        if future.done():
+            break
+        with _state_lock:
+            hung = _hung_decodes
+            concurrency = _decode_concurrency
+        if hung >= concurrency:
+            raise RuntimeError(
+                f"{hung} RAW decode slots hung - storage likely stalled"
+            )
     try:
         return future.result(timeout=_decode_timeout)
     except FuturesTimeoutError:
         with _state_lock:
             _abandoned_decodes += 1
+            _hung_decodes += 1
             abandoned = _abandoned_decodes
         logger.error(
-            "RAW decode timed out after %.0fs (%d/%d abandoned): %s",
-            _decode_timeout, abandoned, _ABANDON_BUDGET, photo,
+            "RAW decode timed out after %.0fs (%d hung): %s",
+            _decode_timeout, abandoned, photo,
         )
-        if abandoned > _ABANDON_BUDGET:
-            raise RuntimeError(
-                f"{abandoned} RAW decodes hung - storage likely stalled"
-            ) from None
+        future.add_done_callback(_on_hung_decode_done)
         return None
 
 


### PR DESCRIPTION
## Summary

Whole-codebase bug hunt (multi-agent find → adversarial verify) followed by fixes. 56 defects fixed across the Python backend and Angular client, plus three follow-ups and the removal of a dead config knob. 8 thematic commits.

### Highlights (severity-ordered)
- **Anonymous visibility fail-open (high):** on an access-controlled install, unauthenticated `GET /api/photos` and `/api/stats/*` returned the whole library — the deny-all visibility clause was skipped for `user_id=None`.
- **Cross-tenant person IDOR:** delete/merge/rename/hide/assign/split operated on a raw `person_id` with no directory-visibility check.
- **Data loss:** WebDAV MOVE onto its own path deleted the file then 500'd; `--backup --keep 0` rotated away the backup it just wrote.
- **Availability:** a non-ASCII viewer/edition password made every login 500 (instance un-loginable).
- Plus: model-OOM aborting whole scans, RAW-decode timeout false-trips, `--retry-failed` reprocessing fixed photos, spurious 503 on RAW captions, empty `photos_fts` on existing DBs, capsule ÷0, orphaned client picks, and a batch of client-side stale-response guards / effect+timer leaks / culling hide-on-commit.

### Verification (local)
- `pytest`: 1878 passed (28 new tests)
- Angular `npm test` (Vitest): 1278 passed
- `ruff check api/ tests/`: clean · `ng lint`: 0 errors · `ng build`: OK

Docs (incl. all translations) updated for the removed `chunk_size` knob; `--rescan-gps` is now wired to match its existing docs.
