### PR TITLE
chore(scan): quiet the scan output and stop it shredding the progress bar

### DIFF
--- a/facet.py
+++ b/facet.py
@@ -14,7 +14,11 @@ import time
 
 # Suppress noisy third-party library output
 os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
-os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "0")
+# Hub progress bars are per-shard weight-loading bars ("Loading weights: 100%
+# ... Materializing param=..."). A multi-pass scan reloads models between every
+# pass, so they redraw hundreds of times over a run and bury the scan's own
+# progress bar. Downloads are logged separately, so nothing is hidden.
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 # Allow unsupported PyTorch MPS operators to run on CPU.  Set this before any
 # dependency has a chance to import torch.
 os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
@@ -31,8 +35,37 @@ warnings.filterwarnings(
 import logging
 logging.getLogger("transformers").setLevel(logging.ERROR)
 logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+# timm announces every pretrained-weight fetch; pyiqa announces every network
+# it builds ("Network [CFANet] is created."). Both fire once per model per
+# pass, which on a multi-pass scan is hundreds of lines saying nothing.
+for _noisy in ("timm", "pyiqa", "matplotlib", "PIL", "urllib3"):
+    logging.getLogger(_noisy).setLevel(logging.WARNING)
 
 logger = logging.getLogger("facet")
+
+
+class _TqdmLoggingHandler(logging.StreamHandler):
+    """Emit through ``tqdm.write`` so log lines do not shred the progress bar.
+
+    A scan prints a live tqdm bar while every pass keeps logging. Writing to
+    the stream directly leaves the record interleaved *into* the bar's line,
+    which is why scan logs are full of half-eaten bars with a timestamp
+    embedded mid-way. ``tqdm.write`` clears the bar, writes, and redraws it.
+    Falls back to the plain StreamHandler behaviour if tqdm is absent.
+    """
+
+    def emit(self, record):
+        try:
+            from tqdm import tqdm
+        except ImportError:
+            return super().emit(record)
+        try:
+            tqdm.write(self.format(record), file=self.stream)
+            self.flush()
+        except RecursionError:
+            raise
+        except Exception:
+            self.handleError(record)
 
 # Ensure the script's directory is in Python path for local imports
 # This allows running the script from any directory
@@ -1562,11 +1595,25 @@ def main():
         except Exception:
             pass
     level_name = (level_name or "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
     logging.basicConfig(
-        level=getattr(logging, level_name, logging.INFO),
+        level=level,
         format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[_TqdmLoggingHandler()],
     )
+    # open_clip logs through the *root* logger with bare logging.info() calls
+    # ("Instantiating model architecture", "Loading full pretrained weights
+    # from", "Model ViT-L-14 creation process complete"), so there is no name
+    # to quiet. Raising root's own level silences those without touching us:
+    # a logger's level gates only what is logged directly to it, and records
+    # propagating up from "facet" still reach root's handlers. That requires
+    # our own trees to carry an explicit level rather than inheriting root's --
+    # "api" as well as "facet", since api.* modules name their loggers after
+    # __name__ and the CLI does reach into them.
+    for _ours in ("facet", "api"):
+        logging.getLogger(_ours).setLevel(level)
+    logging.getLogger().setLevel(max(level, logging.WARNING))
 
     parser = argparse.ArgumentParser(
         description='Facet: AI-powered photo quality assessment',

--- a/models/pyiqa_scorer.py
+++ b/models/pyiqa_scorer.py
@@ -165,6 +165,11 @@ class PyIQAScorer:
         self.device = device
         self.model = None
         self._loaded = False
+        # Skips are counted for the whole pass and reported once on unload.
+        # Per-batch they are noise: topiq_nr_face legitimately declines every
+        # photo without a face, so a landscape-heavy scan logged a warning per
+        # chunk that said nothing a single total does not.
+        self._skipped_totals: dict[str, int] = {}
 
     def load(self):
         """Load model to GPU/CPU."""
@@ -196,6 +201,10 @@ class PyIQAScorer:
         self._loaded = False
         from utils.device import clear_device_cache
         clear_device_cache(self.device)
+        for msg, count in self._skipped_totals.items():
+            logger.warning("  %s skipped %d image(s) in total: %s",
+                           self.model_name, count, msg)
+        self._skipped_totals = {}
         logger.info("  %s unloaded", self.model_name)
 
     # Max long edge for inference (prevents OOM on CPU with high-res images).
@@ -333,8 +342,7 @@ class PyIQAScorer:
                 msg = str(e)
                 skipped[msg] = skipped.get(msg, 0) + 1
                 scores.append(5.0)
-        for msg, count in skipped.items():
-            logger.warning("  %s skipped %d image(s): %s", self.model_name, count, msg)
+        self._record_skips(skipped)
         return scores
 
     def score_batch(self, images: list[Image.Image]) -> list[float]:
@@ -383,9 +391,14 @@ class PyIQAScorer:
                         scores[i] = 5.0
                 logger.debug("  %s batch group fell back to serial: %s", self.model_name, msg)
 
-        for msg, count in skipped.items():
-            logger.warning("  %s skipped %d image(s): %s", self.model_name, count, msg)
+        self._record_skips(skipped)
         return [float(s) for s in scores]
+
+    def _record_skips(self, skipped: dict):
+        """Fold this batch's skips into the pass total, logging only at DEBUG."""
+        for msg, count in skipped.items():
+            self._skipped_totals[msg] = self._skipped_totals.get(msg, 0) + count
+            logger.debug("  %s skipped %d image(s): %s", self.model_name, count, msg)
 
     @property
     def vram_gb(self) -> float:


### PR DESCRIPTION
## The problem

A scan's output is mostly other people's logging, and what remains gets chewed up by the progress bar. From tonight's real scan log:

```
Multi-pass processing: 12%|█▏ | 57/468 [03:07<22:50, 3.33s/it]2026-08-11 21:35:31 INFO [fa
```

The timestamp is landing *inside* the bar's own line.

## Four sources, four seams

| Source | Why it was loud | Fix |
|---|---|---|
| HF hub weight bars | `HF_HUB_DISABLE_PROGRESS_BARS` was explicitly `"0"` — **bars on**. Multi-pass reloads models between passes, so `Loading weights: 100% … Materializing param=…` redrew hundreds of times per run | set to `"1"`; downloads are logged separately so nothing is hidden |
| `open_clip` | Logs with bare `logging.info()` through the **root** logger, so there is no name to quiet | raise root's own level (see below) |
| `timm`, `pyiqa` | One line per weight fetch / per network built, per model, per pass | `WARNING`, with `matplotlib`/`PIL`/`urllib3` |
| `topiq_nr_face skipped N image(s)` | **Ours.** The model declines every photo without a face — expected, not exceptional — but it logged a `WARNING` per *batch*: one every few seconds on a landscape-heavy scan | accumulate per pass, `DEBUG` per batch, one summary on `unload()` |

### The root-logger detail

`open_clip` can't be silenced by name, and raising the root level naively would mute Facet too. It doesn't, because **a logger's level gates only what is logged directly to it** — records propagating up from `facet` still reach root's handlers. That requires our own trees to carry an explicit level instead of inheriting root's, and it's `api` as well as `facet`: `api/*` modules name their loggers after `__name__`, and the CLI does reach into them (`api.routers.burst_culling`).

### The progress bar

Log records now emit via `tqdm.write`, which clears the bar, writes the line, and redraws. Falls back to plain `StreamHandler` behaviour if tqdm isn't importable.

## Verification

Replaying exactly the lines tonight's scan produced:

```
--- surviving output ---
    INFO  [facet] KEEP facet info
    INFO  [facet.scorer] KEEP facet.scorer info
    INFO  [facet.models] KEEP facet.models info
    INFO  [api.routers.burst_culling] KEEP api info
    WARNING [facet.pyiqa] KEEP facet warning
    WARNING [timm] KEEP third-party WARNING
    ERROR [root] KEEP root error

third-party INFO leaked : none
facet/api lines lost    : none
```

Third-party `WARNING`/`ERROR` still surface — only INFO chatter is dropped. The tqdm handler is asserted to route through `tqdm.write` and to keep the record when tqdm is absent.

`test_scan.py`, `test_device.py`, `test_extended_iqa_scorers.py`, `test_multi_pass.py`, `test_multi_pass_pyiqa.py`: **146 passed, 8 skipped**. `ruff check facet.py models/ tests/` clean.

## Deliberately not done

The MediaPipe `Failed to send to clearcut` telemetry line (once a minute) is emitted by C++/absl straight to stderr, so no Python logging filter can catch it. The only lever is `GLOG_minloglevel`, and since the line is logged at ERROR level, suppressing it means `minloglevel=3` — which would also hide genuine MediaPipe failures. Left visible on purpose.
