### PR TITLE
fix(client): stop the mobile bottom bar from swallowing the selection bar

### DIFF
--- a/client/src/app/app.html
+++ b/client/src/app/app.html
@@ -366,8 +366,7 @@
     <div class="mx-4 mt-3 p-3 rounded-lg bg-[var(--mat-sys-surface-container)] text-sm opacity-80">{{ key | translate }}</div>
   }
 
-  <!-- Mobile search bar is rendered as a fixed bar above the gallery bottom bar -->
-
+  <!-- Mobile search bar is rendered as the first row of the gallery bottom stack -->
 
   <!-- Active filter chips bar (gallery route only, when filters are active) -->
   @if (auth.isAuthenticated() && isGalleryRoute() && (activeFilterChips().length || store.filters().similar_to)) {
@@ -449,218 +448,218 @@
     <router-outlet />
   </main>
 
-  <!-- Mobile gallery bottom bar (< md only) -->
-  @if (auth.isAuthenticated() && isGalleryRoute()) {
-    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center gap-1 px-2 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] safe-area-pb">
-      <!-- Search toggle -->
-      <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="mobileSearchOpen.set(!mobileSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
-        <mat-icon>search</mat-icon>
-      </button>
+  <!-- Mobile gallery bottom bars (search row stacks over the toolbar) -->
+  @if (auth.isAuthenticated() && mobileGalleryBarVisible()) {
+    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-[var(--mat-sys-surface-container)] safe-area-pb">
+      @if (mobileSearchOpen()) {
+        <div class="px-4 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+          <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
+            <input matInput
+                   [value]="store.filters().search"
+                   (keyup.enter)="onSearchChange($event); mobileSearchOpen.set(false)"
+                   (blur)="onSearchChange($event)"
+                   [placeholder]="I18N.gallery.search_placeholder | translate"
+                   />
+            <mat-icon matPrefix class="opacity-60">search</mat-icon>
+            <button matSuffix mat-icon-button (click)="clearSearch(); mobileSearchOpen.set(false)">
+              <mat-icon>close</mat-icon>
+            </button>
+          </mat-form-field>
+        </div>
+      }
+      <div class="flex items-center gap-1 px-2 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+        <!-- Search toggle -->
+        <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="mobileSearchOpen.set(!mobileSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
+          <mat-icon>search</mat-icon>
+        </button>
 
-      <!-- Sort selector with label -->
-      <mat-form-field class="flex-1 min-w-0" subscriptSizing="dynamic">
-        <mat-label>{{ I18N.gallery.sort | translate }}</mat-label>
-        <mat-select panelWidth="auto" panelClass="nowrap-panel" [value]="store.filters().sort" (selectionChange)="onSortChange($event.value)">
-          @if (store.config()?.features?.show_my_taste) {
-            <mat-option value="learned_score">{{ I18N.gallery.sort_my_taste | translate }}</mat-option>
-          }
-          @if (sortGroups(); as groups) {
-            @for (group of groups; track group[0]) {
-              <mat-optgroup [label]="('sort_groups.' + (group[0] | sortGroupKey)) | translate">
-                @for (opt of group[1]; track opt.column) {
-                  <mat-option [value]="opt.column">{{ 'sort_options.' + opt.column | translate }}</mat-option>
-                }
-              </mat-optgroup>
+        <!-- Sort selector with label -->
+        <mat-form-field class="flex-1 min-w-0" subscriptSizing="dynamic">
+          <mat-label>{{ I18N.gallery.sort | translate }}</mat-label>
+          <mat-select panelWidth="auto" panelClass="nowrap-panel" [value]="store.filters().sort" (selectionChange)="onSortChange($event.value)">
+            @if (store.config()?.features?.show_my_taste) {
+              <mat-option value="learned_score">{{ I18N.gallery.sort_my_taste | translate }}</mat-option>
             }
-          } @else {
-            <mat-option value="aggregate">{{ I18N.gallery.sort_aggregate | translate }}</mat-option>
-            <mat-option value="aesthetic">{{ I18N.gallery.sort_aesthetic | translate }}</mat-option>
-            <mat-option value="date_taken">{{ I18N.gallery.sort_date | translate }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+            @if (sortGroups(); as groups) {
+              @for (group of groups; track group[0]) {
+                <mat-optgroup [label]="('sort_groups.' + (group[0] | sortGroupKey)) | translate">
+                  @for (opt of group[1]; track opt.column) {
+                    <mat-option [value]="opt.column">{{ 'sort_options.' + opt.column | translate }}</mat-option>
+                  }
+                </mat-optgroup>
+              }
+            } @else {
+              <mat-option value="aggregate">{{ I18N.gallery.sort_aggregate | translate }}</mat-option>
+              <mat-option value="aesthetic">{{ I18N.gallery.sort_aesthetic | translate }}</mat-option>
+              <mat-option value="date_taken">{{ I18N.gallery.sort_date | translate }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
 
-      <!-- Tooltip-mode menu (mobile, first in icon cluster) -->
-      <button mat-icon-button class="!w-10 !h-10 shrink-0"
-              [matMenuTriggerFor]="tooltipModeMenuMobile"
-              [matTooltip]="I18N.gallery.tooltip_mode.label | translate"
-              [attr.aria-label]="I18N.gallery.tooltip_mode.label | translate">
-        <mat-icon>{{
-          store.filters().tooltip_mode === 'click' ? 'touch_app'
-          : store.filters().tooltip_mode === 'off' ? 'visibility_off'
-          : 'chat_bubble_outline'
-        }}</mat-icon>
-      </button>
-      <mat-menu #tooltipModeMenuMobile="matMenu">
-        <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'hover')">
-          <mat-icon>chat_bubble_outline</mat-icon>
-          {{ I18N.gallery.tooltip_mode.hover | translate }}
+        <!-- Tooltip-mode menu (mobile, first in icon cluster) -->
+        <button mat-icon-button class="!w-10 !h-10 shrink-0"
+                [matMenuTriggerFor]="tooltipModeMenuMobile"
+                [matTooltip]="I18N.gallery.tooltip_mode.label | translate"
+                [attr.aria-label]="I18N.gallery.tooltip_mode.label | translate">
+          <mat-icon>{{
+            store.filters().tooltip_mode === 'click' ? 'touch_app'
+            : store.filters().tooltip_mode === 'off' ? 'visibility_off'
+            : 'chat_bubble_outline'
+          }}</mat-icon>
         </button>
-        <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'click')">
-          <mat-icon>touch_app</mat-icon>
-          {{ I18N.gallery.tooltip_mode.click | translate }}
-        </button>
-        <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'off')">
-          <mat-icon>visibility_off</mat-icon>
-          {{ I18N.gallery.tooltip_mode.off | translate }}
-        </button>
-      </mat-menu>
+        <mat-menu #tooltipModeMenuMobile="matMenu">
+          <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'hover')">
+            <mat-icon>chat_bubble_outline</mat-icon>
+            {{ I18N.gallery.tooltip_mode.hover | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'click')">
+            <mat-icon>touch_app</mat-icon>
+            {{ I18N.gallery.tooltip_mode.click | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'off')">
+            <mat-icon>visibility_off</mat-icon>
+            {{ I18N.gallery.tooltip_mode.off | translate }}
+          </button>
+        </mat-menu>
 
-      <!-- Sort direction toggle -->
-      <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="toggleSortDirection()"
-        [matTooltip]="store.filters().sort_direction === 'DESC' ? (I18N.gallery.sort_desc | translate) : (I18N.gallery.sort_asc | translate)">
-        <mat-icon>{{ store.filters().sort_direction === 'DESC' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
-      </button>
+        <!-- Sort direction toggle -->
+        <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="toggleSortDirection()"
+          [matTooltip]="store.filters().sort_direction === 'DESC' ? (I18N.gallery.sort_desc | translate) : (I18N.gallery.sort_asc | translate)">
+          <mat-icon>{{ store.filters().sort_direction === 'DESC' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
+        </button>
 
-      <!-- Slideshow toggle -->
-      <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="store.slideshowActive.set(!store.slideshowActive())" [matTooltip]="I18N.slideshow.start | translate">
-        <mat-icon [style.color]="store.slideshowActive() ? 'var(--mat-sys-primary)' : ''">slideshow</mat-icon>
-      </button>
+        <!-- Slideshow toggle -->
+        <button mat-icon-button class="!w-10 !h-10 shrink-0" (click)="store.slideshowActive.set(!store.slideshowActive())" [matTooltip]="I18N.slideshow.start | translate">
+          <mat-icon [style.color]="store.slideshowActive() ? 'var(--mat-sys-primary)' : ''">slideshow</mat-icon>
+        </button>
 
-      <!-- Filter drawer toggle -->
-      <button
-        mat-icon-button class="!w-10 !h-10 shrink-0"
-        (click)="store.setFilterDrawerOpen(!store.filterDrawerOpen())"
-        [matTooltip]="I18N.ui.buttons.filters | translate"
-        [matBadge]="store.activeFilterCount() || null"
-        matBadgeColor="primary"
-        matBadgeSize="small"
-      >
-        <mat-icon [style.color]="store.filterDrawerOpen() ? 'var(--mat-sys-primary)' : ''">tune</mat-icon>
-      </button>
-    </div>
-  }
-
-  <!-- Mobile gallery search bar -->
-  @if (auth.isAuthenticated() && isGalleryRoute() && mobileSearchOpen()) {
-    <div class="lg:hidden fixed bottom-[45px] left-0 right-0 z-50 px-4 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)]">
-      <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
-        <input matInput
-               [value]="store.filters().search"
-               (keyup.enter)="onSearchChange($event); mobileSearchOpen.set(false)"
-               (blur)="onSearchChange($event)"
-               [placeholder]="I18N.gallery.search_placeholder | translate"
-               />
-        <mat-icon matPrefix class="opacity-60">search</mat-icon>
-        <button matSuffix mat-icon-button (click)="clearSearch(); mobileSearchOpen.set(false)">
-          <mat-icon>close</mat-icon>
-        </button>
-      </mat-form-field>
-    </div>
-  }
-
-  <!-- Mobile albums bottom bar -->
-  @if (auth.isAuthenticated() && isAlbumsRoute()) {
-    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center gap-0 px-2 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] safe-area-pb">
-      <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobileAlbumTypeMenu" [matTooltip]="I18N.albums.filter_type | translate">
-        <mat-icon>filter_list</mat-icon>
-      </button>
-      <mat-menu #mobileAlbumTypeMenu="matMenu">
-        <button mat-menu-item (click)="albumsFilters.typeFilter.set('')">
-          <span [class.font-bold]="!albumsFilters.typeFilter()">{{ I18N.albums.type_all | translate }}</span>
-        </button>
-        <button mat-menu-item (click)="albumsFilters.typeFilter.set('manual')">
-          <span [class.font-bold]="albumsFilters.typeFilter() === 'manual'">{{ I18N.albums.type_manual | translate }}</span>
-        </button>
-        <button mat-menu-item (click)="albumsFilters.typeFilter.set('smart')">
-          <span [class.font-bold]="albumsFilters.typeFilter() === 'smart'">{{ I18N.albums.type_smart | translate }}</span>
-        </button>
-      </mat-menu>
-      <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobileAlbumSortMenu" [matTooltip]="I18N.albums.sort_by | translate">
-        <mat-icon>sort</mat-icon>
-      </button>
-      <mat-menu #mobileAlbumSortMenu="matMenu">
-        <button mat-menu-item (click)="albumsFilters.sort.set('updated_at')">
-          <span [class.font-bold]="albumsFilters.sort() === 'updated_at'">{{ I18N.albums.sort_recent | translate }}</span>
-        </button>
-        <button mat-menu-item (click)="albumsFilters.sort.set('name')">
-          <span [class.font-bold]="albumsFilters.sort() === 'name'">{{ I18N.albums.sort_name | translate }}</span>
-        </button>
-        <button mat-menu-item (click)="albumsFilters.sort.set('photo_count')">
-          <span [class.font-bold]="albumsFilters.sort() === 'photo_count'">{{ I18N.albums.sort_photos | translate }}</span>
-        </button>
-      </mat-menu>
-      <button mat-icon-button class="!w-10 !h-10" (click)="mobileAlbumsSearchOpen.set(!mobileAlbumsSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
-        <mat-icon>search</mat-icon>
-      </button>
-      @if (auth.isEdition()) {
-        <button mat-icon-button class="!w-10 !h-10 ml-auto" [matTooltip]="I18N.albums.create | translate" [attr.aria-label]="I18N.albums.create | translate" (click)="albumsFilters.createRequested.set(albumsFilters.createRequested() + 1)">
-          <mat-icon>add</mat-icon>
-        </button>
-      }
-    </div>
-  }
-
-  <!-- Mobile albums search bar -->
-  @if (auth.isAuthenticated() && isAlbumsRoute() && mobileAlbumsSearchOpen()) {
-    <div class="lg:hidden fixed bottom-[45px] left-0 right-0 z-50 px-4 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)]">
-      <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
-        <input matInput [value]="albumsFilters.search()" (input)="albumsFilters.search.set($any($event.target).value)" [placeholder]="I18N.albums.search | translate" />
-        <mat-icon matPrefix class="opacity-60">search</mat-icon>
-        <button matSuffix mat-icon-button (click)="albumsFilters.search.set(''); mobileAlbumsSearchOpen.set(false)">
-          <mat-icon>close</mat-icon>
-        </button>
-      </mat-form-field>
-    </div>
-  }
-
-  <!-- Mobile persons bottom bar -->
-  @if (auth.isAuthenticated() && isPersonsRoute()) {
-    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center gap-0 px-2 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] safe-area-pb">
-      <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobilePersonsSortMenu" [matTooltip]="I18N.gallery.sort | translate">
-        <mat-icon>sort</mat-icon>
-      </button>
-      <mat-menu #mobilePersonsSortMenu="matMenu">
-        <button mat-menu-item (click)="onPersonsSortChange('count')">
-          <span [class.font-bold]="personsFilters.sort() === 'count'">{{ I18N.persons.sort_count | translate }}</span>
-        </button>
-        <button mat-menu-item (click)="onPersonsSortChange('name')">
-          <span [class.font-bold]="personsFilters.sort() === 'name'">{{ I18N.persons.sort_name | translate }}</span>
-        </button>
-        <mat-divider />
-        <button mat-menu-item (click)="togglePersonsSortDirection()">
-          <mat-icon>{{ personsFilters.sortDirection() === 'desc' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
-          {{ personsFilters.sortDirection() === 'desc' ? (I18N.gallery.sort_desc | translate) : (I18N.gallery.sort_asc | translate) }}
-        </button>
-      </mat-menu>
-      <button mat-icon-button class="!w-10 !h-10" (click)="mobilePersonsSearchOpen.set(!mobilePersonsSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
-        <mat-icon>search</mat-icon>
-      </button>
-      @if (auth.isEdition()) {
+        <!-- Filter drawer toggle -->
         <button
-          mat-icon-button class="!w-10 !h-10"
-          [class.!text-[var(--mat-sys-primary)]]="personsFilters.showHidden()"
-          [attr.aria-pressed]="personsFilters.showHidden()"
-          [matTooltip]="I18N.persons.show_hidden | translate"
-          [attr.aria-label]="I18N.persons.show_hidden | translate"
-          (click)="personsFilters.showHidden.set(!personsFilters.showHidden())">
-          <mat-icon>{{ personsFilters.showHidden() ? 'visibility' : 'visibility_off' }}</mat-icon>
+          mat-icon-button class="!w-10 !h-10 shrink-0"
+          (click)="store.setFilterDrawerOpen(!store.filterDrawerOpen())"
+          [matTooltip]="I18N.ui.buttons.filters | translate"
+          [matBadge]="store.activeFilterCount() || null"
+          matBadgeColor="primary"
+          matBadgeSize="small"
+        >
+          <mat-icon [style.color]="store.filterDrawerOpen() ? 'var(--mat-sys-primary)' : ''">tune</mat-icon>
         </button>
-        <button mat-icon-button class="!w-10 !h-10 ml-auto"
-          [matTooltip]="I18N.manage_persons.new_person | translate"
-          [attr.aria-label]="I18N.manage_persons.new_person | translate"
-          (click)="personsFilters.createRequested.set(personsFilters.createRequested() + 1)">
-          <mat-icon>person_add</mat-icon>
-        </button>
-        <a mat-icon-button class="!w-10 !h-10" routerLink="/merge-suggestions"
-          [matTooltip]="I18N.persons.merge_suggestions | translate"
-          [attr.aria-label]="I18N.persons.merge_suggestions | translate">
-          <mat-icon>auto_fix_high</mat-icon>
-        </a>
-      }
+      </div>
     </div>
   }
 
-  <!-- Mobile persons search bar -->
-  @if (auth.isAuthenticated() && isPersonsRoute() && mobilePersonsSearchOpen()) {
-    <div class="lg:hidden fixed bottom-[45px] left-0 right-0 z-50 px-4 py-1 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)]">
-      <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
-        <input matInput [value]="personsFilters.search()" (input)="personsFilters.search.set($any($event.target).value)" [placeholder]="I18N.persons.search_placeholder | translate" />
-        <mat-icon matPrefix class="opacity-60">search</mat-icon>
-        <button matSuffix mat-icon-button (click)="personsFilters.search.set(''); mobilePersonsSearchOpen.set(false)">
-          <mat-icon>close</mat-icon>
+  <!-- Mobile albums bottom bars (search row stacks over the toolbar) -->
+  @if (auth.isAuthenticated() && isAlbumsRoute()) {
+    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-[var(--mat-sys-surface-container)] safe-area-pb">
+      @if (mobileAlbumsSearchOpen()) {
+        <div class="px-4 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+          <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
+            <input matInput [value]="albumsFilters.search()" (input)="albumsFilters.search.set($any($event.target).value)" [placeholder]="I18N.albums.search | translate" />
+            <mat-icon matPrefix class="opacity-60">search</mat-icon>
+            <button matSuffix mat-icon-button (click)="albumsFilters.search.set(''); mobileAlbumsSearchOpen.set(false)">
+              <mat-icon>close</mat-icon>
+            </button>
+          </mat-form-field>
+        </div>
+      }
+      <div class="flex items-center gap-0 px-2 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+        <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobileAlbumTypeMenu" [matTooltip]="I18N.albums.filter_type | translate">
+          <mat-icon>filter_list</mat-icon>
         </button>
-      </mat-form-field>
+        <mat-menu #mobileAlbumTypeMenu="matMenu">
+          <button mat-menu-item (click)="albumsFilters.typeFilter.set('')">
+            <span [class.font-bold]="!albumsFilters.typeFilter()">{{ I18N.albums.type_all | translate }}</span>
+          </button>
+          <button mat-menu-item (click)="albumsFilters.typeFilter.set('manual')">
+            <span [class.font-bold]="albumsFilters.typeFilter() === 'manual'">{{ I18N.albums.type_manual | translate }}</span>
+          </button>
+          <button mat-menu-item (click)="albumsFilters.typeFilter.set('smart')">
+            <span [class.font-bold]="albumsFilters.typeFilter() === 'smart'">{{ I18N.albums.type_smart | translate }}</span>
+          </button>
+        </mat-menu>
+        <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobileAlbumSortMenu" [matTooltip]="I18N.albums.sort_by | translate">
+          <mat-icon>sort</mat-icon>
+        </button>
+        <mat-menu #mobileAlbumSortMenu="matMenu">
+          <button mat-menu-item (click)="albumsFilters.sort.set('updated_at')">
+            <span [class.font-bold]="albumsFilters.sort() === 'updated_at'">{{ I18N.albums.sort_recent | translate }}</span>
+          </button>
+          <button mat-menu-item (click)="albumsFilters.sort.set('name')">
+            <span [class.font-bold]="albumsFilters.sort() === 'name'">{{ I18N.albums.sort_name | translate }}</span>
+          </button>
+          <button mat-menu-item (click)="albumsFilters.sort.set('photo_count')">
+            <span [class.font-bold]="albumsFilters.sort() === 'photo_count'">{{ I18N.albums.sort_photos | translate }}</span>
+          </button>
+        </mat-menu>
+        <button mat-icon-button class="!w-10 !h-10" (click)="mobileAlbumsSearchOpen.set(!mobileAlbumsSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
+          <mat-icon>search</mat-icon>
+        </button>
+        @if (auth.isEdition()) {
+          <button mat-icon-button class="!w-10 !h-10 ml-auto" [matTooltip]="I18N.albums.create | translate" [attr.aria-label]="I18N.albums.create | translate" (click)="albumsFilters.createRequested.set(albumsFilters.createRequested() + 1)">
+            <mat-icon>add</mat-icon>
+          </button>
+        }
+      </div>
+    </div>
+  }
+
+  <!-- Mobile persons bottom bars (search row stacks over the toolbar) -->
+  @if (auth.isAuthenticated() && mobilePersonsBarVisible()) {
+    <div class="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-[var(--mat-sys-surface-container)] safe-area-pb">
+      @if (mobilePersonsSearchOpen()) {
+        <div class="px-4 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+          <mat-form-field class="w-full" subscriptSizing="dynamic" appearance="outline">
+            <input matInput [value]="personsFilters.search()" (input)="personsFilters.search.set($any($event.target).value)" [placeholder]="I18N.persons.search_placeholder | translate" />
+            <mat-icon matPrefix class="opacity-60">search</mat-icon>
+            <button matSuffix mat-icon-button (click)="personsFilters.search.set(''); mobilePersonsSearchOpen.set(false)">
+              <mat-icon>close</mat-icon>
+            </button>
+          </mat-form-field>
+        </div>
+      }
+      <div class="flex items-center gap-0 px-2 py-1 border-t border-[var(--mat-sys-outline-variant)]">
+        <button mat-icon-button class="!w-10 !h-10" [matMenuTriggerFor]="mobilePersonsSortMenu" [matTooltip]="I18N.gallery.sort | translate">
+          <mat-icon>sort</mat-icon>
+        </button>
+        <mat-menu #mobilePersonsSortMenu="matMenu">
+          <button mat-menu-item (click)="onPersonsSortChange('count')">
+            <span [class.font-bold]="personsFilters.sort() === 'count'">{{ I18N.persons.sort_count | translate }}</span>
+          </button>
+          <button mat-menu-item (click)="onPersonsSortChange('name')">
+            <span [class.font-bold]="personsFilters.sort() === 'name'">{{ I18N.persons.sort_name | translate }}</span>
+          </button>
+          <mat-divider />
+          <button mat-menu-item (click)="togglePersonsSortDirection()">
+            <mat-icon>{{ personsFilters.sortDirection() === 'desc' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
+            {{ personsFilters.sortDirection() === 'desc' ? (I18N.gallery.sort_desc | translate) : (I18N.gallery.sort_asc | translate) }}
+          </button>
+        </mat-menu>
+        <button mat-icon-button class="!w-10 !h-10" (click)="mobilePersonsSearchOpen.set(!mobilePersonsSearchOpen())" [matTooltip]="I18N.ui.filters.search | translate">
+          <mat-icon>search</mat-icon>
+        </button>
+        @if (auth.isEdition()) {
+          <button
+            mat-icon-button class="!w-10 !h-10"
+            [class.!text-[var(--mat-sys-primary)]]="personsFilters.showHidden()"
+            [attr.aria-pressed]="personsFilters.showHidden()"
+            [matTooltip]="I18N.persons.show_hidden | translate"
+            [attr.aria-label]="I18N.persons.show_hidden | translate"
+            (click)="personsFilters.showHidden.set(!personsFilters.showHidden())">
+            <mat-icon>{{ personsFilters.showHidden() ? 'visibility' : 'visibility_off' }}</mat-icon>
+          </button>
+          <button mat-icon-button class="!w-10 !h-10 ml-auto"
+            [matTooltip]="I18N.manage_persons.new_person | translate"
+            [attr.aria-label]="I18N.manage_persons.new_person | translate"
+            (click)="personsFilters.createRequested.set(personsFilters.createRequested() + 1)">
+            <mat-icon>person_add</mat-icon>
+          </button>
+          <a mat-icon-button class="!w-10 !h-10" routerLink="/merge-suggestions"
+            [matTooltip]="I18N.persons.merge_suggestions | translate"
+            [attr.aria-label]="I18N.persons.merge_suggestions | translate">
+            <mat-icon>auto_fix_high</mat-icon>
+          </a>
+        }
+      </div>
     </div>
   }
 

--- a/client/src/app/app.spec.ts
+++ b/client/src/app/app.spec.ts
@@ -10,6 +10,7 @@ import { I18nService } from './core/services/i18n.service';
 import { ThemeService } from './core/services/theme.service';
 import { CompareFiltersService } from './features/comparison/compare-filters.service';
 import { StatsFiltersService } from './features/stats/stats-filters.service';
+import { PersonsFiltersService } from './features/persons/persons-filters.service';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate } from '@angular/service-worker';
@@ -19,9 +20,11 @@ function createApp(routerUrl = '/', extraProviders: Provider[] = []) {
   const filtersSignal = signal<GalleryFilters>({ ...DEFAULT_FILTERS });
   const personsSignal = signal<{ id: number; name: string | null }[]>([]);
   const compareCategorySig = signal('');
+  const selectionCountSignal = signal(0);
   const mockStore = {
     filters: filtersSignal,
     persons: personsSignal,
+    selectionCount: selectionCountSignal,
     updateFilter: vi.fn(),
     resetFilters: vi.fn(() => Promise.resolve()),
     config: signal(null),
@@ -47,7 +50,16 @@ function createApp(routerUrl = '/', extraProviders: Provider[] = []) {
     ],
   });
 
-  return { app: TestBed.inject(App), filtersSignal, personsSignal, mockStore, mockRouter, compareCategorySig };
+  return {
+    app: TestBed.inject(App),
+    filtersSignal,
+    personsSignal,
+    mockStore,
+    mockRouter,
+    compareCategorySig,
+    selectionCountSignal,
+    personsFilters: TestBed.inject(PersonsFiltersService),
+  };
 }
 
 describe('App', () => {
@@ -85,6 +97,42 @@ describe('App', () => {
     it('isCompareRoute ignores query string', () => {
       const { app } = createApp('/compare?category=portrait');
       expect((app as any).isCompareRoute()).toBe(true);
+    });
+  });
+
+  describe('mobile bottom bar vs selection (issue #73)', () => {
+    it('shows the gallery bottom bar when nothing is selected', () => {
+      const { app } = createApp('/');
+      expect((app as any).mobileGalleryBarVisible()).toBe(true);
+    });
+
+    it('hides the gallery bottom bar while photos are selected', () => {
+      const { app, selectionCountSignal } = createApp('/');
+      selectionCountSignal.set(3);
+      expect((app as any).mobileGalleryBarVisible()).toBe(false);
+    });
+
+    it('hides the gallery bottom bar on an album route while photos are selected', () => {
+      const { app, selectionCountSignal } = createApp('/album/12');
+      selectionCountSignal.set(1);
+      expect((app as any).mobileGalleryBarVisible()).toBe(false);
+    });
+
+    it('shows the persons bottom bar when nothing is selected', () => {
+      const { app } = createApp('/persons');
+      expect((app as any).mobilePersonsBarVisible()).toBe(true);
+    });
+
+    it('hides the persons bottom bar while persons are selected', () => {
+      const { app, personsFilters } = createApp('/persons');
+      personsFilters.selectedIds.set(new Set([1, 2]));
+      expect((app as any).mobilePersonsBarVisible()).toBe(false);
+    });
+
+    it('leaves the persons bar alone when the gallery has a selection', () => {
+      const { app, selectionCountSignal } = createApp('/persons');
+      selectionCountSignal.set(5);
+      expect((app as any).mobilePersonsBarVisible()).toBe(true);
     });
   });
 

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -187,6 +187,11 @@ export class App implements OnInit {
   protected readonly isTimelineRoute = computed(() => this.url().split('?')[0].startsWith('/timeline'));
   protected readonly isSharedRoute = computed(() => this.url().split('?')[0].startsWith('/shared/'));
 
+  /** On mobile the selection action bar replaces the route's bottom bar rather than
+   *  stacking on top of it, so the two can never overlap (issue #73). */
+  protected readonly mobileGalleryBarVisible = computed(() => this.isGalleryRoute() && !this.store.selectionCount());
+  protected readonly mobilePersonsBarVisible = computed(() => this.isPersonsRoute() && !this.personsFilters.selectedIds().size);
+
   /** True on routes that render their own per-route header controls, so the
    *  header separator only shows when both the nav and those controls are present. */
   protected readonly hasHeaderControls = computed(() =>

--- a/client/src/app/features/gallery/gallery.component.ts
+++ b/client/src/app/features/gallery/gallery.component.ts
@@ -423,7 +423,7 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
 
     <!-- Selection action bar -->
     @if (selectionCount()) {
-      <div class="fixed bottom-[45px] lg:bottom-0 left-0 right-0 z-50 flex items-center justify-center gap-1 lg:gap-3 px-2 lg:px-6 py-1 lg:py-3 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] shadow-lg">
+      <div class="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-center gap-1 lg:gap-3 px-2 lg:px-6 py-1 lg:py-3 max-lg:pb-[max(0.25rem,env(safe-area-inset-bottom))] bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] shadow-lg">
         <span class="text-sm font-medium shrink-0">{{ I18N.gallery.selection.count | translate:{ count: selectionCount() } }}</span>
         <div class="flex items-center gap-0 lg:gap-2">
           <button mat-icon-button class="lg:!hidden" (click)="clearSelection()" [matTooltip]="I18N.gallery.selection.clear | translate"><mat-icon>close</mat-icon></button>

--- a/client/src/app/features/persons/manage-persons.component.ts
+++ b/client/src/app/features/persons/manage-persons.component.ts
@@ -370,7 +370,7 @@ export class PersonFacesDialogComponent implements OnInit {
 
     <!-- Selection action bar (sticky bottom) -->
     @if (auth.isEdition() && selectedIds().size > 0) {
-      <div class="fixed bottom-[45px] lg:bottom-0 left-0 right-0 z-50 flex flex-col lg:flex-row items-center justify-center gap-2 lg:gap-3 px-4 lg:px-6 py-2 lg:py-3 bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] shadow-lg">
+      <div class="fixed bottom-0 left-0 right-0 z-50 flex flex-col lg:flex-row items-center justify-center gap-2 lg:gap-3 px-4 lg:px-6 py-2 lg:py-3 max-lg:pb-[max(0.5rem,env(safe-area-inset-bottom))] bg-[var(--mat-sys-surface-container)] border-t border-[var(--mat-sys-outline-variant)] shadow-lg">
         <span class="text-sm font-medium">{{ I18N.gallery.selection.count | translate:{ count: selectedIds().size } }}</span>
         <div class="flex items-center gap-2">
           <button mat-button (click)="clearSelection()">
@@ -407,7 +407,7 @@ export class ManagePersonsComponent implements OnInit {
   readonly total = signal(0);
   readonly loading = signal(false);
   readonly editingId = signal<number | null>(null);
-  readonly selectedIds = signal<Set<number>>(new Set());
+  readonly selectedIds = this.personsFilters.selectedIds;
   readonly needsNaming = signal<Person[]>([]);
   readonly needsNamingExpanded = signal(true);
 
@@ -420,6 +420,7 @@ export class ManagePersonsComponent implements OnInit {
   constructor() {
     inject(DestroyRef).onDestroy(() => {
       this.pageHelp.setDescription(null);
+      this.clearSelection();
       const t = this.personsToolbar();
       if (t) this.headerSlot.clear(t);
     });

--- a/client/src/app/features/persons/persons-filters.service.ts
+++ b/client/src/app/features/persons/persons-filters.service.ts
@@ -7,4 +7,7 @@ export class PersonsFiltersService {
   readonly search = signal('');
   readonly showHidden = signal(false);
   readonly createRequested = signal(0);
+  /** Lives here rather than in ManagePersonsComponent so the app shell can swap its
+   *  mobile bottom bar for the selection action bar (issue #73). */
+  readonly selectedIds = signal<Set<number>>(new Set());
 }


### PR DESCRIPTION
Closes #73.

## Problem

On a phone, selecting photos in the gallery drew the selection action bar *behind* the shell's bottom filter bar — only a sliver of the orange "Actions" button stayed reachable (see the screenshot in #73).

Two compounding defects:

1. The selection bar was pinned at a hardcoded `bottom-[45px]`, assuming the shell's mobile bar is 45px tall. That bar carries a sort `mat-form-field` and measures **61px** (verified in an emulated 412×915 viewport).
2. Both bars are `z-50` and the shell renders after `<main>`, so the overlap always resolved in the filter bar's favour.

The same hardcoded offset appeared on the persons page and in the three mobile search bars, which overlapped the toolbars they sat on.

## Fix

Per the reporter's proposal, on mobile the selection bar **replaces** the filter bar rather than stacking on it:

- The selection bar anchors to `bottom-0` (gallery + persons), with a mobile-only safe-area inset that leaves the desktop `lg:py-3` padding untouched.
- The shell hides its gallery/persons bottom bar while a selection is active (`mobileGalleryBarVisible` / `mobilePersonsBarVisible`).
- Each route's search row and toolbar now live in one `fixed bottom-0` flex column instead of being positioned against an assumed bar height — `bottom-[45px]` is gone from the codebase.
- Persons selection state moves to `PersonsFiltersService` so the shell can read it; it is cleared when the page is destroyed.

## Verification

- `npm run test` — 1295 passing, including 6 new `app.spec.ts` cases covering the bar-vs-selection gating.
- `npm run build` — clean.
- Chrome DevTools at 412×915 (mobile + touch), against a throwaway seeded DB:
  - shell bar measures 61px, confirming the 45px assumption was 16px short;
  - with a selection, exactly one fixed bar remains and its `bottom` equals `innerHeight` (flush, fully visible);
  - clearing the selection restores the filter bar;
  - search row and toolbar stack with zero overlap on gallery, albums and persons;
  - persons selection behaves identically, and navigating away clears it;
  - at 1440×900 the selection bar keeps its 12px top/bottom padding and no mobile bar renders.