### PR TITLE
feat(client): pick a folder to filter the gallery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,7 +507,7 @@ See [docs/FACE_RECOGNITION.md](docs/FACE_RECOGNITION.md) for the complete workfl
 
 **i18n:** `GET /api/i18n/languages`, `GET /api/i18n/{lang}` — language list and translation bundles.
 
-**Folders:** `GET /api/folders` — photo folder structure for folder-based browsing.
+**Folders:** `GET /api/folders` — one level of the photo folder structure (`{name, path, photo_count, cover_photo_path}` + `has_direct_photos`), where `path` is directly usable as the gallery's `path_prefix` filter. The Folders view (`/folders`) browses it, and each folder card carries a "filter gallery by this folder" action. The gallery sidebar's **Folder** section (`gallery-filter-sidebar.component.ts`) opens `folder-picker-dialog.component.ts`, a drill-down picker over the same endpoint — a tree is impossible because the endpoint reports no `has_subfolders` and each level costs an uncached subtree scan. Applying sets `path_prefix` (subtree match, `api/routers/gallery.py` `_apply_date_album_geo_filters`), which round-trips through the URL and into `smart_filter_json`. Known limitation: `path_prefix` scopes the photo list only — `/api/filter_options/*`, `/api/type_counts`, `/api/stats/*`, `/api/timeline`, `/api/search` and the map stay library-wide.
 
 **Download:** `GET /api/download/options?path=<path>&is_shared=<bool>` — available download types (original, darktable profiles, raw). `GET /api/download?path=<path>&type=original|darktable|raw&profile=<name>` — download with companion RAW detection and darktable profile conversion.
 

--- a/README.de.md
+++ b/README.de.md
@@ -50,7 +50,7 @@ Bewegen Sie den Mauszeiger über ein beliebiges Foto, um einen Tooltip mit der W
 ### Durchstöbern
 
 - **Galeriemodi** — Mosaik (ausgerichtete Zeilen, die Seitenverhältnisse beibehalten) und Raster (einheitliche Karten mit Metadaten-Overlay)
-- **Filter** — Zeitraum, Inhalts-Tag, Kompositionsmuster, Kamera, Objektiv, Person, Qualitätsstufe, Sternebewertung und benutzerdefinierte Metrikbereiche
+- **Filter** — Zeitraum, Inhalts-Tag, Kompositionsmuster, Kamera, Objektiv, Person, Ordner, Qualitätsstufe, Sternebewertung und benutzerdefinierte Metrikbereiche
 - **Semantische Suche** — geben Sie eine natürlichsprachliche Anfrage wie „Sonnenuntergang am Strand“ ein und finden Sie passende Fotos über Embedding- und Textsuche
 - **Zeitleiste** — chronologischer Browser mit Jahr-/Monatsnavigation und unendlichem Scrollen
 - **Karte** — geotaggte Fotos auf einer interaktiven Karte mit Markierungs-Clustering

--- a/README.es.md
+++ b/README.es.md
@@ -50,7 +50,7 @@ Pasa el cursor sobre cualquier foto para ver un tooltip con el desglose de la pu
 ### Explorar
 
 - **Modos de galería** — mosaico (filas justificadas que preservan las proporciones) y cuadrícula (tarjetas uniformes con superposición de metadatos)
-- **Filtros** — rango de fechas, etiqueta de contenido, patrón de composición, cámara, objetivo, persona, nivel de calidad, valoración por estrellas y rangos de métricas personalizados
+- **Filtros** — rango de fechas, etiqueta de contenido, patrón de composición, cámara, objetivo, persona, carpeta, nivel de calidad, valoración por estrellas y rangos de métricas personalizados
 - **Búsqueda semántica** — escribe una consulta en lenguaje natural como "atardecer en la playa" y encuentra fotos coincidentes mediante búsqueda por embedding y por texto
 - **Cronología** — explorador cronológico con navegación por año/mes y desplazamiento infinito
 - **Mapa** — fotos geoetiquetadas en un mapa interactivo con agrupación de marcadores

--- a/README.fr.md
+++ b/README.fr.md
@@ -50,7 +50,7 @@ Survolez n'importe quelle photo pour afficher une infobulle avec le détail du s
 ### Parcourir
 
 - **Modes de galerie** — mosaïque (rangées justifiées préservant les proportions) et grille (cartes uniformes avec superposition des métadonnées)
-- **Filtres** — plage de dates, tag de contenu, motif de composition, appareil, objectif, personne, niveau de qualité, note (étoiles) et plages de métriques personnalisées
+- **Filtres** — plage de dates, tag de contenu, motif de composition, appareil, objectif, personne, dossier, niveau de qualité, note (étoiles) et plages de métriques personnalisées
 - **Recherche sémantique** — saisissez une requête en langage naturel comme « coucher de soleil à la plage » et trouvez les photos correspondantes grâce à la recherche par embedding et par texte
 - **Chronologie** — navigateur chronologique avec navigation par année/mois et défilement infini
 - **Carte** — photos géolocalisées sur une carte interactive avec regroupement des marqueurs

--- a/README.it.md
+++ b/README.it.md
@@ -50,7 +50,7 @@ Passa il puntatore su una foto per vedere un tooltip con il dettaglio del punteg
 ### Sfogliare
 
 - **Modalità galleria** — mosaico (righe giustificate che preservano le proporzioni) e griglia (schede uniformi con sovrapposizione dei metadati)
-- **Filtri** — intervallo di date, tag di contenuto, modello compositivo, fotocamera, obiettivo, persona, livello di qualità, valutazione a stelle e intervalli di metriche personalizzati
+- **Filtri** — intervallo di date, tag di contenuto, modello compositivo, fotocamera, obiettivo, persona, cartella, livello di qualità, valutazione a stelle e intervalli di metriche personalizzati
 - **Ricerca semantica** — digita una query in linguaggio naturale come "tramonto in spiaggia" e trova le foto corrispondenti tramite embedding e ricerca testuale
 - **Cronologia** — browser cronologico con navigazione per anno/mese e scorrimento infinito
 - **Mappa** — foto geolocalizzate su una mappa interattiva con clustering dei marcatori

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Hover over any photo for a tooltip with the score breakdown and EXIF data.
 ### Browse
 
 - **Gallery modes** — mosaic (justified rows preserving aspect ratios) and grid (uniform cards with metadata overlay)
-- **Filters** — date range, content tag, composition pattern, camera, lens, person, quality level, star rating, and custom metric ranges
+- **Filters** — date range, content tag, composition pattern, camera, lens, person, folder, quality level, star rating, and custom metric ranges
 - **Semantic search** — type a natural-language query like "sunset on the beach" and find matching photos via embedding and text search
 - **Timeline** — chronological browser with year/month navigation and infinite scroll
 - **Map** — geotagged photos on an interactive map with marker clustering

--- a/README.pt.md
+++ b/README.pt.md
@@ -50,7 +50,7 @@ Passe o cursor sobre qualquer foto para ver uma dica com o detalhamento da pontu
 ### Navegar
 
 - **Modos de galeria** — mosaico (linhas justificadas que preservam as proporções) e grade (cards uniformes com sobreposição de metadados)
-- **Filtros** — intervalo de datas, tag de conteúdo, padrão de composição, câmera, lente, pessoa, nível de qualidade, classificação por estrelas e faixas de métricas personalizadas
+- **Filtros** — intervalo de datas, tag de conteúdo, padrão de composição, câmera, lente, pessoa, pasta, nível de qualidade, classificação por estrelas e faixas de métricas personalizadas
 - **Busca semântica** — digite uma consulta em linguagem natural como "pôr do sol na praia" e encontre fotos correspondentes por meio de busca por embedding e texto
 - **Linha do tempo** — navegador cronológico com navegação por ano/mês e rolagem infinita
 - **Mapa** — fotos georreferenciadas em um mapa interativo com agrupamento de marcadores

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -41,6 +41,7 @@ import { SlideshowComponent } from './features/gallery/slideshow.component';
 import { Photo } from './shared/models/photo.model';
 import { DateRangeFilterComponent } from './shared/components/date-range-filter/date-range-filter.component';
 import { I18N } from './core/i18n/keys';
+import { folderDisplayName } from './features/folders/folders.util';
 
 /** Inline dialog for edition password prompt. */
 @Component({
@@ -273,10 +274,7 @@ export class App implements OnInit {
     if (f.quality_tier) chips.push({ id: 'quality_tier', labelKey: 'gallery.quality_tier', value: this.i18n.t('gallery.quality_tiers.' + f.quality_tier), clearKeys: ['quality_tier'] });
     if (f.color_temp) chips.push({ id: 'color_temp', labelKey: 'gallery.color_temp', value: this.i18n.t('gallery.color_temps.' + f.color_temp), clearKeys: ['color_temp'] });
     if (f.hue_bucket) chips.push({ id: 'hue_bucket', labelKey: 'gallery.hue', value: this.i18n.t('gallery.hue_buckets.' + f.hue_bucket), clearKeys: ['hue_bucket'] });
-    if (f.path_prefix) {
-      const folderName = f.path_prefix.replace(/\/$/, '').split('/').pop() || f.path_prefix;
-      chips.push({ id: 'path_prefix', labelKey: 'folders.title', value: folderName, clearKeys: ['path_prefix'] });
-    }
+    if (f.path_prefix) chips.push({ id: 'path_prefix', labelKey: 'folders.title', value: folderDisplayName(f.path_prefix), clearKeys: ['path_prefix'] });
 
     // Person filter — one chip per selected person
     if (f.person_id) {

--- a/client/src/app/core/i18n/keys.ts
+++ b/client/src/app/core/i18n/keys.ts
@@ -1125,6 +1125,7 @@ export const I18N = {
       add_filter: "gallery.sidebar.add_filter",
       semantic_search: "gallery.sidebar.semantic_search",
       location: "gallery.sidebar.location",
+      folder: "gallery.sidebar.folder",
       persons: "gallery.sidebar.persons",
       smart_album_filter_notice: "gallery.sidebar.smart_album_filter_notice",
       virtual_scroll: "gallery.sidebar.virtual_scroll",
@@ -1181,6 +1182,10 @@ export const I18N = {
     subject_placement_range: "gallery.subject_placement_range",
     bg_separation_range: "gallery.bg_separation_range",
     gps_clear: "gallery.gps_clear",
+    choose_folder: "gallery.choose_folder",
+    folder_clear: "gallery.folder_clear",
+    all_folders: "gallery.all_folders",
+    use_this_folder: "gallery.use_this_folder",
     loading_photos: "gallery.loading_photos",
     quality_tier: "gallery.quality_tier",
     quality_tiers: {
@@ -2006,6 +2011,8 @@ export const I18N = {
     empty: "folders.empty",
     root: "folders.root",
     photos_count: "folders.photos_count",
+    find_folder: "folders.find_folder",
+    filter_gallery: "folders.filter_gallery",
   },
   albums_sharing: {
     share: "albums_sharing.share",

--- a/client/src/app/features/folders/folders.component.spec.ts
+++ b/client/src/app/features/folders/folders.component.spec.ts
@@ -123,4 +123,18 @@ describe('FoldersComponent', () => {
       });
     });
   });
+
+  describe('filterInGallery', () => {
+    it('should navigate to the gallery filtered on the folder, without replacing history', () => {
+      const folder = { name: 'Work', path: '/photos/Work/', photo_count: 5, cover_photo_path: null };
+      component.filterInGallery(folder);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/'], {
+        queryParams: {
+          path_prefix: '/photos/Work/',
+          sort: 'date_taken',
+          sort_direction: 'DESC',
+        },
+      });
+    });
+  });
 });

--- a/client/src/app/features/folders/folders.component.ts
+++ b/client/src/app/features/folders/folders.component.ts
@@ -5,24 +5,14 @@ import { DecimalPipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { firstValueFrom } from 'rxjs';
 import { ApiService } from '../../core/services/api.service';
 import { PageHelpService } from '../../core/services/page-help.service';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ThumbnailUrlPipe } from '../../shared/pipes/thumbnail-url.pipe';
 import { I18N } from '../../core/i18n/keys';
-
-interface FolderItem {
-  name: string;
-  path: string;
-  photo_count: number;
-  cover_photo_path: string | null;
-}
-
-interface FoldersResponse {
-  folders: FolderItem[];
-  has_direct_photos: boolean;
-}
+import { buildFolderBreadcrumbs, type FolderItem, type FoldersResponse } from './folders.util';
 
 @Component({
   selector: 'app-folders',
@@ -32,6 +22,7 @@ interface FoldersResponse {
     MatIconModule,
     MatButtonModule,
     MatProgressSpinnerModule,
+    MatTooltipModule,
     TranslatePipe,
     ThumbnailUrlPipe,
   ],
@@ -72,31 +63,41 @@ interface FoldersResponse {
 
     <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
       @for (folder of folders(); track folder.path) {
-        <button
-          class="group flex flex-col rounded-xl overflow-hidden bg-[var(--mat-sys-surface-container)] hover:shadow-lg transition-shadow cursor-pointer text-left"
-          (click)="openFolder(folder)">
-          @if (folder.cover_photo_path) {
-            <div class="relative w-full aspect-[4/3] overflow-hidden">
-              <img [src]="folder.cover_photo_path | thumbnailUrl:320"
-                   [alt]="folder.name"
-                   loading="lazy"
-                   class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />
-              <div class="absolute inset-x-0 top-0 z-[5] flex items-start gap-1 bg-gradient-to-b from-black/70 to-transparent px-2 pt-1.5 pb-4 pointer-events-none">
-                <span class="text-white text-xs font-medium truncate">{{ folder.name }}</span>
+        <div class="relative">
+          <button
+            class="group flex flex-col w-full rounded-xl overflow-hidden bg-[var(--mat-sys-surface-container)] hover:shadow-lg transition-shadow cursor-pointer text-left"
+            (click)="openFolder(folder)">
+            @if (folder.cover_photo_path) {
+              <div class="relative w-full aspect-[4/3] overflow-hidden">
+                <img [src]="folder.cover_photo_path | thumbnailUrl:320"
+                     [alt]="folder.name"
+                     loading="lazy"
+                     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />
+                <div class="absolute inset-x-0 top-0 z-[5] flex items-start gap-1 bg-gradient-to-b from-black/70 to-transparent px-2 pt-1.5 pb-4 pointer-events-none">
+                  <span class="text-white text-xs font-medium truncate">{{ folder.name }}</span>
+                </div>
               </div>
-            </div>
-          } @else {
-            <div class="relative w-full aspect-[4/3] flex items-center justify-center overflow-hidden bg-[var(--mat-sys-surface-container-high)]">
-              <mat-icon class="!text-4xl !w-10 !h-10 opacity-30">folder</mat-icon>
-              <div class="absolute inset-x-0 top-0 z-[5] flex items-start gap-1 bg-gradient-to-b from-black/70 to-transparent px-2 pt-1.5 pb-4 pointer-events-none">
-                <span class="text-white text-xs font-medium truncate">{{ folder.name }}</span>
+            } @else {
+              <div class="relative w-full aspect-[4/3] flex items-center justify-center overflow-hidden bg-[var(--mat-sys-surface-container-high)]">
+                <mat-icon class="!text-4xl !w-10 !h-10 opacity-30">folder</mat-icon>
+                <div class="absolute inset-x-0 top-0 z-[5] flex items-start gap-1 bg-gradient-to-b from-black/70 to-transparent px-2 pt-1.5 pb-4 pointer-events-none">
+                  <span class="text-white text-xs font-medium truncate">{{ folder.name }}</span>
+                </div>
               </div>
+            }
+            <div class="p-3">
+              <div class="text-xs opacity-60">{{ folder.photo_count | number }} {{ I18N.folders.photos_count | translate }}</div>
             </div>
-          }
-          <div class="p-3">
-            <div class="text-xs opacity-60">{{ folder.photo_count | number }} {{ I18N.folders.photos_count | translate }}</div>
-          </div>
-        </button>
+          </button>
+          <button
+            mat-icon-button
+            class="!absolute top-0.5 right-0.5 z-10 !text-white !bg-black/40"
+            [matTooltip]="I18N.folders.filter_gallery | translate"
+            [attr.aria-label]="(I18N.folders.filter_gallery | translate) + ' — ' + folder.name"
+            (click)="filterInGallery(folder)">
+            <mat-icon class="!text-base !w-5 !h-5 !leading-5">filter_alt</mat-icon>
+          </button>
+        </div>
       }
     </div>
   `,
@@ -113,19 +114,7 @@ export class FoldersComponent implements OnInit {
   protected readonly loading = signal(false);
   protected readonly currentPrefix = signal('');
 
-  protected readonly breadcrumbs = computed(() => {
-    const prefix = this.currentPrefix();
-    if (!prefix) return [];
-    const parts = prefix.replace(/\/$/, '').split('/').filter(Boolean);
-    const crumbs: { name: string; path: string }[] = [];
-    for (let i = 0; i < parts.length; i++) {
-      crumbs.push({
-        name: parts[i],
-        path: parts.slice(0, i + 1).join('/') + '/',
-      });
-    }
-    return crumbs;
-  });
+  protected readonly breadcrumbs = computed(() => buildFolderBreadcrumbs(this.currentPrefix()));
 
   ngOnInit(): void {
     this.pageHelp.setDescription(I18N.folders.help);
@@ -172,6 +161,16 @@ export class FoldersComponent implements OnInit {
   protected openFolder(folder: FolderItem): void {
     this.router.navigate(['/folders'], {
       queryParams: { prefix: folder.path },
+    });
+  }
+
+  protected filterInGallery(folder: FolderItem): void {
+    this.router.navigate(['/'], {
+      queryParams: {
+        path_prefix: folder.path,
+        sort: 'date_taken',
+        sort_direction: 'DESC',
+      },
     });
   }
 }

--- a/client/src/app/features/folders/folders.util.spec.ts
+++ b/client/src/app/features/folders/folders.util.spec.ts
@@ -1,0 +1,60 @@
+import { buildFolderBreadcrumbs, folderDisplayName } from './folders.util';
+
+describe('buildFolderBreadcrumbs', () => {
+  it('should return an empty array at root', () => {
+    expect(buildFolderBreadcrumbs('')).toEqual([]);
+  });
+
+  it('should return one crumb for a single-level relative prefix', () => {
+    expect(buildFolderBreadcrumbs('Holidays/')).toEqual([
+      { name: 'Holidays', path: 'Holidays/' },
+    ]);
+  });
+
+  it('should return nested crumbs for a deep relative prefix', () => {
+    expect(buildFolderBreadcrumbs('2026/Summer/Beach/')).toEqual([
+      { name: '2026', path: '2026/' },
+      { name: 'Summer', path: '2026/Summer/' },
+      { name: 'Beach', path: '2026/Summer/Beach/' },
+    ]);
+  });
+
+  it('should preserve the leading slash of an absolute prefix', () => {
+    expect(buildFolderBreadcrumbs('/photos/2026/')).toEqual([
+      { name: 'photos', path: '/photos/' },
+      { name: '2026', path: '/photos/2026/' },
+    ]);
+  });
+
+  it('should preserve both slashes of a UNC prefix', () => {
+    expect(buildFolderBreadcrumbs('//server/share/')).toEqual([
+      { name: 'server', path: '//server/' },
+      { name: 'share', path: '//server/share/' },
+    ]);
+  });
+
+  it('should keep a Windows drive letter attached to its root', () => {
+    expect(buildFolderBreadcrumbs('C:/photos/')).toEqual([
+      { name: 'C:', path: 'C:/' },
+      { name: 'photos', path: 'C:/photos/' },
+    ]);
+  });
+
+  it('should tolerate a missing or repeated trailing slash', () => {
+    expect(buildFolderBreadcrumbs('/photos/2026')).toEqual(buildFolderBreadcrumbs('/photos/2026///'));
+  });
+});
+
+describe('folderDisplayName', () => {
+  it('should return the last segment of a prefix', () => {
+    expect(folderDisplayName('/photos/2026/Beach/')).toBe('Beach');
+  });
+
+  it('should tolerate a missing trailing slash', () => {
+    expect(folderDisplayName('/photos/2026/Beach')).toBe('Beach');
+  });
+
+  it('should fall back to the prefix itself when there is no segment', () => {
+    expect(folderDisplayName('/')).toBe('/');
+  });
+});

--- a/client/src/app/features/folders/folders.util.ts
+++ b/client/src/app/features/folders/folders.util.ts
@@ -1,0 +1,37 @@
+export interface FolderItem {
+  name: string;
+  path: string;
+  photo_count: number;
+  cover_photo_path: string | null;
+}
+
+export interface FoldersResponse {
+  folders: FolderItem[];
+  has_direct_photos: boolean;
+}
+
+export interface FolderCrumb {
+  name: string;
+  path: string;
+}
+
+/**
+ * Split a folder prefix into navigable breadcrumbs. Segments are accumulated rather than
+ * filtered out so leading slashes survive — `/photos/2026/` must not become `photos/`,
+ * which the API would match against nothing.
+ */
+export function buildFolderBreadcrumbs(prefix: string): FolderCrumb[] {
+  if (!prefix) return [];
+  const crumbs: FolderCrumb[] = [];
+  let accumulated = '';
+  for (const segment of prefix.replace(/\/+$/, '').split('/')) {
+    accumulated += segment + '/';
+    if (segment) crumbs.push({ name: segment, path: accumulated });
+  }
+  return crumbs;
+}
+
+/** Last segment of a folder prefix, for compact labels (chip, sidebar). */
+export function folderDisplayName(prefix: string): string {
+  return prefix.replace(/\/+$/, '').split('/').pop() || prefix;
+}

--- a/client/src/app/features/gallery/folder-picker-dialog.component.spec.ts
+++ b/client/src/app/features/gallery/folder-picker-dialog.component.spec.ts
@@ -1,0 +1,174 @@
+import type { Mock } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Observable, of, throwError } from 'rxjs';
+import { ApiService } from '../../core/services/api.service';
+import { FolderPickerDialogComponent, type FolderPickerData } from './folder-picker-dialog.component';
+import type { FolderItem, FoldersResponse } from '../folders/folders.util';
+
+const folder = (name: string, path: string, photo_count = 1): FolderItem =>
+  ({ name, path, photo_count, cover_photo_path: null });
+
+const rootLevel: FoldersResponse = {
+  folders: [folder('Family', '/photos/Family/', 120), folder('Travel', '/photos/Travel/', 80)],
+  has_direct_photos: false,
+};
+
+const familyLevel: FoldersResponse = {
+  folders: [folder('2026', '/photos/Family/2026/', 40)],
+  has_direct_photos: true,
+};
+
+describe('FolderPickerDialogComponent', () => {
+  let mockApi: { get: Mock };
+  const mockDialogRef = { close: vi.fn() };
+
+  const createComponent = (data: FolderPickerData = {}) => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: ApiService, useValue: mockApi },
+      ],
+    });
+    return TestBed.runInInjectionContext(() => new FolderPickerDialogComponent());
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi = { get: vi.fn(() => of(rootLevel)) };
+  });
+
+  it('loads the root level when no prefix is supplied', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    expect(mockApi.get).toHaveBeenCalledWith('/folders', { prefix: '' });
+    expect(component.prefix()).toBe('');
+    expect(component.children()).toHaveLength(2);
+  });
+
+  it('opens directly on the supplied prefix in a single request', async () => {
+    mockApi.get.mockReturnValue(of(familyLevel));
+    const component = createComponent({ path_prefix: '/photos/Family/' });
+    await Promise.resolve();
+
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(mockApi.get).toHaveBeenCalledWith('/folders', { prefix: '/photos/Family/' });
+    expect(component.prefix()).toBe('/photos/Family/');
+  });
+
+  it('drills in using the path returned by the API verbatim', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    mockApi.get.mockReturnValue(of(familyLevel));
+    await component.navigateTo('/photos/Family/');
+
+    expect(mockApi.get).toHaveBeenLastCalledWith('/folders', { prefix: '/photos/Family/' });
+    expect(component.prefix()).toBe('/photos/Family/');
+    expect(component.children()[0].name).toBe('2026');
+  });
+
+  it('serves an already visited level from cache without refetching', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    mockApi.get.mockReturnValue(of(familyLevel));
+    await component.navigateTo('/photos/Family/');
+    const callsAfterDrillIn = mockApi.get.mock.calls.length;
+
+    await component.navigateTo('');
+    await component.navigateTo('/photos/Family/');
+
+    expect(mockApi.get.mock.calls.length).toBe(callsAfterDrillIn);
+    expect(component.prefix()).toBe('/photos/Family/');
+  });
+
+  it('closes with the current prefix on apply', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    mockApi.get.mockReturnValue(of(familyLevel));
+    await component.navigateTo('/photos/Family/');
+    component.dialogRef.close(component.prefix());
+
+    expect(mockDialogRef.close).toHaveBeenCalledWith('/photos/Family/');
+  });
+
+  it('closes with an empty prefix when applied at root, which clears the filter', async () => {
+    const component = createComponent({ path_prefix: '/photos/Family/' });
+    await Promise.resolve();
+
+    mockApi.get.mockReturnValue(of(rootLevel));
+    await component.navigateTo('');
+    component.dialogRef.close(component.prefix());
+
+    expect(mockDialogRef.close).toHaveBeenCalledWith('');
+  });
+
+  it('shows an empty level instead of failing when the folder has no children', async () => {
+    mockApi.get.mockReturnValue(of({ folders: [], has_direct_photos: true }));
+    const component = createComponent({ path_prefix: '/photos/Family/2026/Beach/' });
+    await Promise.resolve();
+
+    expect(component.children()).toEqual([]);
+    expect(component.loading()).toBe(false);
+    expect(component.prefix()).toBe('/photos/Family/2026/Beach/');
+  });
+
+  it('recovers from a transport error without leaving the dialog spinning', async () => {
+    mockApi.get.mockReturnValue(throwError(() => new Error('offline')));
+    const component = createComponent();
+    await Promise.resolve();
+
+    expect(component.children()).toEqual([]);
+    expect(component.loading()).toBe(false);
+  });
+
+  it('filters the visible children by name, case-insensitively', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    component.query.set('trav');
+
+    expect(component.filteredChildren()).toHaveLength(1);
+    expect(component.filteredChildren()[0].name).toBe('Travel');
+  });
+
+  it('clears the name filter when the level changes', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+    component.query.set('trav');
+
+    mockApi.get.mockReturnValue(of(familyLevel));
+    await component.navigateTo('/photos/Family/');
+
+    expect(component.query()).toBe('');
+  });
+
+  it('discards a stale level when responses arrive out of order', async () => {
+    const component = createComponent();
+    await Promise.resolve();
+
+    let resolveSlow: (value: FoldersResponse) => void = () => {};
+    const slow = new Observable<FoldersResponse>(subscriber => {
+      resolveSlow = value => {
+        subscriber.next(value);
+        subscriber.complete();
+      };
+    });
+
+    mockApi.get.mockReturnValueOnce(slow);
+    const stale = component.navigateTo('/photos/Family/');
+
+    mockApi.get.mockReturnValueOnce(of(familyLevel));
+    await component.navigateTo('/photos/Travel/');
+
+    resolveSlow(rootLevel);
+    await stale;
+
+    expect(component.prefix()).toBe('/photos/Travel/');
+    expect(component.children()[0].name).toBe('2026');
+  });
+});

--- a/client/src/app/features/gallery/folder-picker-dialog.component.ts
+++ b/client/src/app/features/gallery/folder-picker-dialog.component.ts
@@ -1,0 +1,158 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { firstValueFrom } from 'rxjs';
+import { ApiService } from '../../core/services/api.service';
+import { TranslatePipe } from '../../shared/pipes/translate.pipe';
+import { I18N } from '../../core/i18n/keys';
+import {
+  buildFolderBreadcrumbs,
+  folderDisplayName,
+  type FolderItem,
+  type FoldersResponse,
+} from '../folders/folders.util';
+
+export interface FolderPickerData {
+  path_prefix?: string;
+}
+
+@Component({
+  selector: 'app-folder-picker-dialog',
+  standalone: true,
+  imports: [
+    DecimalPipe,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    TranslatePipe,
+  ],
+  template: `
+    <h2 mat-dialog-title>{{ I18N.gallery.choose_folder | translate }}</h2>
+    <mat-dialog-content class="!flex !flex-col gap-2 min-w-[320px]">
+      <nav class="flex items-center gap-1 text-sm flex-wrap">
+        <button mat-button class="!min-w-0 !px-2" (click)="navigateTo('')">
+          <mat-icon class="!text-base !w-4 !h-4 !leading-4 mr-1">home</mat-icon>
+          {{ I18N.folders.root | translate }}
+        </button>
+        @for (crumb of breadcrumbs(); track crumb.path) {
+          <mat-icon class="!text-base !w-4 !h-4 !leading-4 opacity-40">chevron_right</mat-icon>
+          @if (!$last) {
+            <button mat-button class="!min-w-0 !px-2" (click)="navigateTo(crumb.path)">{{ crumb.name }}</button>
+          } @else {
+            <span class="px-2 font-medium">{{ crumb.name }}</span>
+          }
+        }
+      </nav>
+
+      <div class="flex items-center gap-2 rounded-lg bg-[var(--mat-sys-surface-container-high)] px-3 py-2">
+        <mat-icon class="!text-base !w-5 !h-5 !leading-5 opacity-60">filter_alt</mat-icon>
+        <span class="text-xs opacity-70">{{ I18N.gallery.use_this_folder | translate }}</span>
+        <span class="text-sm font-medium truncate">
+          @if (prefix()) {
+            {{ currentName() }}
+          } @else {
+            {{ I18N.gallery.all_folders | translate }}
+          }
+        </span>
+      </div>
+
+      @if (children().length > 1) {
+        <mat-form-field subscriptSizing="dynamic" class="w-full">
+          <mat-icon matPrefix class="mr-1 opacity-60">search</mat-icon>
+          <input matInput
+                 [placeholder]="I18N.folders.find_folder | translate"
+                 [attr.aria-label]="I18N.folders.find_folder | translate"
+                 [value]="query()"
+                 (input)="query.set($any($event.target).value)" />
+        </mat-form-field>
+      }
+
+      @if (loading()) {
+        <div class="flex justify-center py-8">
+          <mat-spinner diameter="32" />
+        </div>
+      } @else if (!filteredChildren().length) {
+        <p class="text-xs opacity-50 px-1 py-6 text-center">{{ I18N.folders.empty | translate }}</p>
+      } @else {
+        <div class="flex flex-col gap-1 max-h-[360px] overflow-y-auto">
+          @for (folder of filteredChildren(); track folder.path) {
+            <button
+              class="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full"
+              (click)="navigateTo(folder.path)"
+            >
+              <mat-icon class="!text-base !w-5 !h-5 !leading-5 opacity-60 shrink-0">folder</mat-icon>
+              <span class="text-sm truncate flex-1">{{ folder.name }}</span>
+              <span class="text-xs opacity-60 shrink-0">{{ folder.photo_count | number }}</span>
+              <mat-icon class="!text-base !w-4 !h-4 !leading-4 opacity-40 shrink-0">chevron_right</mat-icon>
+            </button>
+          }
+        </div>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>{{ I18N.ui.buttons.cancel | translate }}</button>
+      <button mat-flat-button (click)="dialogRef.close(prefix())">{{ I18N.ui.buttons.apply | translate }}</button>
+    </mat-dialog-actions>
+  `,
+})
+export class FolderPickerDialogComponent {
+  protected readonly I18N = I18N;
+  private readonly api = inject(ApiService);
+  readonly dialogRef = inject(MatDialogRef<FolderPickerDialogComponent>);
+  private readonly data: FolderPickerData = inject(MAT_DIALOG_DATA, { optional: true }) ?? {};
+
+  readonly prefix = signal(this.data.path_prefix ?? '');
+  readonly children = signal<FolderItem[]>([]);
+  readonly loading = signal(false);
+  readonly query = signal('');
+
+  protected readonly breadcrumbs = computed(() => buildFolderBreadcrumbs(this.prefix()));
+  protected readonly currentName = computed(() => folderDisplayName(this.prefix()));
+  readonly filteredChildren = computed(() => {
+    const query = this.query().toLowerCase().trim();
+    const all = this.children();
+    return query ? all.filter(f => f.name.toLowerCase().includes(query)) : all;
+  });
+
+  private readonly levelCache = new Map<string, FolderItem[]>();
+  private loadSeq = 0;
+
+  constructor() {
+    void this.navigateTo(this.prefix());
+  }
+
+  async navigateTo(prefix: string): Promise<void> {
+    const seq = ++this.loadSeq;
+    this.prefix.set(prefix);
+    this.query.set('');
+
+    const cached = this.levelCache.get(prefix);
+    if (cached) {
+      this.children.set(cached);
+      this.loading.set(false);
+      return;
+    }
+
+    this.loading.set(true);
+    try {
+      const res = await firstValueFrom(this.api.get<FoldersResponse>('/folders', { prefix }));
+      if (seq !== this.loadSeq) return;
+      this.levelCache.set(prefix, res.folders);
+      this.children.set(res.folders);
+    } catch {
+      // The endpoint reports its own failures as an empty list, so only transport errors land here.
+      if (seq !== this.loadSeq) return;
+      this.children.set([]);
+    } finally {
+      if (seq === this.loadSeq) this.loading.set(false);
+    }
+  }
+}

--- a/client/src/app/features/gallery/gallery-filter-sidebar.component.spec.ts
+++ b/client/src/app/features/gallery/gallery-filter-sidebar.component.spec.ts
@@ -44,6 +44,7 @@ describe('GalleryFilterSidebarComponent', () => {
         min_subject_prominence: '', max_subject_prominence: '',
         min_subject_placement: '', max_subject_placement: '',
         min_bg_separation: '', max_bg_separation: '',
+        path_prefix: '',
       }),
       filterDrawerOpen: signal(true),
       cameras: signal([]),
@@ -139,6 +140,13 @@ describe('GalleryFilterSidebarComponent', () => {
       expect(component.sectionActiveCounts()['equipment']).toBe(2);
     });
 
+    it('counts an active path_prefix for the folder section', () => {
+      const mockStore = (component as any).store;
+      expect(component.sectionActiveCounts()['folder']).toBe(0);
+      mockStore.filters.set({ ...mockStore.filters(), path_prefix: '/photos/Family/' });
+      expect(component.sectionActiveCounts()['folder']).toBe(1);
+    });
+
     it('counts favorites_only, is_monochrome, hide_rejected for refine section', () => {
       const mockStore = (component as any).store;
       mockStore.filters.set({ ...mockStore.filters(), favorites_only: true, is_monochrome: true, hide_rejected: true });
@@ -216,6 +224,21 @@ describe('GalleryFilterSidebarComponent', () => {
       mockStore.filters.set({ ...mockStore.filters(), min_iso: '100' });
       component.onDynamicRangeChange(isoFilter, 'max', 25600);
       expect(mockStore.updateFilterDebounced).toHaveBeenCalledWith('max_iso', '');
+    });
+  });
+
+  describe('folder filter', () => {
+    it('clearFolderFilter empties path_prefix', () => {
+      const mockStore = (component as any).store;
+      mockStore.filters.set({ ...mockStore.filters(), path_prefix: '/photos/Family/' });
+      component.clearFolderFilter();
+      expect(mockStore.updateFilter).toHaveBeenCalledWith('path_prefix', '');
+    });
+
+    it('currentFolderName shows the last segment of the active prefix', () => {
+      const mockStore = (component as any).store;
+      mockStore.filters.set({ ...mockStore.filters(), path_prefix: '/photos/Family/2026/' });
+      expect(component.currentFolderName()).toBe('2026');
     });
   });
 });

--- a/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
+++ b/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
@@ -25,6 +25,7 @@ import { AlbumService, Album } from '../../core/services/album.service';
 import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
 import { SaveSmartAlbumDialogComponent } from '../albums/save-smart-album-dialog.component';
+import { folderDisplayName } from '../folders/folders.util';
 import { I18N } from '../../core/i18n/keys';
 
 export const ADDITIONAL_FILTERS: AdditionalFilterDef[] = [
@@ -655,6 +656,44 @@ function saveSectionStates(states: Record<string, boolean>): void {
         </mat-expansion-panel>
       }
 
+      <!-- Folder filter -->
+      @if (store.config()?.features?.show_folders || store.filters().path_prefix) {
+        <mat-expansion-panel class="!mb-1" [expanded]="sectionStates()['folder'] === true"
+                             (opened)="onSectionToggle('folder', true)"
+                             (closed)="onSectionToggle('folder', false)"
+                             [style.background-color]="sectionStates()['folder'] === true ? 'var(--mat-sys-surface-container)' : null">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="flex items-center gap-2">
+              <mat-icon class="!text-base !w-5 !h-5 !leading-5 opacity-60">folder</mat-icon>
+              {{ I18N.gallery.sidebar.folder | translate }}
+              @if (sectionActiveCounts()['folder']) {
+                <span class="text-xs rounded-full min-w-[1.25rem] h-5 px-1.5 flex items-center justify-center bg-[var(--mat-sys-primary)] text-[var(--mat-sys-on-primary)] leading-none">{{ sectionActiveCounts()['folder'] }}</span>
+              }
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="flex flex-col gap-2 pb-2">
+            @if (store.filters().path_prefix) {
+              <div class="flex items-center gap-1">
+                <button mat-stroked-button class="flex-1 min-w-0 !justify-start" [matTooltip]="store.filters().path_prefix"
+                        [attr.aria-label]="I18N.gallery.choose_folder | translate" (click)="openFolderPicker()">
+                  <mat-icon>folder</mat-icon>
+                  <span class="truncate">{{ currentFolderName() }}</span>
+                </button>
+                <button mat-icon-button [matTooltip]="I18N.gallery.folder_clear | translate"
+                        [attr.aria-label]="I18N.gallery.folder_clear | translate" (click)="clearFolderFilter()">
+                  <mat-icon>close</mat-icon>
+                </button>
+              </div>
+            } @else {
+              <button mat-stroked-button class="w-full" (click)="openFolderPicker()">
+                <mat-icon>folder_open</mat-icon>
+                {{ I18N.gallery.choose_folder | translate }}
+              </button>
+            }
+          </div>
+        </mat-expansion-panel>
+      }
+
       <!-- Metric filter sections (collapsed by default) -->
       <!-- Common metric sections -->
       @for (group of commonFilterGroups(); track group.sectionKey) {
@@ -800,6 +839,8 @@ export class GalleryFilterSidebarComponent {
     if (el) el.value = '';
   }
 
+  readonly currentFolderName = computed(() => folderDisplayName(this.store.filters().path_prefix));
+
   readonly sectionIcons = SECTION_ICONS;
   private i18n = inject(I18nService);
 
@@ -898,6 +939,7 @@ export class GalleryFilterSidebarComponent {
       equipment: (f.camera ? 1 : 0) + (f.lens ? 1 : 0),
       persons: f.person_id ? f.person_id.split(',').length : 0,
       refine: (f.favorites_only ? 1 : 0) + (f.is_monochrome ? 1 : 0) + (f.hide_rejected ? 1 : 0),
+      folder: f.path_prefix ? 1 : 0,
     };
     const fAny = f as Record<string, any>;
     for (const sectionKey of SECTION_ORDER) {
@@ -986,6 +1028,25 @@ export class GalleryFilterSidebarComponent {
 
   clearGpsFilter(): void {
     this.store.updateFilters({ gps_lat: '', gps_lng: '', gps_radius_km: '' });
+  }
+
+  openFolderPicker(): void {
+    import('./folder-picker-dialog.component').then(m => {
+      const ref = this.dialog.open(m.FolderPickerDialogComponent, {
+        width: '95vw',
+        maxWidth: '600px',
+        data: { path_prefix: this.store.filters().path_prefix },
+      });
+      ref.afterClosed().subscribe((result?: string) => {
+        if (result !== undefined && result !== this.store.filters().path_prefix) {
+          this.store.updateFilter('path_prefix', result);
+        }
+      });
+    });
+  }
+
+  clearFolderFilter(): void {
+    this.store.updateFilter('path_prefix', '');
   }
 
   saveAsSmartAlbum(): void {

--- a/docs/VIEWER.md
+++ b/docs/VIEWER.md
@@ -466,7 +466,18 @@ Browse your photo library by directory structure. Access via the `/folders` rout
 - Breadcrumb navigation to move up the directory tree
 - Each folder shows a cover photo (highest-scoring image in that directory)
 - Click a folder to descend into it, or click a photo to open it in the gallery
+- Each folder card has a filter action that opens the gallery restricted to that folder — available on every folder, not only leaf folders
 - Respects multi-user directory visibility in multi-user mode
+
+### Folder Filter
+
+The gallery filter sidebar has a **Folder** section. **Choose folder…** opens a picker that walks the
+directory tree one level at a time; applying it restricts the gallery to that folder **and all of its
+subfolders**. The active folder shows up as a filter chip, combines with every other filter (score,
+person, date…), survives a reload through the `path_prefix` URL parameter, and is saved into smart albums.
+
+The folder filter narrows the photo grid only — the sidebar dropdowns, type counts, statistics,
+timeline, map and search stay library-wide.
 
 ## GPS Filter Dialog
 

--- a/docs/de/VIEWER.md
+++ b/docs/de/VIEWER.md
@@ -457,7 +457,19 @@ Durchsuchen Sie Ihre Fotobibliothek nach Verzeichnisstruktur. Zugriff über die 
 - Brotkrümel-Navigation, um im Verzeichnisbaum nach oben zu wechseln
 - Jeder Ordner zeigt ein Titelbild (das am höchsten bewertete Bild in diesem Verzeichnis)
 - Klicken Sie auf einen Ordner, um in ihn abzusteigen, oder auf ein Foto, um es in der Galerie zu öffnen
+- Jede Ordnerkachel bietet eine Filteraktion, die die Galerie auf diesen Ordner eingeschränkt öffnet — verfügbar für jeden Ordner, nicht nur für Endordner
 - Berücksichtigt im Mehrbenutzermodus die Verzeichnissichtbarkeit der Benutzer
+
+### Ordnerfilter
+
+Die Filterleiste der Galerie enthält einen Abschnitt **Ordner**. **Ordner wählen…** öffnet eine Auswahl,
+die den Verzeichnisbaum Ebene für Ebene durchläuft; das Anwenden beschränkt die Galerie auf diesen Ordner
+**und alle seine Unterordner**. Der aktive Ordner erscheint als Filter-Chip, lässt sich mit allen anderen
+Filtern kombinieren (Bewertung, Person, Datum…), übersteht ein Neuladen über den URL-Parameter
+`path_prefix` und wird in intelligenten Alben gespeichert.
+
+Der Ordnerfilter schränkt nur das Fotoraster ein — die Auswahllisten der Filterleiste, die Typzähler, die
+Statistiken, die Zeitleiste, die Karte und die Suche bleiben bibliotheksweit.
 
 ## GPS-Filterdialog
 

--- a/docs/es/VIEWER.md
+++ b/docs/es/VIEWER.md
@@ -456,7 +456,19 @@ Explora tu biblioteca de fotos por la estructura de directorios. Accede mediante
 - Navegación por migas de pan para subir en el árbol de directorios
 - Cada carpeta muestra una foto de portada (la imagen con mayor puntuación de ese directorio)
 - Haz clic en una carpeta para entrar en ella, o haz clic en una foto para abrirla en la galería
+- Cada tarjeta de carpeta ofrece una acción de filtrado que abre la galería restringida a esa carpeta — disponible en cualquier carpeta, no solo en las finales
 - Respeta la visibilidad de directorios multiusuario en modo multiusuario
+
+### Filtro por carpeta
+
+El panel de filtros de la galería tiene una sección **Carpeta**. **Elegir carpeta…** abre un selector que
+recorre el árbol de directorios nivel a nivel; al aplicarlo, la galería se restringe a esa carpeta **y a
+todas sus subcarpetas**. La carpeta activa aparece como una etiqueta de filtro, se combina con el resto de
+filtros (puntuación, persona, fecha…), sobrevive a una recarga mediante el parámetro de URL `path_prefix`
+y se guarda en los álbumes inteligentes.
+
+El filtro por carpeta solo restringe la cuadrícula de fotos: los desplegables del panel, los recuentos por
+tipo, las estadísticas, la línea de tiempo, el mapa y la búsqueda siguen abarcando toda la biblioteca.
 
 ## Diálogo de filtro GPS
 

--- a/docs/fr/VIEWER.md
+++ b/docs/fr/VIEWER.md
@@ -457,7 +457,20 @@ Parcourez votre bibliothèque photo par structure de répertoires. Accessible vi
 - Navigation par fil d'Ariane pour remonter dans l'arborescence des répertoires
 - Chaque dossier affiche une photo de couverture (l'image la mieux notée de ce répertoire)
 - Cliquez sur un dossier pour y descendre, ou sur une photo pour l'ouvrir dans la galerie
+- Chaque vignette de dossier propose une action de filtrage qui ouvre la galerie restreinte à ce dossier — disponible sur tous les dossiers, pas seulement les dossiers terminaux
 - Respecte la visibilité des répertoires multi-utilisateurs en mode multi-utilisateurs
+
+### Filtre par dossier
+
+Le panneau de filtres de la galerie comporte une section **Dossier**. **Choisir un dossier…** ouvre un
+sélecteur qui parcourt l'arborescence niveau par niveau ; l'appliquer restreint la galerie à ce dossier
+**et à tous ses sous-dossiers**. Le dossier actif apparaît sous forme de puce de filtre, se combine avec
+tous les autres filtres (note, personne, date…), survit à un rechargement via le paramètre d'URL
+`path_prefix` et est enregistré dans les albums intelligents.
+
+Le filtre par dossier restreint uniquement la grille de photos — les listes déroulantes du panneau, les
+compteurs par type, les statistiques, la chronologie, la carte et la recherche restent à l'échelle de
+toute la bibliothèque.
 
 ## Boîte de dialogue Filtre GPS
 

--- a/docs/it/VIEWER.md
+++ b/docs/it/VIEWER.md
@@ -457,7 +457,19 @@ Sfoglia la tua libreria di foto in base alla struttura delle directory. Accessib
 - Navigazione tramite breadcrumb per risalire l'albero delle directory
 - Ogni cartella mostra una foto di copertina (l'immagine con il punteggio più alto in quella directory)
 - Clicca su una cartella per entrarvi, oppure clicca su una foto per aprirla nella galleria
+- Ogni scheda di cartella offre un'azione di filtro che apre la galleria limitata a quella cartella — disponibile su qualsiasi cartella, non solo su quelle finali
 - Rispetta la visibilità delle directory multiutente in modalità multiutente
+
+### Filtro per cartella
+
+Il pannello dei filtri della galleria include una sezione **Cartella**. **Scegli cartella…** apre un
+selettore che percorre l'albero delle directory un livello alla volta; applicandolo la galleria viene
+limitata a quella cartella **e a tutte le sue sottocartelle**. La cartella attiva compare come chip di
+filtro, si combina con tutti gli altri filtri (punteggio, persona, data…), sopravvive a un ricaricamento
+tramite il parametro URL `path_prefix` ed è salvata negli album intelligenti.
+
+Il filtro per cartella restringe soltanto la griglia delle foto: i menu a discesa del pannello, i
+conteggi per tipo, le statistiche, la cronologia, la mappa e la ricerca restano sull'intera libreria.
 
 ## Finestra filtro GPS
 

--- a/docs/pt/VIEWER.md
+++ b/docs/pt/VIEWER.md
@@ -456,7 +456,19 @@ Navegue pela sua biblioteca de fotos pela estrutura de diretórios. Acesse pela 
 - Navegação por trilha de navegação (breadcrumb) para subir na árvore de diretórios
 - Cada pasta mostra uma foto de capa (a imagem de maior pontuação naquele diretório)
 - Clique em uma pasta para entrar nela, ou clique em uma foto para abri-la na galeria
+- Cada cartão de pasta oferece uma ação de filtro que abre a galeria restrita àquela pasta — disponível em qualquer pasta, não apenas nas finais
 - Respeita a visibilidade de diretórios multiusuário no modo multiusuário
+
+### Filtro por pasta
+
+O painel de filtros da galeria tem uma seção **Pasta**. **Escolher pasta…** abre um seletor que percorre a
+árvore de diretórios um nível de cada vez; ao aplicá-lo, a galeria fica restrita àquela pasta **e a todas
+as suas subpastas**. A pasta ativa aparece como um chip de filtro, combina-se com todos os outros filtros
+(pontuação, pessoa, data…), sobrevive a um recarregamento pelo parâmetro de URL `path_prefix` e é salva
+nos álbuns inteligentes.
+
+O filtro por pasta restringe apenas a grade de fotos — as listas suspensas do painel, as contagens por
+tipo, as estatísticas, a linha do tempo, o mapa e a busca continuam abrangendo toda a biblioteca.
 
 ## Diálogo de Filtro por GPS
 

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -1125,6 +1125,7 @@
       "add_filter": "Filter hinzufügen...",
       "semantic_search": "Semantische Suche",
       "location": "Standort",
+      "folder": "Ordner",
       "persons": "Personen",
       "smart_album_filter_notice": "Smart-Album — Filteränderungen werden automatisch gespeichert.",
       "virtual_scroll": "Schnelles Scrollen (virtualisiert)",
@@ -1181,6 +1182,10 @@
     "saturation_range": "Sättigung",
     "star_rating_range": "Sternebewertung",
     "gps_clear": "Standort entfernen",
+    "choose_folder": "Ordner wählen…",
+    "folder_clear": "Ordner entfernen",
+    "all_folders": "Alle Ordner",
+    "use_this_folder": "Diesen Ordner verwenden",
     "loading_photos": "Fotos werden geladen…",
     "quality_tier": "Qualitätsstufe",
     "quality_tiers": {
@@ -2007,7 +2012,9 @@
     "title": "Ordner",
     "empty": "Keine Ordner gefunden.",
     "root": "Stammverzeichnis",
-    "photos_count": "Fotos"
+    "photos_count": "Fotos",
+    "find_folder": "Ordner suchen…",
+    "filter_gallery": "Galerie nach diesem Ordner filtern"
   },
   "albums_sharing": {
     "share": "Album teilen",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -1121,6 +1121,7 @@
       "add_filter": "Add Filter...",
       "semantic_search": "Semantic Search",
       "location": "Location",
+      "folder": "Folder",
       "persons": "Persons",
       "smart_album_filter_notice": "Smart album — filter changes are saved automatically.",
       "virtual_scroll": "Fast scrolling (virtualized)",
@@ -1177,6 +1178,10 @@
     "subject_placement_range": "Subject Placement",
     "bg_separation_range": "BG Separation",
     "gps_clear": "Clear location",
+    "choose_folder": "Choose folder…",
+    "folder_clear": "Clear folder",
+    "all_folders": "All folders",
+    "use_this_folder": "Use this folder",
     "loading_photos": "Loading photos…",
     "quality_tier": "Quality Tier",
     "quality_tiers": {
@@ -2001,7 +2006,9 @@
     "title": "Folders",
     "empty": "No folders found.",
     "root": "Root",
-    "photos_count": "photos"
+    "photos_count": "photos",
+    "find_folder": "Find a folder…",
+    "filter_gallery": "Filter gallery by this folder"
   },
   "albums_sharing": {
     "share": "Share Album",

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -1121,6 +1121,7 @@
       "add_filter": "Agregar filtro...",
       "semantic_search": "Búsqueda semántica",
       "location": "Ubicación",
+      "folder": "Carpeta",
       "persons": "Personas",
       "smart_album_filter_notice": "Álbum inteligente — los filtros se guardan automáticamente.",
       "virtual_scroll": "Desplazamiento rápido (virtualizado)",
@@ -1177,6 +1178,10 @@
     "saturation_range": "Saturación",
     "star_rating_range": "Valoración por estrellas",
     "gps_clear": "Borrar ubicación",
+    "choose_folder": "Elegir carpeta…",
+    "folder_clear": "Borrar carpeta",
+    "all_folders": "Todas las carpetas",
+    "use_this_folder": "Usar esta carpeta",
     "loading_photos": "Cargando fotos…",
     "quality_tier": "Nivel de calidad",
     "quality_tiers": {
@@ -2003,7 +2008,9 @@
     "title": "Carpetas",
     "empty": "No se encontraron carpetas.",
     "root": "Raíz",
-    "photos_count": "fotos"
+    "photos_count": "fotos",
+    "find_folder": "Buscar una carpeta…",
+    "filter_gallery": "Filtrar la galería por esta carpeta"
   },
   "albums_sharing": {
     "share": "Compartir álbum",

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -1121,6 +1121,7 @@
       "add_filter": "Ajouter un filtre...",
       "semantic_search": "Recherche sémantique",
       "location": "Localisation",
+      "folder": "Dossier",
       "persons": "Personnes",
       "smart_album_filter_notice": "Album intelligent — les filtres sont enregistrés automatiquement.",
       "virtual_scroll": "Défilement rapide (virtualisé)",
@@ -1177,6 +1178,10 @@
     "subject_placement_range": "Placement du sujet",
     "bg_separation_range": "Séparation fond",
     "gps_clear": "Supprimer la position",
+    "choose_folder": "Choisir un dossier…",
+    "folder_clear": "Supprimer le dossier",
+    "all_folders": "Tous les dossiers",
+    "use_this_folder": "Utiliser ce dossier",
     "loading_photos": "Chargement des photos…",
     "quality_tier": "Niveau de qualité",
     "quality_tiers": {
@@ -2003,7 +2008,9 @@
     "title": "Dossiers",
     "empty": "Aucun dossier trouvé.",
     "root": "Racine",
-    "photos_count": "photos"
+    "photos_count": "photos",
+    "find_folder": "Rechercher un dossier…",
+    "filter_gallery": "Filtrer la galerie sur ce dossier"
   },
   "albums_sharing": {
     "share": "Partager l'album",

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -1121,6 +1121,7 @@
       "add_filter": "Aggiungi filtro...",
       "semantic_search": "Ricerca semantica",
       "location": "Posizione",
+      "folder": "Cartella",
       "persons": "Persone",
       "smart_album_filter_notice": "Album intelligente — i filtri vengono salvati automaticamente.",
       "virtual_scroll": "Scorrimento rapido (virtualizzato)",
@@ -1177,6 +1178,10 @@
     "saturation_range": "Saturazione",
     "star_rating_range": "Valutazione a stelle",
     "gps_clear": "Rimuovi posizione",
+    "choose_folder": "Scegli cartella…",
+    "folder_clear": "Rimuovi cartella",
+    "all_folders": "Tutte le cartelle",
+    "use_this_folder": "Usa questa cartella",
     "loading_photos": "Caricamento foto…",
     "quality_tier": "Livello di qualità",
     "quality_tiers": {
@@ -2003,7 +2008,9 @@
     "title": "Cartelle",
     "empty": "Nessuna cartella trovata.",
     "root": "Radice",
-    "photos_count": "foto"
+    "photos_count": "foto",
+    "find_folder": "Cerca una cartella…",
+    "filter_gallery": "Filtra la galleria per questa cartella"
   },
   "albums_sharing": {
     "share": "Condividi album",

--- a/i18n/translations/pt.json
+++ b/i18n/translations/pt.json
@@ -1121,6 +1121,7 @@
       "add_filter": "Adicionar filtro...",
       "semantic_search": "Busca semântica",
       "location": "Localização",
+      "folder": "Pasta",
       "persons": "Pessoas",
       "smart_album_filter_notice": "Álbum inteligente — as alterações de filtro são salvas automaticamente.",
       "virtual_scroll": "Rolagem rápida (virtualizada)",
@@ -1177,6 +1178,10 @@
     "subject_placement_range": "Posicionamento do sujeito",
     "bg_separation_range": "Separação do fundo",
     "gps_clear": "Limpar localização",
+    "choose_folder": "Escolher pasta…",
+    "folder_clear": "Limpar pasta",
+    "all_folders": "Todas as pastas",
+    "use_this_folder": "Usar esta pasta",
     "loading_photos": "Carregando fotos…",
     "quality_tier": "Nível de qualidade",
     "quality_tiers": {
@@ -2001,7 +2006,9 @@
     "title": "Pastas",
     "empty": "Nenhuma pasta encontrada.",
     "root": "Raiz",
-    "photos_count": "fotos"
+    "photos_count": "fotos",
+    "find_folder": "Procurar uma pasta…",
+    "filter_gallery": "Filtrar a galeria por esta pasta"
   },
   "albums_sharing": {
     "share": "Compartilhar álbum",

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -313,6 +313,62 @@ class TestGalleryPhotos:
 
 
 # ---------------------------------------------------------------------------
+# Folder (path_prefix) Filter
+# ---------------------------------------------------------------------------
+
+class TestGalleryPathPrefixFilter:
+    """GET /api/photos?path_prefix= — subtree match on the directory boundary.
+
+    The viewer's folder picker feeds these prefixes straight from /api/folders,
+    so the normalisation and escaping below are part of that contract.
+    """
+
+    PHOTOS = [
+        _photo("/lib/A/one.jpg", "2024:01:01 10:00:00"),
+        _photo("/lib/A/B/C/deep.jpg", "2024:01:01 10:00:00"),
+        _photo("/lib/Alpha/other.jpg", "2024:01:01 10:00:00"),
+        _photo("/lib/100_MEDIA/wild.jpg", "2024:01:01 10:00:00"),
+        _photo("/lib/100XMEDIA/decoy.jpg", "2024:01:01 10:00:00"),
+        _photo("C:\\lib\\W\\win.jpg", "2024:01:01 10:00:00"),
+    ]
+
+    def _paths_for(self, tmp_path, path_prefix):
+        db_path = str(tmp_path / f"test-{abs(hash(path_prefix))}.db")
+        _make_db(db_path, self.PHOTOS)
+        app = _create_app_no_auth()
+        with (
+            mock.patch("api.routers.gallery.get_db", _conn_factory(db_path)),
+            mock.patch("api.routers.gallery.get_async_db", _async_conn_factory(db_path)),
+            mock.patch("api.routers.gallery.VIEWER_CONFIG", _VIEWER_CONFIG),
+            mock.patch("api.db_helpers._existing_columns_cache", _TEST_PHOTOS_COLUMNS),
+            mock.patch.dict("api.config._count_cache", {}, clear=True),
+        ):
+            resp = TestClient(app).get("/api/photos", params={"path_prefix": path_prefix, "per_page": 50})
+        assert resp.status_code == 200
+        return sorted(p["path"] for p in resp.json()["photos"])
+
+    def test_matches_the_whole_subtree(self, tmp_path):
+        assert self._paths_for(tmp_path, "/lib/A") == ["/lib/A/B/C/deep.jpg", "/lib/A/one.jpg"]
+
+    def test_trailing_slash_variants_are_equivalent(self, tmp_path):
+        bare = self._paths_for(tmp_path, "/lib/A")
+        assert self._paths_for(tmp_path, "/lib/A/") == bare
+        assert self._paths_for(tmp_path, "/lib/A///") == bare
+
+    def test_stops_at_the_directory_boundary(self, tmp_path):
+        assert "/lib/Alpha/other.jpg" not in self._paths_for(tmp_path, "/lib/A")
+
+    def test_underscore_is_not_a_like_wildcard(self, tmp_path):
+        assert self._paths_for(tmp_path, "/lib/100_MEDIA") == ["/lib/100_MEDIA/wild.jpg"]
+
+    def test_windows_paths_match_a_forward_slash_prefix(self, tmp_path):
+        assert self._paths_for(tmp_path, "C:/lib/W/") == ["C:\\lib\\W\\win.jpg"]
+
+    def test_empty_prefix_filters_nothing(self, tmp_path):
+        assert len(self._paths_for(tmp_path, "")) == len(self.PHOTOS)
+
+
+# ---------------------------------------------------------------------------
 # Hide Bursts
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #71.

## Summary

`path_prefix` was already a working gallery filter — it reached the SQL, round-tripped through the URL, was counted by `countActiveFilters()`, rendered an active-filter chip, and was saved into `smart_filter_json` — but nothing in the viewer could set it. It was reachable only by hand-editing the URL, or implicitly when the Folders view auto-redirected out of a folder that happened to have no subfolders.

- **Sidebar Folder section** — opens a picker over `GET /api/folders`. Once a folder is applied the section collapses to a single row: the folder name (click to change it) plus a clear (×).
- **Folder picker dialog** — drills down one level at a time behind a breadcrumb, with a name filter, a per-level cache and a sequence guard. Applying at the root clears the filter.
- **Folders view** — every card gets a "filter gallery by this folder" action, so any folder can be picked, not only leaf ones.
- **Bundled fix** — breadcrumbs no longer drop the leading slash (see below).

No backend change: `GET /api/folders` already returns `path` values usable as `path_prefix` verbatim.

### Why a drill-down and not an expandable tree

`GET /api/folders` reports no `has_subfolders`, so a tree would have to draw a chevron on every row and only reveal leaves *after* expanding — and each expand runs an uncached, unbounded `SELECT path, aggregate` over that subtree (`api/routers/folders.py:60-63`). Drilling costs one request per user decision and opens straight onto the folder already filtered on.

## Root cause of the bundled breadcrumb fix

`FoldersComponent.breadcrumbs()` rebuilt paths with `split('/').filter(Boolean)` then `join('/')`, dropping the leading slash. On a library under `/photos`, clicking a crumb navigated to `prefix=photos/`, which matched nothing, tripped the zero-subfolder auto-redirect, and dumped the user into an **empty gallery**. Reproduced in the browser before fixing. Both the view and the picker now share `buildFolderBreadcrumbs`, which accumulates segments and keeps absolute, UNC and drive-letter roots intact.

## Known limitation (documented, not fixed here)

`path_prefix` scopes the photo grid and its total only. `/api/filter_options/*`, `/api/type_counts`, `/api/stats/*`, `/api/timeline`, `/api/search` and the map stay library-wide, so the sidebar dropdowns and type counts still describe the whole library. Pre-existing; now stated in `docs/VIEWER.md` in all six languages.