### PR TITLE
fix(tagger): skip embeddings from another image tower instead of aborting

### DIFF
--- a/models/tagger.py
+++ b/models/tagger.py
@@ -6,8 +6,11 @@ similarity to predefined tag vocabulary.
 """
 
 
+import logging
+
 from utils import bytes_to_embedding
 
+logger = logging.getLogger("facet.tagger")
 
 _tokenizer_cache = {}
 
@@ -84,6 +87,9 @@ class CLIPTagger:
         self.backend = backend
         self.text_embeddings = None
         self.tag_names = None
+        # Rows whose stored embedding came from a different image tower. Counted
+        # rather than logged per photo: a library can hold thousands of them.
+        self.skipped_dim_mismatch = 0
 
         # Load vocabulary from config
         self._load_vocabulary()
@@ -146,10 +152,31 @@ class CLIPTagger:
         if self.text_embeddings is None or clip_embedding_bytes is None:
             return []
 
+        embedding = bytes_to_embedding(clip_embedding_bytes)
+
+        # A library outlives the profile that filled it: switching vram_profile
+        # swaps the image tower (CLIP 768 <-> SigLIP 1152) while rows written by
+        # the previous one stay exactly as they were. This tagger's text tower
+        # matches only the active profile, so a row from the other one cannot be
+        # scored against it. Unguarded, that matmul raised a bare shape
+        # RuntimeError that killed the caller's entire pass -- a scan's whole
+        # post-processing tail, tagging through vec population -- rather than
+        # skipping the one photo it could not tag. Checked before the tensor is
+        # built, so a row being discarded never costs a device copy.
+        expected_dim = self.text_embeddings.shape[-1]
+        if len(embedding) != expected_dim:
+            self.skipped_dim_mismatch += 1
+            if self.skipped_dim_mismatch == 1:
+                logger.warning(
+                    "Skipping photos whose stored embedding is %d-dim: this tagger's text "
+                    "tower is %d-dim. Re-embed them under the active profile "
+                    "(--recompute-embeddings) to have them tagged.",
+                    len(embedding), expected_dim)
+            return []
+
         import torch
 
         # Convert bytes back to tensor, matching text_embeddings dtype
-        embedding = bytes_to_embedding(clip_embedding_bytes)
         image_features = torch.tensor(embedding).unsqueeze(0).to(self.device)
         image_features = image_features.to(self.text_embeddings.dtype)
 

--- a/tag_existing.py
+++ b/tag_existing.py
@@ -62,6 +62,11 @@ def tag_untagged_photos(db_path, tagger, threshold=0.22, max_tags=5, verbose=Fal
                     logger.info("  %s: %s", row['filename'], tags_str)
 
         conn.commit()
+        skipped = getattr(tagger, 'skipped_dim_mismatch', 0)
+        if skipped:
+            logger.warning(
+                "%d photo(s) skipped: their stored embedding does not match this "
+                "tagger's text tower. They stay untagged until re-embedded.", skipped)
         return tagged_count
 
 

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -167,3 +167,92 @@ class TestResolveScanTagger:
 
         assert result is built
         build.assert_called_once_with(cfg, device="cuda")
+
+
+# ---------------------------------------------------------------------------
+# 4. Mixed embedding dimensions must not abort the pass
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingDimensionMismatch:
+    """A library outlives the profile that filled it.
+
+    Switching ``vram_profile`` swaps the image tower (CLIP 768 <-> SigLIP 1152)
+    while rows written by the previous one stay as they were. Scoring such a row
+    against the active profile's text tower used to raise a bare
+    ``RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x1152 and
+    768x449)``, which killed the caller: on a real 129k library that took out a
+    scan's entire post-processing tail -- tagging, moment detection, junk
+    detection and vec population -- because 836 rows from an old test batch
+    carried the other tower's embeddings.
+    """
+
+    @staticmethod
+    def _tagger(text_dim=768, tags=8):
+        """A tagger whose text tower is `text_dim` wide.
+
+        Deliberately torch-free: the guard reads ``text_embeddings.shape`` and
+        the length of the decoded embedding, both of which numpy provides, so
+        the mismatch path can be exercised on CI, which installs no torch. Only
+        the matching case reaches the matmul, and that test skips accordingly.
+        """
+        import numpy as np
+
+        from models.tagger import CLIPTagger
+
+        tagger = CLIPTagger.__new__(CLIPTagger)
+        tagger.device = "cpu"
+        tagger.text_embeddings = np.ones((tags, text_dim), dtype=np.float32)
+        tagger.tag_names = [f"tag{i}" for i in range(tags)]
+        tagger.skipped_dim_mismatch = 0
+        return tagger
+
+    @staticmethod
+    def _embedding(dim):
+        import struct
+
+        return struct.pack(f"{dim}f", *([0.1] * dim))
+
+    def test_matching_dimension_still_tags(self):
+        """The only case that reaches the matmul, so the only one needing torch."""
+        torch = pytest.importorskip("torch")
+
+        tagger = self._tagger()
+        tagger.text_embeddings = torch.ones((8, 768), dtype=torch.float32)
+        tags = tagger.get_tags_from_embedding(self._embedding(768), threshold=-1e9, max_tags=3)
+        assert tags
+        assert tagger.skipped_dim_mismatch == 0
+
+    def test_mismatched_dimension_is_skipped_not_raised(self):
+        tagger = self._tagger()
+        assert tagger.get_tags_from_embedding(self._embedding(1152), threshold=-1e9) == []
+        assert tagger.skipped_dim_mismatch == 1
+
+    def test_a_mismatch_does_not_abort_the_rest_of_the_run(self):
+        """The regression itself: one bad row must not cost every later row.
+
+        Needs torch because the matched rows go all the way through the matmul,
+        which is the point -- they must still be tagged after the bad one.
+        """
+        torch = pytest.importorskip("torch")
+
+        tagger = self._tagger()
+        tagger.text_embeddings = torch.ones((8, 768), dtype=torch.float32)
+        embeddings = [self._embedding(768), self._embedding(1152), self._embedding(768)]
+        tagged = sum(
+            1 for e in embeddings
+            if tagger.get_tags_from_embedding(e, threshold=-1e9, max_tags=1)
+        )
+        assert tagged == 2
+        assert tagger.skipped_dim_mismatch == 1
+
+    def test_mismatches_are_counted_not_logged_per_photo(self, caplog):
+        """836 of them in the library that found this; one warning, not 836."""
+        import logging
+
+        tagger = self._tagger()
+        with caplog.at_level(logging.WARNING, logger="facet.tagger"):
+            for _ in range(50):
+                tagger.get_tags_from_embedding(self._embedding(1152))
+
+        assert tagger.skipped_dim_mismatch == 50
+        assert len([r for r in caplog.records if "1152-dim" in r.getMessage()]) == 1


### PR DESCRIPTION
## What happened

A scan finished scoring 468 photos successfully, then died in its post-processing tail:

```
File "D:\photo-llm\facet.py", line 1475, in _run_scan
    tagged = run_tagging(scorer.db_path, tagger, scorer.config)
File "D:\photo-llm\models\tagger.py", line 158, in get_tags_from_embedding
    similarities = (image_features @ self.text_embeddings.T).squeeze(0)
RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x1152 and 768x449)
```

## Why

A library outlives the profile that filled it. Switching `vram_profile` swaps the image tower — CLIP 768 ↔ SigLIP 1152 — while rows written by the previous one stay exactly as they were. `get_tags_from_embedding` scored every row against the active profile's text tower with **no dimension check**.

The exception wasn't contained anywhere. `tag_untagged_photos` selects every untagged row that has an embedding, so on a 129k library holding **836 rows from an old SigLIP test batch**, one of them took down the entire tail:

| Stage | Ran? |
|---|---|
| Scoring (468 photos) | ✅ `scan_runs` completed |
| Bursts / brackets / panoramas | ✅ 20,576 groups, 226 bracket sets, 247 panorama sets |
| **Tagging** | ❌ crashed here |
| **Moment detection** | ❌ never reached |
| **Junk detection** | ❌ never reached |
| **Vec population** | ❌ never reached |

2,274 freshly scanned photos were left with no tags, no narrative moment and no junk verdict — and nothing in the output explained why beyond a bare shape mismatch.

The function's own docstring already advertised `768 or 1152 floats` as input while the matmul assumed a single width, which is roughly how this survived.

## The fix

Check the dimension before the matmul. A mismatched row is skipped and counted; the first one explains itself and names the way out:

```
Skipping photos whose stored embedding is 1152-dim: this tagger's text tower is
768-dim. Re-embed them under the active profile (--recompute-embeddings) to have
them tagged.
```

Counted rather than logged per photo — there can be thousands — and `tag_untagged_photos` reports the total when it finishes.

## Tests

`TestEmbeddingDimensionMismatch` in `tests/test_tagging.py` covers the matching case, the skip, the running total, the single-warning behaviour, and the regression proper:

```python
def test_a_mismatch_does_not_abort_the_rest_of_the_run(self):
    """The regression itself: one bad row must not cost every later row."""
```

`tests/test_tagging.py`, `test_scan.py`, `test_device.py`: **125 passed, 8 skipped**. `ruff check models/ tests/ tag_existing.py` clean.
