### PR TITLE
perf(scan): resolve each path once instead of three times

### DIFF
--- a/facet.py
+++ b/facet.py
@@ -1180,8 +1180,33 @@ def _run_scan(args, resumed_run):
                     if p.suffix.lower() in valid_suffixes:
                         all_files.append(p)
 
-    # Deduplicate (needed for case-insensitive filesystems like Windows)
-    all_files = list({f.resolve(): f for f in all_files}.values())
+    # Deduplicate (needed for case-insensitive filesystems like Windows).
+    #
+    # resolve() is a filesystem round-trip, and on a UNC/NAS library it is the
+    # dominant startup cost -- the same paths were resolved three times over:
+    # here, again to build the unscanned set, and a third time to filter the
+    # todo list. Measured against an SMB library of 153,574 files: ~3.9 ms cold
+    # and ~2 ms warm per call, so two of those passes were minutes of pure
+    # latency before a single photo was read. Resolve once and let every later
+    # caller take the string from _resolved().
+    _resolved_cache = {}
+
+    def _resolved(path):
+        """This path's resolved string, computed at most once per scan."""
+        cached = _resolved_cache.get(path)
+        if cached is None:
+            cached = str(path.resolve())
+            _resolved_cache[path] = cached
+        return cached
+
+    deduplicated = {}
+    for f in all_files:
+        # Keyed on the resolved Path, not its string: Path equality is
+        # case-insensitive on Windows, which is what makes this a dedup.
+        resolved = f.resolve()
+        _resolved_cache[f] = str(resolved)
+        deduplicated.setdefault(resolved, f)
+    all_files = list(deduplicated.values())
 
     # --retry-failed: the worklist comes from scan_failures, not the dir walk
     if args.retry_failed:
@@ -1196,14 +1221,14 @@ def _run_scan(args, resumed_run):
     jpeg_like = {'.jpg', '.jpeg'} | HEIF_EXTENSIONS
     jpegs_stems = {f.stem.lower() for f in all_files if f.suffix.lower() in jpeg_like}
     if args.retry_failed:
-        unscanned = {str(f.resolve()) for f in all_files}
+        unscanned = {_resolved(f) for f in all_files}
     elif args.force_since:
         from processing.scan_state import filter_paths_scanned_before
         unscanned = filter_paths_scanned_before(
-            args.db, (str(f.resolve()) for f in all_files), args.force_since,
+            args.db, (_resolved(f) for f in all_files), args.force_since,
         )
     elif args.force:
-        unscanned = {str(f.resolve()) for f in all_files}
+        unscanned = {_resolved(f) for f in all_files}
         if args.resume and resumed_run:
             from processing.scan_state import filter_paths_scanned_since
             unscanned = filter_paths_scanned_since(
@@ -1211,10 +1236,10 @@ def _run_scan(args, resumed_run):
                 scorer.config.version_hash,
             )
     else:
-        unscanned = scorer.filter_unscanned_paths(str(f.resolve()) for f in all_files)
+        unscanned = scorer.filter_unscanned_paths(_resolved(f) for f in all_files)
 
     # Filter the list to only include new or un-scanned files
-    todo_list = [f for f in all_files if str(f.resolve()) in unscanned
+    todo_list = [f for f in all_files if _resolved(f) in unscanned
                  and not (f.suffix.lower() in RAW_EXTENSIONS and f.stem.lower() in jpegs_stems)]
     raw_paired_skipped = sum(
         1 for f in all_files
@@ -1441,7 +1466,7 @@ def _run_scan(args, resumed_run):
     else:
         scan_run.finish('completed')
         if args.retry_failed and todo_list:
-            retried_paths = [str(f.resolve()) for f in todo_list]
+            retried_paths = [_resolved(f) for f in todo_list]
             with get_connection(scorer.db_path) as conn:
                 conn.executemany(
                     "DELETE FROM scan_failures WHERE path = ? AND scan_run_id != ?",


### PR DESCRIPTION
## The problem

A scan resolved every candidate path **three times**:

```python
all_files = list({f.resolve(): f for f in all_files}.values())            # dedup
unscanned = scorer.filter_unscanned_paths(str(f.resolve()) for f in ...)  # again
todo_list = [f for f in all_files if str(f.resolve()) in unscanned ...]   # and again
```

On a local disk that is invisible. On a UNC/NAS library it is the dominant startup cost, because every `resolve()` is a filesystem round-trip.

Measured on an SMB library of **153,574 files**:

| Pass | per call | rate |
|---|---|---|
| Cold (first resolve) | 3.94 ms | 254/s |
| Warm (2nd) | 2.08 ms | 480/s |
| Warm (3rd) | 1.83 ms | 546/s |

The two redundant passes were minutes of pure latency before a single photo had been read — on that library a scan spent **14.5 minutes** in startup, most of it here.

## The fix

Resolve once during the dedup pass, and hand the string to every later caller via a memoising `_resolved()`.

Two details that are deliberate rather than incidental:

- **The dedup still keys on the resolved `Path`, not its string.** `Path` equality is case-insensitive on Windows, which is the entire reason that pass exists; switching the key to `str` would quietly stop deduplicating case variants.
- **`_resolved()` memoises on demand rather than trusting the dedup pass.** `--retry-failed` *replaces* `all_files` with paths read back out of `scan_failures`, which the cache has never seen, so a lookup-only helper would `KeyError` there.

## Verification

A fixture exercising RAW+JPEG pairs, an orphan RAW, a nested subdirectory, a HEIC/DNG pair, an already-scanned file and a case-variant duplicate, run through both the old three-pass logic and the new cached logic:

```
input files (incl. case variant): 10
old todo list: 5
new todo list: 5
IDENTICAL todo lists  ->  behaviour preserved
resolve() calls  old=28  new=10  (2.8x fewer)
```

Test suites touching the scan path — `test_scan.py`, `test_device.py`, `test_scan_interrupt.py`, `test_retry_failed_cleanup.py`, `test_multi_pass.py`, `test_rescan_preservation.py`:

```
134 passed, 8 skipped
```

`ruff check facet.py tests/ --select E,F,W` clean.
