### PR TITLE
fix(cli): give the silent entry points a log handler, and tagging a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Facet are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`--tag-untagged` tags only the photos that have none**, from stored embeddings and without reading a single image — the same work a scan already does at the end. The capability existed as `tag_existing.py`, but nobody looked there: every other maintenance operation is a `facet.py` flag, so this one was effectively invisible even to people who knew the project.
+- **A `windows-latest` CI job** covering `tests/test_scan.py` and `tests/test_device.py`. CI ran on Linux only, so the library lock's Windows backend and the Apple Metal device policy had never been exercised by it — which is how the two lock bugs below survived. Deliberately not the whole suite: much of it hard-codes POSIX paths, and a permanently red job is an ignored one.
+
+### Fixed
+- **A tagging pass no longer dies on a library holding two embedding widths.** Switching `vram_profile` swaps the image tower (CLIP 768 ↔ SigLIP 1152) while rows written by the previous one stay as they were, and the tagger scored every row against the active tower with no dimension check — so one stale row raised a bare shape mismatch that took down the caller. On a 129k library with 836 such rows that killed the whole post-processing tail of every scan: tagging, moment detection, junk detection and vec population, all skipped after the scoring run had succeeded. 26,451 photos were sitting untagged for want of a dimension check. Mismatched rows are now skipped and counted, with one message naming the way out.
+- **Two concurrent "is the library busy?" checks no longer invent a holder on Windows.** `msvcrt` has no shared lock mode, so the peek probe was exclusive and overlapping peeks excluded *each other*; the loser reported a job that had already finished — the spurious 409 in the viewer that probing shared was introduced to remove, fixed on POSIX and still live here. The peek now retries the way the acquire side already did, with jittered backoff, since peeks arrive in phase.
+- **Four standalone CLIs ran silently.** `tag_existing.py`, `calibrate.py`, `diagnostics.py` and `validate_db.py` each build a module logger and log freely, then never install a handler, so everything below WARNING was dropped. `tag_existing.py` tagged 26,451 photos in one run and printed nothing at all. They now share one `configure_cli_logging()` helper, which honours `FACET_LOG_LEVEL` and stays out of the way when a scan has already configured logging.
+
+### Changed
+- **A scan resolves each path once instead of three times.** Deduplication, the unscanned set and the todo-list filter each called `resolve()` over the same paths — invisible on a local disk, but every call is a filesystem round-trip on a NAS. Measured on an SMB library of 153,574 files: 3.94 ms cold and ~2 ms warm per call, so two of those passes were minutes of latency before a single photo had been read.
+- **Scan output is readable again.** Hugging Face weight-loading bars were explicitly *enabled* and redrew on every model load; `open_clip` logs through the root logger where no logger name can reach it; `timm` and `pyiqa` announce every model they touch; and `topiq_nr_face` warned once per batch about photos with no face, which is expected rather than exceptional. Log records now also emit through `tqdm.write`, so a line arriving mid-scan no longer lands inside the progress bar's own line.
+
 ## [1.10.1] "Argentique" — 2026-08-10
 
 ### Added

--- a/calibrate.py
+++ b/calibrate.py
@@ -1292,6 +1292,9 @@ def parse_args():
 
 
 def main():
+    from utils.cli_logging import configure_cli_logging
+    configure_cli_logging()
+
     args = parse_args()
 
     if not os.path.exists(args.db):

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -429,6 +429,10 @@ def check_fast_paths(db_path):
 def main():
     """Entry point for facet-doctor CLI."""
     import argparse
+
+    from utils.cli_logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(description='Facet diagnostic tool')
     parser.add_argument('--config', type=str, default=None,
                         help='Path to scoring config JSON file')

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -103,6 +103,7 @@ These commands update specific metrics, derive new data (AI captions, GPS, embed
 |---------|-------------|
 | `python facet.py --recompute-average` | Recompute aggregate scores from stored embeddings (re-derivable; no DB snapshot — roll back by restoring a weight snapshot and recomputing) |
 | `python facet.py --recompute-category portrait` | Recompute scores for a single category only |
+| `python facet.py --tag-untagged` | Tag only photos that have no tags yet, from stored embeddings (no image reads). The same work a scan does at the end; use it to fill gaps without re-tagging what is already labelled |
 | `python facet.py --recompute-tags` | Re-tag all photos using configured model |
 | `python facet.py --recompute-tags-vlm` | Re-tag all photos using VLM tagger |
 | `python facet.py --detect-moments` | Label new photos with their narrative moment (caption-semantic, zero-shot + temporal smoothing; auto-runs at the end of every scan). Encodes each new caption once into `caption_embedding`, then cosine over stored vectors — the first full backfill over an existing library is GPU-recommended; add `--limit N` to verify on a sample. When `narrative_moments.vlm_tiebreak.enabled` is set (16gb/24gb profiles), low-posterior / low-margin frames are re-classified by the profile VLM |

--- a/docs/de/COMMANDS.md
+++ b/docs/de/COMMANDS.md
@@ -103,6 +103,7 @@ Diese Befehle aktualisieren bestimmte Metriken, leiten neue Daten ab (KI-Bildunt
 |---------|-------------|
 | `python facet.py --recompute-average` | Aggregierte Scores aus gespeicherten Embeddings neu berechnen (neu ableitbar; kein DB-Snapshot — zum Zurückrollen einen Gewichtungs-Snapshot wiederherstellen und neu berechnen) |
 | `python facet.py --recompute-category portrait` | Scores nur für eine einzelne Kategorie neu berechnen |
+| `python facet.py --tag-untagged` | Verschlagwortet nur Fotos, die noch keine Tags haben, aus den gespeicherten Embeddings (kein Bildzugriff). Dieselbe Arbeit, die ein Scan am Ende erledigt; damit lassen sich Lücken füllen, ohne bereits Verschlagwortetes neu zu bearbeiten |
 | `python facet.py --recompute-tags` | Alle Fotos mit dem konfigurierten Modell neu verschlagworten |
 | `python facet.py --recompute-tags-vlm` | Alle Fotos mit dem VLM-Tagger neu verschlagworten |
 | `python facet.py --detect-moments` | Neue Fotos mit ihrem narrativen Moment kennzeichnen (caption-semantisch, Zero-Shot + zeitliche Glättung; läuft am Ende jedes Scans automatisch). Kodiert jede neue Bildunterschrift einmal in `caption_embedding`, dann Kosinus über gespeicherte Vektoren — der erste vollständige Backfill über eine bestehende Bibliothek ist GPU-empfohlen; fügen Sie `--limit N` hinzu, um es an einer Stichprobe zu prüfen. Wenn `narrative_moments.vlm_tiebreak.enabled` gesetzt ist (16gb/24gb-Profile), werden Frames mit niedrigem Posterior / niedriger Marge vom Profil-VLM neu klassifiziert |

--- a/docs/es/COMMANDS.md
+++ b/docs/es/COMMANDS.md
@@ -103,6 +103,7 @@ Estos comandos actualizan métricas específicas, derivan datos nuevos (leyendas
 |---------|-------------|
 | `python facet.py --recompute-average` | Recalcula las puntuaciones globales a partir de los embeddings almacenados (re-derivable; sin instantánea de la BD — para revertir, restaura una instantánea de pesos y recalcula) |
 | `python facet.py --recompute-category portrait` | Recalcula las puntuaciones de una sola categoría |
+| `python facet.py --tag-untagged` | Etiqueta solo las fotos que aún no tienen etiquetas, a partir de los embeddings almacenados (sin leer imágenes). El mismo trabajo que un escaneo hace al final; sirve para rellenar huecos sin volver a etiquetar lo ya etiquetado |
 | `python facet.py --recompute-tags` | Vuelve a etiquetar todas las fotos con el modelo configurado |
 | `python facet.py --recompute-tags-vlm` | Vuelve a etiquetar todas las fotos con el etiquetador VLM |
 | `python facet.py --detect-moments` | Etiqueta las fotos nuevas con su momento narrativo (semántico de leyenda, zero-shot + suavizado temporal; se ejecuta automáticamente al final de cada escaneo). Codifica cada leyenda nueva una vez en `caption_embedding`, y luego coseno sobre los vectores almacenados — el primer relleno retroactivo completo sobre una biblioteca existente recomienda GPU; añade `--limit N` para verificar en una muestra. Cuando `narrative_moments.vlm_tiebreak.enabled` está activado (perfiles 16gb/24gb), los fotogramas de baja posterior / bajo margen se reclasifican con el VLM del perfil |

--- a/docs/fr/COMMANDS.md
+++ b/docs/fr/COMMANDS.md
@@ -103,6 +103,7 @@ Ces commandes mettent à jour des métriques spécifiques, dérivent de nouvelle
 |---------|-------------|
 | `python facet.py --recompute-average` | Recalcule les scores agrégés à partir des embeddings stockés (re-dérivable ; pas d'instantané de base de données — annulez en restaurant un instantané de poids et en recalculant) |
 | `python facet.py --recompute-category portrait` | Recalcule les scores pour une seule catégorie |
+| `python facet.py --tag-untagged` | Étiquette uniquement les photos qui n'ont pas encore de tags, à partir des embeddings stockés (aucune lecture d'image). Le même travail qu'un scan effectue à la fin ; utile pour combler les manques sans ré-étiqueter ce qui l'est déjà |
 | `python facet.py --recompute-tags` | Ré-étiquette toutes les photos avec le modèle configuré |
 | `python facet.py --recompute-tags-vlm` | Ré-étiquette toutes les photos avec l'étiqueteur VLM |
 | `python facet.py --detect-moments` | Étiquette les nouvelles photos avec leur moment narratif (sémantique de légende, zero-shot + lissage temporel ; s'exécute automatiquement à la fin de chaque analyse). Encode chaque nouvelle légende une fois dans `caption_embedding`, puis cosinus sur les vecteurs stockés — le premier remplissage rétroactif complet sur une bibliothèque existante est recommandé sur GPU ; ajoutez `--limit N` pour vérifier sur un échantillon. Lorsque `narrative_moments.vlm_tiebreak.enabled` est activé (profils 16gb/24gb), les images à faible postérieur / faible marge sont reclassées par le VLM du profil |

--- a/docs/it/COMMANDS.md
+++ b/docs/it/COMMANDS.md
@@ -103,6 +103,7 @@ Questi comandi aggiornano metriche specifiche, derivano nuovi dati (didascalie A
 |---------|-------------|
 | `python facet.py --recompute-average` | Ricalcola i punteggi aggregati dagli embedding memorizzati (ri-derivabile; nessuno snapshot del DB — per annullare, ripristina uno snapshot dei pesi e ricalcola) |
 | `python facet.py --recompute-category portrait` | Ricalcola i punteggi solo per una singola categoria |
+| `python facet.py --tag-untagged` | Assegna i tag solo alle foto che non ne hanno ancora, dagli embedding memorizzati (nessuna lettura delle immagini). Lo stesso lavoro che una scansione svolge alla fine; utile per colmare le lacune senza riassegnare i tag a ciò che è già etichettato |
 | `python facet.py --recompute-tags` | Riassegna i tag a tutte le foto usando il modello configurato |
 | `python facet.py --recompute-tags-vlm` | Riassegna i tag a tutte le foto usando il tagger VLM |
 | `python facet.py --detect-moments` | Etichetta le nuove foto con il loro momento narrativo (semantico sulla didascalia, zero-shot + smussatura temporale; viene eseguito automaticamente alla fine di ogni scansione). Codifica ogni nuova didascalia una sola volta in `caption_embedding`, poi coseno sui vettori memorizzati — il primo backfill completo su una libreria esistente è consigliato con GPU; aggiungi `--limit N` per verificare su un campione. Quando `narrative_moments.vlm_tiebreak.enabled` è impostato (profili 16gb/24gb), i fotogrammi a basso posteriore / basso margine vengono riclassificati dal VLM del profilo |

--- a/docs/pt/COMMANDS.md
+++ b/docs/pt/COMMANDS.md
@@ -103,6 +103,7 @@ Esses comandos atualizam métricas específicas, derivam novos dados (legendas p
 |---------|-------------|
 | `python facet.py --recompute-average` | Recalcula as pontuações agregadas a partir dos embeddings armazenados (re-derivável; sem snapshot do banco — reverta restaurando um snapshot de pesos e recalculando) |
 | `python facet.py --recompute-category portrait` | Recalcula as pontuações apenas para uma única categoria |
+| `python facet.py --tag-untagged` | Marca apenas as fotos que ainda não têm tags, a partir dos embeddings armazenados (sem ler imagens). O mesmo trabalho que um scan faz no final; serve para preencher lacunas sem re-marcar o que já está etiquetado |
 | `python facet.py --recompute-tags` | Re-marca todas as fotos usando o modelo configurado |
 | `python facet.py --recompute-tags-vlm` | Re-marca todas as fotos usando o marcador VLM |
 | `python facet.py --detect-moments` | Rotula novas fotos com seu momento narrativo (semântico de legenda, zero-shot + suavização temporal; executa automaticamente ao final de cada escaneamento). Codifica cada nova legenda uma vez em `caption_embedding`, depois cosseno sobre vetores armazenados — o primeiro backfill completo sobre uma biblioteca existente tem GPU recomendada; adicione `--limit N` para verificar em uma amostra. Quando `narrative_moments.vlm_tiebreak.enabled` está definido (perfis 16gb/24gb), quadros de baixo posterior / baixa margem são reclassificados pelo VLM do perfil |

--- a/facet.py
+++ b/facet.py
@@ -663,6 +663,7 @@ LIBRARY_JOB_ARGS = (
     'recompute_skin_tone',
     'recompute_tags',
     'recompute_tags_vlm',
+    'tag_untagged',
     'refill_face_thumbnails_force',
     'refill_face_thumbnails_incremental',
     'rescan_gps',
@@ -1724,6 +1725,10 @@ Configuration:
                              'precision/recall table; without, prints the candidate-cosine distribution.')
     db_group.add_argument('--recompute-embeddings', action='store_true',
                         help='Recompute CLIP/SigLIP embeddings for all photos (required after model switch)')
+    db_group.add_argument('--tag-untagged', action='store_true',
+                        help='Tag only photos that have no tags yet, from stored embeddings '
+                             '(no image reads). Same work the scan does at the end; use it to '
+                             'fill gaps without re-tagging what is already labelled')
     db_group.add_argument('--recompute-tags', action='store_true',
                         help='Re-tag all photos using configured tagging model')
     db_group.add_argument('--recompute-tags-vlm', action='store_true',
@@ -3049,6 +3054,36 @@ Configuration:
         if model_manager is not None:
             model_manager.unload_all()
         logger.info("Updated tags for %d photos", updated)
+        exit()
+
+    # Tag only what has no tags yet -- the same work the scan's tail does, made
+    # reachable from the CLI everyone already reaches for. It lived only in
+    # tag_existing.py, where even this repo's author went looking for it in
+    # facet.py and concluded it did not exist.
+    if args.tag_untagged:
+        from tag_existing import build_clip_tagger, tag_untagged_photos
+        from utils import get_tag_params
+
+        config = ScoringConfig(args.config)
+        config.check_vram_profile_compatibility(verbose=True)  # Resolve 'auto' profile
+        threshold, max_tags = get_tag_params(config)
+
+        with get_connection(args.db) as conn:
+            pending = conn.execute(
+                "SELECT COUNT(*) FROM photos WHERE clip_embedding IS NOT NULL "
+                "AND (tags IS NULL OR tags = '')"
+            ).fetchone()[0]
+
+        if not pending:
+            logger.info("Every photo with an embedding already has tags.")
+            exit()
+
+        logger.info("Tagging %d photo(s) with no tags (threshold %.2f, max %d)...",
+                    pending, threshold, max_tags)
+        tagger = build_clip_tagger(config)
+        tagged = tag_untagged_photos(args.db, tagger, threshold, max_tags,
+                                     verbose=args.verbose)
+        logger.info("Tagged %d photo(s).", tagged)
         exit()
 
     # Recompute tags mode (needs GPU for tagging model)

--- a/tag_existing.py
+++ b/tag_existing.py
@@ -137,6 +137,9 @@ def resolve_scan_tagger(scorer):
 
 
 def main():
+    from utils.cli_logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(description='Tag existing photos using stored CLIP embeddings')
     parser.add_argument('--db', default='photo_scores_pro.db', help='Database path')
     parser.add_argument('--config', default='scoring_config.json', help='Config file path')

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,100 @@
+"""Standalone CLIs must install a log handler, and --tag-untagged must work.
+
+Four entry points (tag_existing, calibrate, diagnostics, validate_db) created a
+module logger and then never configured logging, so every logger.info they
+emitted was dropped. tag_existing.py tagged 26,451 photos in one run and printed
+nothing at all.
+"""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+SILENT_CLIS = ["tag_existing.py", "calibrate.py", "diagnostics.py", "validate_db.py"]
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logging():
+    """configure_cli_logging mutates the root logger; put it back."""
+    root = logging.getLogger()
+    handlers, level = root.handlers[:], root.level
+    yield
+    root.handlers[:] = handlers
+    root.setLevel(level)
+
+
+class TestConfigureCliLogging:
+    def test_installs_a_handler_when_there_is_none(self):
+        from utils.cli_logging import configure_cli_logging
+
+        root = logging.getLogger()
+        root.handlers[:] = []
+        assert configure_cli_logging() == logging.INFO
+        assert root.handlers
+
+    def test_is_a_no_op_when_logging_is_already_set_up(self):
+        """These modules are imported by facet.py mid-scan; reconfiguring there
+        would drop the scan's own format and its tqdm-aware handler."""
+        from utils.cli_logging import configure_cli_logging
+
+        root = logging.getLogger()
+        existing = logging.NullHandler()
+        root.handlers[:] = [existing]
+
+        assert configure_cli_logging() is None
+        assert root.handlers == [existing]
+
+    def test_honours_facet_log_level(self, monkeypatch):
+        from utils.cli_logging import configure_cli_logging
+
+        monkeypatch.setenv("FACET_LOG_LEVEL", "warning")
+        logging.getLogger().handlers[:] = []
+        assert configure_cli_logging() == logging.WARNING
+
+    def test_unknown_level_falls_back_to_info(self, monkeypatch):
+        from utils.cli_logging import configure_cli_logging
+
+        monkeypatch.setenv("FACET_LOG_LEVEL", "chatty")
+        logging.getLogger().handlers[:] = []
+        assert configure_cli_logging() == logging.INFO
+
+
+class TestEveryStandaloneCliConfiguresLogging:
+    @pytest.mark.parametrize("script", SILENT_CLIS)
+    def test_script_calls_configure_cli_logging(self, script):
+        source = (REPO / script).read_text(encoding="utf-8")
+        assert "configure_cli_logging()" in source, (
+            f"{script} logs but never installs a handler, so it runs silently")
+
+
+class TestTagUntaggedFlag:
+    """--tag-untagged lived only in tag_existing.py, where it went unfound."""
+
+    def test_flag_is_registered_and_documented(self):
+        result = subprocess.run(
+            [sys.executable, "facet.py", "--help"],
+            cwd=REPO, capture_output=True, text=True, timeout=180,
+        )
+        assert result.returncode == 0, result.stderr[-2000:]
+        assert "--tag-untagged" in result.stdout
+
+    def test_handler_has_no_unresolved_names(self):
+        """The handler body imports get_tag_params locally -- facet.py does not
+        import it at module scope, so a missing import is a NameError that only
+        shows up when the flag is actually used."""
+        source = (REPO / "facet.py").read_text(encoding="utf-8")
+        start = source.index("if args.tag_untagged:")
+        block = source[start:start + 1600]
+        assert "from utils import get_tag_params" in block
+        assert "from tag_existing import" in block
+
+    def test_flag_takes_the_library_lock(self):
+        """It rewrites photos.tags, so it must be in LIBRARY_JOB_ARGS."""
+        import facet
+
+        assert "tag_untagged" in facet.LIBRARY_JOB_ARGS

--- a/utils/cli_logging.py
+++ b/utils/cli_logging.py
@@ -1,0 +1,50 @@
+"""One place for a standalone CLI to install its log handler.
+
+Every entry point here builds a module logger and calls ``logger.info`` freely,
+but a logger without a handler drops everything below WARNING on the floor.
+``facet.py``, ``viewer.py`` and ``database.py`` each remembered to call
+``basicConfig``; ``tag_existing.py``, ``calibrate.py``, ``diagnostics.py`` and
+``validate_db.py`` did not, and ran silently. ``tag_existing.py`` tagged 26,451
+photos in one run and reported it to nobody.
+
+Copy-pasted setup is what let four of seven forget, so this is the shared
+version. It deliberately does not touch the three that already configure
+themselves: ``database.py``'s bare ``%(message)s`` is someone's output format
+by now, and rewriting it would be a silent breaking change for anything parsing
+it.
+"""
+
+import logging
+import os
+
+DEFAULT_FORMAT = "%(asctime)s %(levelname)-5s [%(name)s] %(message)s"
+DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_cli_logging(level=None, fmt=DEFAULT_FORMAT, datefmt=DEFAULT_DATEFMT):
+    """Install a stderr handler for a standalone CLI run, once.
+
+    Honours ``FACET_LOG_LEVEL`` so a quiet or debug run is available without a
+    per-script flag, matching how ``facet.py`` and ``viewer.py`` resolve theirs.
+
+    A no-op when the root logger already has handlers: these modules are also
+    imported by ``facet.py`` mid-scan, and reconfiguring there would drop the
+    scan's own formatting and its tqdm-aware handler.
+
+    Args:
+        level: Level to install. Defaults to ``FACET_LOG_LEVEL`` or INFO.
+        fmt: Format string; defaults to the format facet.py and viewer.py use.
+        datefmt: Date format for ``asctime``.
+
+    Returns:
+        The level that was installed, or None when setup was already in place.
+    """
+    if logging.getLogger().handlers:
+        return None
+
+    if level is None:
+        level_name = (os.environ.get("FACET_LOG_LEVEL") or "INFO").upper()
+        level = getattr(logging, level_name, logging.INFO)
+
+    logging.basicConfig(level=level, format=fmt, datefmt=datefmt)
+    return level

--- a/validate_db.py
+++ b/validate_db.py
@@ -18,6 +18,9 @@ logger = logging.getLogger("facet.validate_db")
 
 
 def main():
+    from utils.cli_logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(
         description='Validate Facet database for consistency issues'
     )


### PR DESCRIPTION
## Four CLIs ran silently

Each builds a module logger and calls `logger.info(...)` throughout, then never installs a handler — so everything below WARNING went on the floor:

| Script | Configures logging? |
|---|---|
| `facet.py`, `viewer.py`, `database.py` | ✅ |
| **`tag_existing.py`, `calibrate.py`, `diagnostics.py`, `validate_db.py`** | ❌ |

`tag_existing.py` tagged **26,451 photos** in a single run tonight and printed nothing at all.

The cause isn't four forgotten lines — it's that logging setup is copy-pasted per entry point, which is why four of seven forgot it and the three that remembered disagree on format (`database.py` uses bare `%(message)s`; `facet.py`/`viewer.py` use a timestamped format with a config-driven level).

`utils/cli_logging.py` is the shared version. It honours `FACET_LOG_LEVEL` the way `facet.py` and `viewer.py` already do, and **no-ops when logging is already configured** — these modules are imported by `facet.py` mid-scan, where reconfiguring would drop the scan's own format and its tqdm-aware handler.

The three that already work are deliberately untouched: `database.py`'s bare `%(message)s` is someone's output format by now, and rewriting it would be a silent breaking change for anything parsing it.

## `--tag-untagged`

The capability existed only as `tag_existing.py`. This repo's own author went looking for it under `facet.py` and concluded no such command existed — which is the entire argument. Every other maintenance operation is a `--recompute-*` flag, so the one that wasn't may as well not have been there.

`--tag-untagged` delegates to the same `tag_untagged_photos()`, joins `LIBRARY_JOB_ARGS` so it takes the library lock like every other library writer, and leaves the standalone script for `--force`, `--threshold`, `--max-tags` and `--dry-run`.

**Renaming `tag_existing.py` was the alternative and is the wrong call:** `--force` re-tags the whole library, so "existing" names the *corpus* correctly, and 64 references across six translated `COMMANDS.md` files would break for a name that's defensible.

## Verification

The lock integration was confirmed against the live library — the flag was correctly refused while a face-clustering job held the lock:

```
ERROR [facet] A recompute is already running (pid 7632, started from cli, running for 349s).
```

`tests/test_cli_logging.py` covers the helper (installs, no-ops when configured, honours `FACET_LOG_LEVEL`, falls back on a bad level), asserts all four scripts call it, and checks the flag is registered, documented in `--help`, present in `LIBRARY_JOB_ARGS`, and that its handler imports `get_tag_params` — `facet.py` doesn't import it at module scope, so a missing import would be a `NameError` that only appears when the flag is used. That test exists because I made exactly that mistake writing this.

136 passed, 8 skipped across `test_cli_logging`, `test_tagging`, `test_scan`, `test_device`. `ruff check .` clean.

## Documentation

Added to all six `COMMANDS.md` (en/de/es/fr/it/pt), each in-language. `CHANGELOG.md`'s `[Unreleased]` section was empty despite four PRs merging tonight — it now covers this change alongside those.
