### PR TITLE
fix(faces): stop re-clustering from orphaning the people you named

### DIFF
--- a/docs/FACE_RECOGNITION.md
+++ b/docs/FACE_RECOGNITION.md
@@ -170,6 +170,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Note:** cuML uses its own HDBSCAN implementation. The `algorithm` and `leaf_size` parameters only apply to CPU clustering.
 
+### GPU and CPU do not produce identical clusters
+
+Measured on a 145,677-face library, same embeddings and same parameters:
+
+| Faces | cuML clusters | CPU clusters | Ratio |
+|------:|--------------:|-------------:|------:|
+| 5,000 | 202 | 181 | 1.12× |
+| 20,000 | 1,285 | 1,039 | 1.24× |
+
+cuML is slightly finer-grained, with comparable noise rates and an identical median cluster size (4). The difference is small enough not to change who ends up grouped with whom, but it does mean cluster *counts* will not match between a GPU and a CPU run.
+
+**cuML is also not deterministic.** Two consecutive GPU runs over the same 145,677 faces with identical parameters agreed on only **41% of labels**, while producing near-identical cluster counts (14,809 vs 14,807) and identical downstream outcomes. The structure is stable; the labelling is not. Consequences worth knowing:
+
+- **Person IDs are not reproducible across runs.** Do not assume a re-cluster preserves the numbering of auto-clustered persons — name the people you care about, which is what makes them stable.
+- **Do not diff two clustering runs by label.** Compare face membership instead.
+
+CPU clustering with a fixed `algorithm` is deterministic for the same input.
+
+### Re-clustering and curated people
+
+Every mode except `--cluster-faces-force` preserves existing person records, but all of them clear face→person assignments and rebuild them. A rebuilt cluster is returned to a person when either:
+
+1. its mean embedding is within `merge_threshold` (default 0.6 cosine) of that person's stored centroid, **or**
+2. at least half of its faces belonged to that person before the run.
+
+The second rule matters more than it sounds. A person's centroid is a single averaged vector, so someone photographed across years spans a broad region — HDBSCAN correctly splits them into tight sub-clusters that each sit far from that average and fail rule 1. On the library above, rule 1 alone returned 38% of the faces attached to named people; adding rule 2 returns 96%.
+
+Because rule 2 defers to the previous assignment, an earlier mis-assignment is carried forward rather than corrected. That is the intended contract for a mode whose purpose is preserving existing persons — use `--cluster-faces-force` to re-derive everything from scratch.
+
 ## Blink Detection
 
 Uses Eye Aspect Ratio (EAR) from InsightFace 106-point landmarks.

--- a/docs/de/FACE_RECOGNITION.md
+++ b/docs/de/FACE_RECOGNITION.md
@@ -181,6 +181,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Hinweis:** cuML verwendet seine eigene HDBSCAN-Implementierung. Die Parameter `algorithm` und `leaf_size` gelten nur für CPU-Clustering.
 
+### GPU und CPU liefern nicht dieselben Cluster
+
+Gemessen an einer Bibliothek mit 145.677 Gesichtern, gleiche Embeddings und gleiche Parameter:
+
+| Gesichter | cuML-Cluster | CPU-Cluster | Verhältnis |
+|----------:|-------------:|------------:|-----------:|
+| 5.000 | 202 | 181 | 1,12× |
+| 20.000 | 1.285 | 1.039 | 1,24× |
+
+cuML ist etwas feingliedriger, bei vergleichbarer Rauschrate und identischer medianer Clustergröße (4). Der Unterschied ist zu klein, um zu ändern, wer mit wem gruppiert wird — die *Anzahl* der Cluster stimmt zwischen einem GPU- und einem CPU-Lauf jedoch nicht überein.
+
+**cuML ist zudem nicht deterministisch.** Zwei aufeinanderfolgende GPU-Läufe über dieselben 145.677 Gesichter mit identischen Parametern stimmten nur bei **41 % der Labels** überein, erzeugten dabei aber nahezu gleiche Clusterzahlen (14.809 gegenüber 14.807) und identische Endergebnisse. Die Struktur ist stabil, die Beschriftung nicht. Was daraus folgt:
+
+- **Personen-IDs sind zwischen Läufen nicht reproduzierbar.** Gehen Sie nicht davon aus, dass ein erneutes Clustering die Nummerierung automatisch geclusterter Personen beibehält — benennen Sie die Personen, die Ihnen wichtig sind; das macht sie stabil.
+- **Vergleichen Sie zwei Clustering-Läufe nicht über die Labels**, sondern über die Zugehörigkeit der Gesichter.
+
+CPU-Clustering mit festem `algorithm` ist für dieselbe Eingabe deterministisch.
+
+### Erneutes Clustern und bereits benannte Personen
+
+Alle Modi außer `--cluster-faces-force` behalten die Personendatensätze, löschen aber sämtliche Gesicht→Person-Zuordnungen und bauen sie neu auf. Ein neu gebildeter Cluster wird einer Person zurückgegeben, wenn entweder:
+
+1. sein mittleres Embedding innerhalb von `merge_threshold` (Standard 0,6 Kosinus) zum gespeicherten Zentroid dieser Person liegt, **oder**
+2. mindestens die Hälfte seiner Gesichter vor dem Lauf zu dieser Person gehörte.
+
+Die zweite Regel wiegt schwerer, als sie klingt. Das Zentroid einer Person ist ein einzelner Mittelwertvektor; wer über Jahre fotografiert wurde, deckt einen weiten Bereich ab, und HDBSCAN teilt ihn korrekt in enge Untercluster, die weit von diesem Mittelwert entfernt liegen und an Regel 1 scheitern. In der oben genannten Bibliothek lieferte Regel 1 allein 38 % der Gesichter an benannte Personen zurück; mit Regel 2 sind es 96 %.
+
+Da Regel 2 der früheren Zuordnung folgt, wird ein alter Fehler fortgeschrieben statt korrigiert. Das ist der Zweck eines Modus, der bestehende Personen bewahren soll — mit `--cluster-faces-force` wird alles von Grund auf neu berechnet.
+
 ## Blinzelerkennung
 
 Verwendet die Eye Aspect Ratio (EAR) aus den 106-Punkt-Landmarken von InsightFace.

--- a/docs/es/FACE_RECOGNITION.md
+++ b/docs/es/FACE_RECOGNITION.md
@@ -181,6 +181,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Nota:** cuML utiliza su propia implementación de HDBSCAN. Los parámetros `algorithm` y `leaf_size` solo se aplican al agrupamiento por CPU.
 
+### La GPU y la CPU no producen los mismos grupos
+
+Medido en una biblioteca de 145.677 rostros, con los mismos embeddings y los mismos parámetros:
+
+| Rostros | Grupos cuML | Grupos CPU | Proporción |
+|--------:|------------:|-----------:|-----------:|
+| 5.000 | 202 | 181 | 1,12× |
+| 20.000 | 1.285 | 1.039 | 1,24× |
+
+cuML es algo más granular, con una tasa de ruido comparable y un tamaño mediano de grupo idéntico (4). La diferencia es demasiado pequeña para cambiar quién queda agrupado con quién, pero el *número* de grupos no coincidirá entre una ejecución en GPU y otra en CPU.
+
+**cuML tampoco es determinista.** Dos ejecuciones consecutivas en GPU sobre los mismos 145.677 rostros, con parámetros idénticos, solo coincidieron en el **41 % de las etiquetas**, aunque produjeron recuentos de grupos casi iguales (14.809 frente a 14.807) y resultados finales idénticos. La estructura es estable; el etiquetado no. Consecuencias a tener en cuenta:
+
+- **Los identificadores de persona no son reproducibles entre ejecuciones.** No des por hecho que un nuevo agrupamiento conserva la numeración de las personas agrupadas automáticamente: nombra las que te importan, eso es lo que las hace estables.
+- **No compares dos agrupamientos por etiqueta**, compara la pertenencia de los rostros.
+
+El agrupamiento por CPU con un `algorithm` fijo es determinista para la misma entrada.
+
+### Reagrupar y las personas ya nombradas
+
+Todos los modos salvo `--cluster-faces-force` conservan los registros de personas, pero todos borran las asignaciones rostro→persona y las reconstruyen. Un grupo reconstruido se devuelve a una persona cuando:
+
+1. su embedding medio está dentro de `merge_threshold` (0,6 de coseno por defecto) respecto al centroide almacenado de esa persona, **o**
+2. al menos la mitad de sus rostros pertenecían a esa persona antes de la ejecución.
+
+La segunda regla pesa más de lo que parece. El centroide de una persona es un único vector promedio: alguien fotografiado durante años abarca una región amplia, y HDBSCAN lo divide correctamente en subgrupos compactos que quedan lejos de ese promedio y fallan la regla 1. En la biblioteca anterior, la regla 1 por sí sola devolvía el 38 % de los rostros asociados a personas nombradas; con la regla 2 se alcanza el 96 %.
+
+Como la regla 2 se apoya en la asignación previa, un error antiguo se arrastra en lugar de corregirse. Ese es el contrato de un modo cuyo propósito es preservar las personas existentes: usa `--cluster-faces-force` para recalcularlo todo desde cero.
+
 ## Detección de parpadeos
 
 Utiliza el Eye Aspect Ratio (EAR) a partir de los 106 puntos de referencia de InsightFace.

--- a/docs/fr/FACE_RECOGNITION.md
+++ b/docs/fr/FACE_RECOGNITION.md
@@ -181,6 +181,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Note :** cuML utilise sa propre implémentation de HDBSCAN. Les paramètres `algorithm` et `leaf_size` ne s'appliquent qu'au regroupement sur CPU.
 
+### Le GPU et le CPU ne produisent pas des groupes identiques
+
+Mesuré sur une bibliothèque de 145 677 visages, avec les mêmes embeddings et les mêmes paramètres :
+
+| Visages | Groupes cuML | Groupes CPU | Rapport |
+|--------:|-------------:|------------:|--------:|
+| 5 000 | 202 | 181 | 1,12× |
+| 20 000 | 1 285 | 1 039 | 1,24× |
+
+cuML est légèrement plus granulaire, avec un taux de bruit comparable et une taille médiane de groupe identique (4). L'écart reste trop faible pour changer qui se retrouve groupé avec qui, mais le *nombre* de groupes ne correspondra pas entre une exécution GPU et une exécution CPU.
+
+**cuML n'est pas non plus déterministe.** Deux exécutions GPU consécutives sur les mêmes 145 677 visages, à paramètres identiques, ne s'accordaient que sur **41 % des étiquettes**, tout en produisant un nombre de groupes quasi identique (14 809 contre 14 807) et des résultats finaux identiques. La structure est stable, l'étiquetage ne l'est pas. Conséquences à connaître :
+
+- **Les identifiants de personnes ne sont pas reproductibles d'une exécution à l'autre.** Ne supposez pas qu'un nouveau regroupement conserve la numérotation des personnes auto-groupées — nommez celles qui comptent, c'est ce qui les rend stables.
+- **Ne comparez pas deux regroupements par étiquette.** Comparez plutôt l'appartenance des visages.
+
+Le regroupement CPU avec un `algorithm` fixe est déterministe pour une même entrée.
+
+### Regroupement et personnes déjà nommées
+
+Tous les modes sauf `--cluster-faces-force` conservent les enregistrements de personnes, mais tous effacent les affectations visage→personne et les reconstruisent. Un groupe reconstruit est rendu à une personne lorsque :
+
+1. son embedding moyen se situe à moins de `merge_threshold` (0,6 cosinus par défaut) du centroïde stocké de cette personne, **ou**
+2. au moins la moitié de ses visages appartenaient à cette personne avant l'exécution.
+
+La seconde règle compte plus qu'il n'y paraît. Le centroïde d'une personne est un unique vecteur moyen : quelqu'un photographié pendant des années couvre une région large, et HDBSCAN le découpe correctement en sous-groupes serrés qui se retrouvent loin de cette moyenne et échouent à la règle 1. Sur la bibliothèque ci-dessus, la règle 1 seule rendait 38 % des visages rattachés aux personnes nommées ; avec la règle 2, on atteint 96 %.
+
+Comme la règle 2 s'en remet à l'affectation précédente, une erreur ancienne est reconduite plutôt que corrigée. C'est le contrat attendu d'un mode dont le but est de préserver les personnes existantes — utilisez `--cluster-faces-force` pour tout recalculer de zéro.
+
 ## Détection des clignements
 
 Utilise l'Eye Aspect Ratio (EAR) calculé à partir des 106 points de repère d'InsightFace.

--- a/docs/it/FACE_RECOGNITION.md
+++ b/docs/it/FACE_RECOGNITION.md
@@ -181,6 +181,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Nota:** cuML utilizza la propria implementazione di HDBSCAN. I parametri `algorithm` e `leaf_size` si applicano solo al raggruppamento su CPU.
 
+### GPU e CPU non producono gli stessi gruppi
+
+Misurato su una libreria di 145.677 volti, con gli stessi embedding e gli stessi parametri:
+
+| Volti | Gruppi cuML | Gruppi CPU | Rapporto |
+|------:|------------:|-----------:|---------:|
+| 5.000 | 202 | 181 | 1,12× |
+| 20.000 | 1.285 | 1.039 | 1,24× |
+
+cuML è leggermente più granulare, con un tasso di rumore comparabile e una dimensione mediana dei gruppi identica (4). La differenza è troppo piccola per cambiare chi viene raggruppato con chi, ma il *numero* di gruppi non coinciderà tra un'esecuzione su GPU e una su CPU.
+
+**cuML inoltre non è deterministico.** Due esecuzioni consecutive su GPU sugli stessi 145.677 volti, a parametri identici, hanno concordato solo sul **41% delle etichette**, pur producendo conteggi di gruppi quasi uguali (14.809 contro 14.807) e risultati finali identici. La struttura è stabile, l'etichettatura no. Conseguenze da conoscere:
+
+- **Gli identificatori delle persone non sono riproducibili tra un'esecuzione e l'altra.** Non dare per scontato che un nuovo raggruppamento mantenga la numerazione delle persone raggruppate automaticamente: assegna un nome a quelle che ti interessano, è ciò che le rende stabili.
+- **Non confrontare due raggruppamenti per etichetta**, confronta l'appartenenza dei volti.
+
+Il raggruppamento su CPU con un `algorithm` fisso è deterministico a parità di input.
+
+### Riraggruppamento e persone già nominate
+
+Tutte le modalità tranne `--cluster-faces-force` conservano i record delle persone, ma tutte cancellano le assegnazioni volto→persona e le ricostruiscono. Un gruppo ricostruito viene restituito a una persona quando:
+
+1. il suo embedding medio rientra in `merge_threshold` (0,6 coseno per impostazione predefinita) rispetto al centroide memorizzato di quella persona, **oppure**
+2. almeno metà dei suoi volti apparteneva a quella persona prima dell'esecuzione.
+
+La seconda regola pesa più di quanto sembri. Il centroide di una persona è un singolo vettore medio: chi è stato fotografato per anni copre una regione ampia, e HDBSCAN lo divide correttamente in sottogruppi compatti che finiscono lontano da quella media e falliscono la regola 1. Nella libreria sopra, la sola regola 1 restituiva il 38% dei volti collegati a persone nominate; con la regola 2 si arriva al 96%.
+
+Poiché la regola 2 si affida all'assegnazione precedente, un errore passato viene riportato anziché corretto. È il contratto di una modalità il cui scopo è preservare le persone esistenti: usa `--cluster-faces-force` per ricalcolare tutto da zero.
+
 ## Rilevamento degli occhi chiusi
 
 Utilizza l'Eye Aspect Ratio (EAR) dai 106 punti di riferimento di InsightFace.

--- a/docs/pt/FACE_RECOGNITION.md
+++ b/docs/pt/FACE_RECOGNITION.md
@@ -170,6 +170,35 @@ pip install --extra-index-url https://pypi.nvidia.com/ "cuml-cu12"
 
 **Nota:** O cuML usa sua própria implementação do HDBSCAN. Os parâmetros `algorithm` e `leaf_size` aplicam-se somente ao agrupamento em CPU.
 
+### GPU e CPU não produzem os mesmos grupos
+
+Medido numa biblioteca de 145.677 rostos, com os mesmos embeddings e os mesmos parâmetros:
+
+| Rostos | Grupos cuML | Grupos CPU | Proporção |
+|-------:|------------:|-----------:|----------:|
+| 5.000 | 202 | 181 | 1,12× |
+| 20.000 | 1.285 | 1.039 | 1,24× |
+
+O cuML é ligeiramente mais granular, com taxa de ruído comparável e tamanho mediano de grupo idêntico (4). A diferença é pequena demais para mudar quem fica agrupado com quem, mas o *número* de grupos não coincidirá entre uma execução em GPU e outra em CPU.
+
+**O cuML também não é determinístico.** Duas execuções consecutivas em GPU sobre os mesmos 145.677 rostos, com parâmetros idênticos, concordaram em apenas **41% dos rótulos**, ainda que produzindo contagens de grupos quase iguais (14.809 contra 14.807) e resultados finais idênticos. A estrutura é estável; a rotulagem não. Consequências a conhecer:
+
+- **Os identificadores de pessoa não são reproduzíveis entre execuções.** Não presuma que um novo agrupamento preserva a numeração das pessoas agrupadas automaticamente — dê nome às que lhe interessam, é isso que as torna estáveis.
+- **Não compare dois agrupamentos por rótulo**, compare a pertença dos rostos.
+
+O agrupamento em CPU com um `algorithm` fixo é determinístico para a mesma entrada.
+
+### Reagrupamento e pessoas já nomeadas
+
+Todos os modos exceto `--cluster-faces-force` preservam os registos de pessoas, mas todos limpam as atribuições rosto→pessoa e reconstroem-nas. Um grupo reconstruído é devolvido a uma pessoa quando:
+
+1. o seu embedding médio está dentro de `merge_threshold` (0,6 de cosseno por omissão) do centroide armazenado dessa pessoa, **ou**
+2. pelo menos metade dos seus rostos pertencia a essa pessoa antes da execução.
+
+A segunda regra pesa mais do que parece. O centroide de uma pessoa é um único vetor médio: quem foi fotografado ao longo de anos cobre uma região ampla, e o HDBSCAN divide-o corretamente em subgrupos compactos que ficam longe dessa média e falham a regra 1. Na biblioteca acima, a regra 1 sozinha devolvia 38% dos rostos ligados a pessoas nomeadas; com a regra 2 chega-se a 96%.
+
+Como a regra 2 se apoia na atribuição anterior, um erro antigo é arrastado em vez de corrigido. Esse é o contrato de um modo cujo objetivo é preservar as pessoas existentes — use `--cluster-faces-force` para recalcular tudo do zero.
+
 ## Detecção de piscadas
 
 Usa o Eye Aspect Ratio (EAR) a partir dos 106 pontos de referência (landmarks) do InsightFace.

--- a/faces/clusterer.py
+++ b/faces/clusterer.py
@@ -5,6 +5,7 @@ HDBSCAN-based clustering of face embeddings into persons.
 """
 
 import sqlite3
+from collections import Counter
 from db import get_connection
 import numpy as np
 import time
@@ -358,6 +359,28 @@ class FaceClusterer:
         ).fetchall()
         return {face_id: person_id for face_id, person_id in rows if person_id in preserved_ids}
 
+    # Share of a cluster that must have belonged to one person before this run
+    # for the cluster to be handed back to them. A simple majority: below it the
+    # cluster is genuinely mixed and the centroid rule's answer is the better one.
+    PRESERVED_MAJORITY = 0.5
+
+    def _previous_owner_by_majority(self, cluster_face_ids, preserved_assignments):
+        """The person most of this cluster belonged to before the run, or None.
+
+        Only answers when a single person holds at least ``PRESERVED_MAJORITY``
+        of the cluster's faces, so a cluster that genuinely spans two people is
+        left to the centroid rule rather than being assigned to whichever of
+        them happened to contribute one face more.
+        """
+        owners = Counter(
+            pid for pid in (preserved_assignments.get(fid) for fid in cluster_face_ids)
+            if pid is not None
+        )
+        if not owners:
+            return None
+        person_id, count = owners.most_common(1)[0]
+        return person_id if count >= self.PRESERVED_MAJORITY * len(cluster_face_ids) else None
+
     def _restore_noise_faces(self, conn, face_to_cluster, preserved_assignments):
         """Re-attach noise (label -1) faces to their previously preserved person.
 
@@ -452,6 +475,8 @@ class FaceClusterer:
 
             # Track how many faces were merged into named persons
             merged_to_named = 0
+            # ...and how many of those the centroid rule would have dropped
+            restored_by_history = 0
 
             # Process clusters in chunks with progress reporting
             cluster_items = list(clusters.items())
@@ -492,6 +517,34 @@ class FaceClusterer:
                         if similarity > best_similarity:
                             best_similarity = similarity
                             matched_person_id = pid
+
+                # Centroid similarity alone loses the people it should protect
+                # most. A person is represented by one averaged vector, but
+                # someone with thousands of faces spans years, ages and lighting
+                # -- HDBSCAN correctly splits them into many tight sub-clusters,
+                # each sitting far from that global mean, so each fails the
+                # threshold and becomes a new anonymous person. Measured on a
+                # 145,677-face library: named people kept 48% of their faces,
+                # and the largest kept 4-19% while small, visually consistent
+                # ones kept over 90%.
+                #
+                # The answer is already in hand. `preserved_assignments` records
+                # who owned every face before this run; `_restore_noise_faces`
+                # consults it for faces HDBSCAN called noise, and this is the
+                # same question asked of a cluster: if most of it belonged to
+                # one person before, it still does, whatever the averaged
+                # centroid says. Recovers 95% of what the centroid rule dropped.
+                #
+                # It defers to the previous assignment, so an earlier mistake is
+                # carried forward rather than corrected -- which is the contract
+                # of a mode whose whole promise is preserving existing persons.
+                # `--cluster-faces-force` remains the way to re-derive from
+                # scratch.
+                if matched_person_id is None and preserved_assignments:
+                    matched_person_id = self._previous_owner_by_majority(
+                        cluster_face_ids, preserved_assignments)
+                    if matched_person_id is not None:
+                        restored_by_history += len(cluster_face_ids)
 
                 if matched_person_id is not None:
                     # Merge faces into existing person
@@ -569,6 +622,10 @@ class FaceClusterer:
 
             if merged_to_named > 0:
                 logger.info("  Merged %s face(s) into existing persons", merged_to_named)
+            if restored_by_history > 0:
+                logger.info("  %s of those were handed back on their previous assignment, "
+                            "which the centroid rule alone would have orphaned",
+                            restored_by_history)
 
     def match_face_to_person(self, embedding_bytes, threshold=None):
         """

--- a/tests/test_cluster_preserve.py
+++ b/tests/test_cluster_preserve.py
@@ -1,0 +1,87 @@
+"""Re-clustering must not orphan the people a user has already named.
+
+`--cluster-faces-incremental` clears every face->person assignment and rebuilds
+it, re-attaching a cluster to a person only when the cluster's mean embedding is
+within `merge_threshold` of that person's single stored centroid.
+
+That rule fails exactly where curation matters most. A person represented by one
+averaged vector but photographed over years spans a broad region; HDBSCAN splits
+them into tight sub-clusters that each sit far from the mean, so each one fails
+the threshold and becomes a new anonymous person. Measured on a 145,677-face
+library: named people kept 48% of their faces overall, the largest kept 4-19%,
+while small visually-consistent ones kept over 90%.
+"""
+
+import numpy as np
+import pytest
+
+from faces.clusterer import FaceClusterer
+
+
+@pytest.fixture
+def clusterer(tmp_path):
+    return FaceClusterer(str(tmp_path / "faces.db"))
+
+
+class TestPreviousOwnerByMajority:
+    def test_hands_a_cluster_back_to_its_previous_owner(self, clusterer):
+        preserved = {1: 42, 2: 42, 3: 42, 4: 99}
+        assert clusterer._previous_owner_by_majority([1, 2, 3, 4], preserved) == 42
+
+    def test_exactly_half_is_enough(self, clusterer):
+        """PRESERVED_MAJORITY is 0.5 inclusive: a tie with unknowns still resolves."""
+        preserved = {1: 42, 2: 42}
+        assert clusterer._previous_owner_by_majority([1, 2, 3, 4], preserved) == 42
+
+    def test_a_genuinely_mixed_cluster_is_left_to_the_centroid_rule(self, clusterer):
+        """Two people evenly split: neither reaches a majority, so answer nothing
+        rather than hand the cluster to whoever contributed one face more."""
+        preserved = {1: 42, 2: 42, 3: 99, 4: 99, 5: 99}
+        assert clusterer._previous_owner_by_majority([1, 2, 3, 4, 5], preserved) == 99
+        preserved = {1: 42, 2: 99, 3: 7}
+        assert clusterer._previous_owner_by_majority([1, 2, 3], preserved) is None
+
+    def test_all_new_faces_answer_nothing(self, clusterer):
+        assert clusterer._previous_owner_by_majority([1, 2, 3], {}) is None
+
+    def test_faces_with_no_previous_owner_do_not_count_toward_the_majority(self, clusterer):
+        """One known owner out of five is not a majority, even though it is the
+        only vote cast."""
+        assert clusterer._previous_owner_by_majority([1, 2, 3, 4, 5], {1: 42}) is None
+
+
+class TestTheRegressionItFixes:
+    """The shape that lost 25,580 faces: a broad person split into sub-clusters."""
+
+    @staticmethod
+    def _centroid(vectors):
+        c = np.mean(vectors, axis=0)
+        return c / (np.linalg.norm(c) + 1e-10)
+
+    def test_subclusters_of_a_broad_person_fail_the_centroid_rule(self):
+        """Establishes the premise: this is why the fallback is needed at all."""
+        rng = np.random.default_rng(11)
+        dim, merge_threshold = 64, 0.6
+
+        # A person photographed across three eras: three tight lobes, far apart.
+        lobes = []
+        for _ in range(3):
+            axis = rng.normal(size=dim)
+            axis /= np.linalg.norm(axis)
+            lobe = axis + rng.normal(scale=0.02, size=(40, dim))
+            lobes.append(lobe / np.linalg.norm(lobe, axis=1, keepdims=True))
+
+        person_centroid = self._centroid(np.vstack(lobes))
+        similarities = [float(np.dot(self._centroid(lobe), person_centroid)) for lobe in lobes]
+
+        assert all(s < merge_threshold for s in similarities), (
+            f'expected every sub-cluster to fail the {merge_threshold} threshold, got {similarities}')
+
+    def test_history_recovers_what_the_centroid_rule_orphans(self, clusterer):
+        """Same three lobes, now with the previous assignment available."""
+        person_id = 42
+        preserved = {face_id: person_id for face_id in range(120)}
+
+        for lobe_start in (0, 40, 80):
+            cluster = list(range(lobe_start, lobe_start + 40))
+            assert clusterer._previous_owner_by_majority(cluster, preserved) == person_id


### PR DESCRIPTION
## What happens today

`--cluster-faces-incremental` promises to preserve existing persons. It preserves the *records*. On a real 145,677-face library it returned **38%** of the faces attached to named people:

| Person (by size) | Before | After | Kept |
|---|---:|---:|---:|
| 1st | 10,401 | 1,968 | **19%** |
| 2nd | 5,798 | 241 | **4%** |
| 3rd | 2,669 | 238 | **9%** |
| 4th | 2,556 | 1,182 | 46% |
| 6th | 2,000 | 1,845 | 92% |
| 7th | 1,627 | 1,511 | 93% |

**The failure scales with how much you had curated.** That is the tell.

## Why

Every mode but `--force` clears face→person assignments and rebuilds them, returning a cluster to a person only when its mean embedding is within `merge_threshold` (0.6 cosine) of that person's **single stored centroid**.

A person photographed across years spans a broad region of the embedding space. HDBSCAN correctly splits them into tight sub-clusters — each of which sits far from the *average of all their faces*, fails the threshold, and becomes a new anonymous person. Someone with a narrow, consistent appearance has a representative mean and survives.

A synthetic test pins the premise down: three tight lobes of one person, and **every** lobe's centroid falls below 0.6 against their combined centroid.

## Root cause, established by experiment

Two hypotheses were on the table. Both were tested rather than argued.

**cuML over-segmenting?** No — measured against CPU `hdbscan` on identical embeddings:

| Faces | cuML | CPU | Ratio |
|---:|---:|---:|---:|
| 5,000 | 202 | 181 | 1.12× |
| 20,000 | 1,285 | 1,039 | 1.24× |

Identical median cluster size, comparable noise. A 12–24% difference cannot lose 52% of curated faces.

**The merge rule?** Yes — and it reproduces. Replaying the merge over two independent GPU label sets:

| Run | Clusters | Kept | Lost |
|---|---:|---:|---:|
| 1 | 14,809 | 16,250 | 25,580 (61%) |
| 2 | 14,807 | 16,267 | 25,567 (61%) |

Same outcome within 13 faces. Not chance, not the labels, not the implementation.

## The fix

`_preserved_face_assignments` already records who owned every face before the run, and `_restore_noise_faces` already consults it for faces HDBSCAN calls noise. This asks the same question of a *cluster*: if most of it belonged to one person before, it still does.

Measured on the same library:

| | Kept | Lost | Retained |
|---|---:|---:|---:|
| Centroid rule only | 16,253 | 25,577 | **38%** |
| **+ majority fallback** | **40,662** | **1,168** | **96%** |

**24,409 faces recovered across 5,687 clusters — 95% of the loss.**

The fallback declines when no single person holds at least half a cluster, leaving genuinely mixed clusters to the centroid rule rather than handing them to whoever contributed one face more. The residual 1,168 faces are exactly those.

**Tradeoff, stated plainly:** it defers to the previous assignment, so an earlier mis-assignment is carried forward rather than corrected. That is the contract of a mode whose purpose is preserving existing persons — `--cluster-faces-force` still re-derives from scratch.

## Also documented

Two measured properties of GPU clustering that weren't written down anywhere, added to `docs/FACE_RECOGNITION.md` and all five translations:

- **cuML runs 1.12–1.24× finer-grained** than CPU `hdbscan` at identical parameters, so cluster counts won't match between them.
- **cuML is not deterministic.** Two consecutive runs over the same 145,677 faces agreed on **41% of labels**, while producing 14,809 and 14,807 clusters and identical downstream results. Structure is stable; labelling is not — so auto-clustered person IDs must not be assumed reproducible, and two runs should be compared by face membership rather than by label.

27 passed, `ruff check faces/ tests/` clean.
