### PR TITLE
fix(lock): stop a Windows peek from inventing a holder, and run CI there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,29 @@ jobs:
       - name: Run tests
         run: python -m pytest --tb=short -q --cov=api --cov=processing --cov=analyzers --cov=config --cov=utils --cov-report=term-missing
 
+  windows-tests:
+    name: Python Tests (Windows)
+    # Runs after the Linux suite: no point spending a Windows runner on a tree
+    # that is already red, and this is the last gate rather than a parallel one.
+    needs: python-tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install test dependencies
+        run: pip install pytest pytest-asyncio pytest-cov fastapi[standard] httpx pyjwt pillow numpy scipy scikit-learn opencv-python-headless tqdm aiosqlite sqlite-vec imagehash psutil
+      - name: Run the platform-sensitive suites
+        # Deliberately NOT the whole suite. Much of it hard-codes POSIX paths
+        # ("/lib/a.jpg") that no Windows path ever matches, so a full run is
+        # permanently red and therefore ignored. These two files are the actual
+        # platform surface: the library lock picks a different backend here
+        # (msvcrt byte-range locks, which have no shared mode), and the device
+        # policy resolves CUDA/MPS/CPU. Both were unexercised until this job.
+        run: python -m pytest tests/test_scan.py tests/test_device.py -q --tb=short
+
   angular-tests:
     name: Angular Tests
     runs-on: ubuntu-latest

--- a/facet.py
+++ b/facet.py
@@ -6,6 +6,7 @@ CLI entry point. The scoring engine is in processing/scorer.py.
 """
 import atexit
 import os
+import random
 import signal
 import sys
 import threading
@@ -695,6 +696,7 @@ class _FlockBackend:
     """
 
     peek_open_flags = os.O_RDONLY
+    has_shared_mode = True
 
     @staticmethod
     def take_exclusive(fd):
@@ -712,14 +714,15 @@ class _FlockBackend:
 class _MsvcrtBackend:
     """Windows byte-range locks (``msvcrt.locking``), which have no shared mode.
 
-    A peek therefore probes with the same exclusive lock and drops it again;
-    two peeks can still collide, but neither can report a finished job because
-    ``release`` empties the payload first. The locked byte sits past the
-    payload so a Windows range lock -- mandatory, unlike POSIX advisory locks
-    -- never blocks reading the holder's JSON.
+    A peek therefore probes with the same exclusive lock and drops it again,
+    so two peeks collide with each other; ``_read_holder`` retries the probe to
+    tell a peer's microsecond-long peek from a real job. The locked byte sits
+    past the payload so a Windows range lock -- mandatory, unlike POSIX
+    advisory locks -- never blocks reading the holder's JSON.
     """
 
     peek_open_flags = os.O_RDWR
+    has_shared_mode = False
 
     @staticmethod
     def _lock_reserved_byte(fd, mode):
@@ -848,8 +851,23 @@ def _take_os_lock(fd, attempts=1):
     return False
 
 
-def _lock_is_free(fd):
-    """True when no job holds the lock, probed without taking it away."""
+def _lock_is_free(fd, attempts=1):
+    """True when no job holds the lock, probed without taking it away.
+
+    ``attempts`` above 1 is for backends whose "shared" probe is really an
+    exclusive one: there a peer peek holds the byte for microseconds while a
+    real job holds it for minutes, so retrying tells the two apart. The backoff
+    is jittered because peeks arrive in phase -- a viewer polls every client at
+    once -- and a fixed sleep would just re-collide the same herd each round.
+    """
+    for _ in range(attempts - 1):
+        try:
+            _OS_LOCK.take_shared(fd)
+        except OSError:
+            time.sleep(LIBRARY_LOCK_RETRY_SECONDS * random.uniform(0.5, 1.5))
+            continue
+        _OS_LOCK.unlock(fd)
+        return True
     try:
         _OS_LOCK.take_shared(fd)
     except OSError:
@@ -871,6 +889,13 @@ def _read_holder(lock_path):
     The probe is read-only and, where the platform has a shared mode, taken
     in it: two overlapping peeks that excluded each other would make one of
     them read a finished job's leftover payload as a live holder.
+
+    Where it has none -- Windows byte-range locks -- the probe is itself
+    exclusive, so overlapping peeks exclude *each other* and the loser is
+    retried rather than believed, exactly as ``_take_os_lock`` already does on
+    the acquire side. An empty payload stays "held" on purpose: a holder whose
+    ``_write_payload`` hit ENOSPC owns the lock with an empty file, and calling
+    that free would be the worse error of the two.
     """
     if _OS_LOCK is None:
         return None
@@ -879,7 +904,8 @@ def _read_holder(lock_path):
     except OSError:
         return None
     try:
-        if _lock_is_free(fd):
+        attempts = 1 if _OS_LOCK.has_shared_mode else LIBRARY_LOCK_RETRY_ATTEMPTS
+        if _lock_is_free(fd, attempts=attempts):
             return None
         return _decode_holder(os.read(fd, LIBRARY_LOCK_READ_BYTES))
     finally:

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -972,19 +972,26 @@ class TestLibraryLock:
 
     def test_acquire_retries_before_declaring_a_conflict(self, tmp_path, monkeypatch):
         """Reading the holder also takes the lock for a few microseconds, so a
-        viewer poll landing on an acquire must not refuse the job outright."""
+        viewer poll landing on an acquire must not refuse the job outright.
+
+        Patched at the backend seam rather than at ``fcntl.flock``: ``fcntl`` is
+        None on Windows, so patching it there made this assert the retry only on
+        POSIX and raise AttributeError everywhere else.
+        """
         import facet
 
         calls = []
-        real_flock = facet.fcntl.flock
+        real_take_exclusive = facet._OS_LOCK.take_exclusive
 
-        def flaky_flock(fd, operation):
-            calls.append(operation)
+        def flaky_take_exclusive(fd):
+            calls.append(fd)
             if len(calls) == 1:
                 raise BlockingIOError(11, "Resource temporarily unavailable")
-            return real_flock(fd, operation)
+            return real_take_exclusive(fd)
 
-        monkeypatch.setattr(facet.fcntl, "flock", flaky_flock)
+        monkeypatch.setattr(
+            facet._OS_LOCK, "take_exclusive", staticmethod(flaky_take_exclusive)
+        )
         lock = facet.LibraryLock(str(tmp_path / "photos.db"), kind="recompute")
         lock.acquire()
         lock.release()
@@ -1001,6 +1008,14 @@ class TestLibraryLock:
 
         assert library_job_holder(db_path) is None
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="os.kill on Windows maps every signal except CTRL_C_EVENT/"
+               "CTRL_BREAK_EVENT to TerminateProcess, so this would kill the "
+               "test runner outright instead of unwinding into the context "
+               "manager. test_sigterm_handler_is_restored_after_release still "
+               "covers the handler there.",
+    )
     def test_release_on_sigterm_frees_the_lock(self, tmp_path):
         from facet import LibraryLock, library_job_holder
 
@@ -1071,7 +1086,13 @@ class TestLibraryLock:
         finally:
             first.release()
 
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    @pytest.mark.skipif(
+        os.name == "nt" or getattr(os, "geteuid", lambda: -1)() == 0,
+        reason="root ignores directory permissions, and Windows has neither "
+               "geteuid nor a chmod that can make a directory unwritable for "
+               "its owner. Evaluated at import, so an unguarded os.geteuid "
+               "made this whole module uncollectable on Windows.",
+    )
     def test_unwritable_cache_dir_raises_a_clear_error(self, tmp_path):
         """New failure mode introduced by the lock: the cache dir may be owned
         by the other user in a viewer/CLI split. It must name the path and the
@@ -1135,6 +1156,14 @@ def _fake_mount_table(tmp_path, entries):
     return str(table)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Reads /proc/mounts and feeds POSIX mount points through "
+           "os.path.abspath, which on Windows rewrites '/mnt/nas' to "
+           "'<drive>:\\mnt\\nas' and can never match. The warning is Linux-only "
+           "by design: it exists because flock over SMB is arbitrated host-side, "
+           "whereas Windows byte-range locks over SMB2 are server-arbitrated.",
+)
 class TestHostLocalLockWarning:
     """``flock`` is arbitrated by the kernel that took it, so on an SMB/CIFS
     mount two machines each believe they hold the library lock. The lock cannot


### PR DESCRIPTION
## The bug

On Windows, two concurrent `library_job_holder()` peeks can invent a holder that does not exist — a spurious 409 / `running: true` in the viewer. That is precisely the bug `test_concurrent_peeks_never_manufacture_a_holder` was written to lock out; it was fixed on POSIX and has been live on Windows ever since.

`msvcrt.locking` has no shared mode, so `_MsvcrtBackend.take_shared` was byte-identical to `take_exclusive`. Overlapping peeks therefore excluded **each other**, and the loser fell through to the payload read and returned `UNKNOWN_LIBRARY_JOB`:

```
{'kind': 'library job', 'origin': 'unknown', 'pid': None}   x14 of 16 peeks
```

## The fix

`_take_os_lock` already handles the symmetric problem on the *acquire* side, and says why:

> a peek's probe holds the file for the microseconds it takes to read the payload, and a real conflict lasts minutes

The peek side simply had no equivalent. It now retries the same way, gated on a new `has_shared_mode` flag per backend.

- **POSIX is byte-identical.** `attempts=1` makes `range(0)` empty, falling straight through to the original single probe.
- **The backoff is jittered.** This mattered more than expected: peeks arrive in phase (a viewer polls every client at once), so a flat sleep just re-collided the same herd each round — 16 concurrent peeks went 14 phantoms → 11 with a fixed delay, and **0 across 20 runs** once jittered.
- **An empty payload still reads as held, deliberately.** A first attempt at "empty means free" was wrong and the suite caught it: a holder whose `_write_payload` hit ENOSPC owns the lock with an empty file, and reporting that as free is the worse of the two errors (`test_a_failed_payload_write_keeps_the_lock_itself`).

## Why it was never caught

CI is `ubuntu-latest` only, so the entire `_MsvcrtBackend` path has never run. Three POSIX-only assumptions in `tests/test_scan.py` compounded it:

| Assumption | Effect on Windows |
|---|---|
| `os.geteuid()` inside a `skipif` decorator | Evaluated at **import**; attribute absent on Windows, so all 88 tests in the module were uncollectable and every lock test silently vanished |
| `test_release_on_sigterm_frees_the_lock` | `os.kill` maps every signal but `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` to `TerminateProcess` — it **killed the test runner** (exit 15) |
| `test_acquire_retries_before_declaring_a_conflict` | Patched `facet.fcntl.flock`; `fcntl` is `None` off POSIX. Now patches whichever backend was selected |

`TestHostLocalLockWarning` is skipped on Windows: it parses `/proc/mounts` and feeds POSIX mount points through `os.path.abspath`, which rewrites `/mnt/nas` to `<drive>:\mnt\nas`. That warning is Linux-only by design — `flock` over SMB is arbitrated host-side, Windows byte-range locks over SMB2 are not.

## The CI job

Adds `windows-tests` running `test_scan.py` + `test_device.py`, with `needs: python-tests` so it gates last and does not spend a Windows runner on an already-red tree.

Deliberately **not** the whole suite: much of it hard-codes POSIX paths, so a full Windows run is permanently red and therefore ignored. These two files are the actual platform surface — the lock picks a different backend, and the device policy resolves CUDA/MPS/CPU.

## Verification (Windows 11, Python 3.13)

| Check | Result |
|---|---|
| `test_concurrent_peeks_never_manufacture_a_holder` | 0 failures / 20 runs |
| Full `TestLibraryLock` | 0 failures / 5 runs |
| The new job's exact command | 116 passed, 8 skipped, exit 0 |
| Full suite, before vs after | same 11 pre-existing failures; **fixes 3, regresses 0** |
| `ruff check tests/ --select E,F,W` | clean |

The 11 remaining failures (`test_single_pass_preserves`, `test_webdav`, `test_config_writes`) are identical in count and file on master and are untouched by this change.
