### PR TITLE
fix: full-project review sweep — 79 verified findings

### DIFF
--- a/analyzers/capsule_generator.py
+++ b/analyzers/capsule_generator.py
@@ -2198,7 +2198,7 @@ def _generate_dimension_capsules(conn, capsule_config, min_aggregate, vis, user_
                 "type": dim_name, "id": full_id,
                 "title_key": dim["title_key"],
                 "title_params": {dim["param_name"]: display},
-                "title": display,
+                "title": dim["title_tpl"].format(value=display),
                 "subtitle": f"{len(paths)} photos",
                 "cover_photo_path": _pick_cover_photo(paths, full_id, capsule_config=capsule_config),
                 "photo_count": len(paths), "icon": dim["icon"],

--- a/analyzers/capsule_generator.py
+++ b/analyzers/capsule_generator.py
@@ -1699,11 +1699,11 @@ def _generate_score_per_dim(conn, capsules, capsule_config, min_aggregate,
     try:
         group_rows = conn.execute(  # lgtm[py/sql-injection]
             f"""SELECT dim_val, dim_label, cnt, paths FROM (
-                SELECT {expr} AS dim_val, {label_expr} AS dim_label,
+                SELECT dim_val, dim_label,
                        COUNT(*) AS cnt,
                        GROUP_CONCAT(path, '||') AS paths
                 FROM (
-                    SELECT path, {expr}, {label_expr}
+                    SELECT path, {expr} AS dim_val, {label_expr} AS dim_label
                     FROM photos {join}
                     WHERE aggregate >= ? {extra_filter} AND {vis_sql}
                     ORDER BY {sort}
@@ -2154,11 +2154,11 @@ def _generate_dimension_capsules(conn, capsule_config, min_aggregate, vis, user_
         try:
             group_rows = conn.execute(  # lgtm[py/sql-injection]
                 f"""SELECT dim_val, dim_label, cnt, paths FROM (
-                    SELECT {sql_expr} AS dim_val, {label_expr} AS dim_label,
+                    SELECT dim_val, dim_label,
                            COUNT(*) AS cnt,
                            GROUP_CONCAT(path, '||') AS paths
                     FROM (
-                        SELECT path, {sql_expr}, {label_expr}
+                        SELECT path, {sql_expr} AS dim_val, {label_expr} AS dim_label
                         FROM photos {join}
                         WHERE aggregate >= ? {extra_filter} AND {vis_sql}
                         ORDER BY aggregate DESC

--- a/api/auth.py
+++ b/api/auth.py
@@ -20,7 +20,7 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from api.config import (
-    JWT_SECRET, JWT_ALGORITHM, JWT_EXPIRY_HOURS,
+    JWT_ALGORITHM, JWT_EXPIRY_HOURS,
     VIEWER_CONFIG,
     config_load_failed,
     is_multi_user_enabled
@@ -54,13 +54,19 @@ def password_generation(password_key: str) -> str:
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a JWT access token bound to the current password generations."""
+    # Read the secret through the module rather than the import-time bound
+    # name: reload_config() rebinds api.config.JWT_SECRET in place, and a
+    # snapshot taken at import time would keep signing with a rotated-out
+    # secret until process restart. Mirrors frame._secret().
+    from api import config
+
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + (expires_delta or timedelta(hours=JWT_EXPIRY_HOURS))
     to_encode['exp'] = expire
     to_encode['iat'] = datetime.now(timezone.utc)
     to_encode[VIEWER_GENERATION_CLAIM] = password_generation(VIEWER_PASSWORD_KEY)
     to_encode[EDITION_GENERATION_CLAIM] = password_generation(EDITION_PASSWORD_KEY)
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    return jwt.encode(to_encode, config.JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def _match_password_generations(payload: dict) -> Optional[dict]:
@@ -92,8 +98,10 @@ def decode_access_token(token: str) -> Optional[dict]:
     expiry alone cannot express "this password has since changed", and no token
     is revocable server-side otherwise.
     """
+    from api import config  # fresh read — see create_access_token
+
     try:
-        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        payload = jwt.decode(token, config.JWT_SECRET, algorithms=[JWT_ALGORITHM])
     except (jwt.InvalidTokenError, jwt.ExpiredSignatureError):
         return None
     return _match_password_generations(payload)

--- a/api/config.py
+++ b/api/config.py
@@ -151,19 +151,34 @@ def _load_and_ensure_share_secret():
     context or password-upgrade write can neither lose this secret nor be lost
     under it. Writes atomically via temp file + rename to avoid partial writes.
 
-    A config that exists but does not parse gets an ephemeral in-memory secret
-    and is never rewritten: persisting a share_secret-only stub over a partial
-    or corrupt file would destroy the whole config (and its .backup with it).
+    The secret is always persisted, never kept in memory only: with
+    ``--workers>1`` each process runs this independently, and an in-memory-only
+    secret would mint a different key per worker, so a JWT signed by one is
+    rejected by the others at random. A genuinely absent config is a fresh,
+    never-configured install — it still needs a secret to boot, so one is
+    generated and written to a minimal new file. A config that EXISTS but does
+    not parse is different: minting a secret there would silently paper over a
+    broken file with the very same per-worker divergence, so that case fails
+    loudly instead of starting up half-working.
     """
-    config, _ = _read_config()
+    config, parsed_ok = _read_config()
     if 'share_secret' not in config or not config['share_secret']:
         with CONFIG_WRITE_LOCK:
             config, parsed_ok = _read_config()
             if 'share_secret' not in config or not config['share_secret']:
+                config_exists = os.path.exists(_CONFIG_PATH)
+                if config_exists and not parsed_ok:
+                    raise RuntimeError(
+                        f"{_CONFIG_PATH} exists but could not be parsed. Refusing to "
+                        "mint an in-memory-only share secret in that state: with "
+                        "--workers>1 each worker would mint its own, and JWTs signed "
+                        "by one would be rejected by the others. Fix or remove the "
+                        "file, then restart."
+                    )
                 config['share_secret'] = secrets.token_hex(32)
-                if parsed_ok:
+                if config_exists:
                     shutil.copy2(_CONFIG_PATH, f"{_CONFIG_PATH}.backup")
-                    atomic_write_json(_CONFIG_PATH, config)
+                atomic_write_json(_CONFIG_PATH, config)
     return config, config['share_secret']
 
 
@@ -332,16 +347,31 @@ def reload_config():
         JWT_SECRET = _share_secret
 
 
+def _prefix_boundary_match(path, prefix):
+    """True if ``path`` equals ``prefix`` or continues past it at a separator.
+
+    A bare ``startswith`` would let a configured prefix like ``/mnt/photos``
+    wrongly match ``/mnt/photos-backup``. Require the next character to be a
+    path separator, mirroring the ``+ os.sep`` boundary check in
+    ``api/path_validation.py``.
+    """
+    return (
+        path == prefix
+        or path.startswith(prefix + '/')
+        or path.startswith(prefix + '\\')
+    )
+
+
 def map_disk_path(db_path):
     """Map a database path to a local disk path using viewer.path_mapping config."""
     path_mapping = VIEWER_CONFIG.get('path_mapping', {})
     for prefix_from, prefix_to in path_mapping.items():
-        if db_path.startswith(prefix_from):
+        if _prefix_boundary_match(db_path, prefix_from):
             db_path = prefix_to + db_path[len(prefix_from):]
             break
         normalized = db_path.replace('\\', '/')
         prefix_normalized = prefix_from.replace('\\', '/')
-        if normalized.startswith(prefix_normalized):
+        if _prefix_boundary_match(normalized, prefix_normalized):
             db_path = prefix_to + normalized[len(prefix_normalized):]
             break
     return db_path.replace('\\', os.sep).replace('/', os.sep)

--- a/api/config_writes.py
+++ b/api/config_writes.py
@@ -257,7 +257,7 @@ def update_category_weights(config_path, category, snapshot_tag, get_db, *,
 
         backup_path = None
         if backup:
-            backup_path = _backup_config(config_path, prune=False)
+            backup_path = _backup_config(config_path)
 
         if weights is not None:
             if replace_weights:

--- a/api/db_helpers.py
+++ b/api/db_helpers.py
@@ -22,6 +22,7 @@ from api.config import (
     _photo_tags_available, _photo_tags_lock, PHOTO_TAGS_CACHE_TTL,
     _count_cache, _count_cache_lock, COUNT_CACHE_TTL,
     is_multi_user_enabled, get_user_directories, _FULL_CONFIG, VIEWER_CONFIG,
+    config_load_failed,
 )
 from api.database import get_db_connection
 from db import DEFAULT_DB_PATH
@@ -192,7 +193,9 @@ def hide_duplicates_sql(table_alias: str = '') -> str:
 HIDE_BLINKS_SQL = "(is_blink = 0 OR is_blink IS NULL)"
 HIDE_BURSTS_SQL = hide_bursts_sql()
 HIDE_DUPLICATES_SQL = hide_duplicates_sql()
-HIDDEN_BURST_SQL = "(is_burst_lead = 0 AND burst_group_id IS NOT NULL)"
+HIDDEN_BURST_SQL = (
+    "(is_burst_lead = 0 AND burst_group_id IS NOT NULL "
+    "AND (is_sequence_lead IS NULL OR is_sequence_lead = 0))")
 HIDDEN_DUPLICATE_SQL = "(is_duplicate_lead = 0 AND duplicate_group_id IS NOT NULL)"
 
 # Keep every ordinary photo plus the base exposure of each bracket. Deliberately
@@ -724,6 +727,41 @@ def repair_stale_representative(conn, person_id):
         )
 
 
+def recompute_person_centroid(conn, person_id):
+    """Recompute ``person_id``'s centroid from the mean of its faces' embeddings.
+
+    API-created persons (create / assign / split) and merge targets are stored
+    with a NULL centroid. Incremental re-clustering used to drop every person
+    with a NULL centroid from its preservation set, so on the next run
+    ``UPDATE faces SET person_id = NULL`` orphaned all their faces and the
+    cleanup then deleted the named person. Giving each touched person a real
+    centroid keeps them matchable.
+
+    Mirrors the clusterer's own centroid math: 512-dim float32 embeddings, each
+    L2-normalized, averaged, then renormalized. A person with no usable
+    embeddings has its centroid set to NULL (it is still preserved by the
+    history rule, never by centroid similarity).
+    """
+    import numpy as np
+    rows = conn.execute(
+        "SELECT embedding FROM faces WHERE person_id = ? AND embedding IS NOT NULL",
+        (person_id,),
+    ).fetchall()
+    embeddings = []
+    for row in rows:
+        emb = np.frombuffer(row[0], dtype=np.float32)
+        if len(emb) == 512:
+            embeddings.append(emb / (np.linalg.norm(emb) + 1e-10))
+    if not embeddings:
+        conn.execute("UPDATE persons SET centroid = NULL WHERE id = ?", (person_id,))
+        return
+    centroid = np.mean(embeddings, axis=0).astype(np.float32)
+    centroid = centroid / (np.linalg.norm(centroid) + 1e-10)
+    conn.execute(
+        "UPDATE persons SET centroid = ? WHERE id = ?", (centroid.tobytes(), person_id)
+    )
+
+
 def reassign_faces_to_person(conn, person_id, face_ids):
     """Reassign a set of faces to ``person_id``; auto-delete emptied old persons.
 
@@ -773,6 +811,11 @@ def reassign_faces_to_person(conn, person_id, face_ids):
             deleted_persons.append(old_id)
         else:
             repair_stale_representative(conn, old_id)
+            recompute_person_centroid(conn, old_id)
+
+    # Give the (possibly freshly-created) target a real centroid so incremental
+    # re-clustering preserves it instead of orphaning its faces.
+    recompute_person_centroid(conn, person_id)
 
     row = conn.execute(
         "SELECT face_count FROM persons WHERE id = ?", (person_id,)
@@ -870,8 +913,16 @@ def is_access_controlled_install():
     world-readable, so ownership must never deny access there. Shared by
     ``get_visibility_clause`` and the album-access check so both honour the same
     install-mode carve-out.
+
+    Mirrors ``api.auth._is_open_install``: an unparseable ``scoring_config.json``
+    yields an empty config carrying no password, which reads exactly like a
+    deliberately open install and would hand the whole library to anonymous
+    callers. Such an install is treated as access-controlled (fail closed) until
+    the config parses again.
     """
-    return is_multi_user_enabled() or bool(VIEWER_CONFIG.get('password', ''))
+    return (config_load_failed()
+            or is_multi_user_enabled()
+            or bool(VIEWER_CONFIG.get('password', '')))
 
 
 def get_visibility_clause(user_id, table_alias='photos'):
@@ -900,8 +951,14 @@ def get_visibility_clause(user_id, table_alias='photos'):
     params = []
     for d in all_dirs:
         prefix = d.rstrip('/\\') + '/'
-        conditions.append(f"{table_alias}.path LIKE ?")
-        params.append(prefix + '%')
+        # Escape LIKE wildcards so a directory containing % or _ can only match
+        # itself: an unescaped `_` matches any single character, so a user scoped
+        # to `.../a_b/` would also see `.../axb/` belonging to another user.
+        # Backslashes are escaped too (they stay literal path separators, not
+        # LIKE escapes) now that we declare ESCAPE. Mirrors folders.py.
+        escaped = prefix.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+        conditions.append(f"{table_alias}.path LIKE ? ESCAPE '\\'")
+        params.append(escaped + '%')
 
     return f"({' OR '.join(conditions)})", params
 

--- a/api/routers/albums.py
+++ b/api/routers/albums.py
@@ -84,7 +84,7 @@ def _check_album_access(conn, album_id, user_id):
     album = conn.execute("SELECT * FROM albums WHERE id = ?", (album_id,)).fetchone()
     if not album:
         raise HTTPException(status_code=404, detail="Album not found")
-    if is_access_controlled_install() and album['user_id'] and album['user_id'] != user_id:
+    if is_access_controlled_install() and album['user_id'] != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
     return album
 
@@ -96,7 +96,7 @@ async def _check_album_access_async(conn, album_id, user_id):
     await cur.close()
     if not album:
         raise HTTPException(status_code=404, detail="Album not found")
-    if is_access_controlled_install() and album['user_id'] and album['user_id'] != user_id:
+    if is_access_controlled_install() and album['user_id'] != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
     return album
 
@@ -408,6 +408,10 @@ def list_albums(
         if user_id:
             where_clauses.append("(user_id = ? OR user_id IS NULL)")
             params.append(user_id)
+        elif is_access_controlled_install():
+            # Anonymous on a locked/multi-user install must not enumerate every
+            # album's names, paths and smart-filter JSON — fail closed.
+            where_clauses.append("1=0")
         if search.strip():
             where_clauses.append("(name LIKE ? OR description LIKE ?)")
             params.extend([f"%{search.strip()}%", f"%{search.strip()}%"])

--- a/api/routers/albums.py
+++ b/api/routers/albums.py
@@ -1048,17 +1048,24 @@ def get_album_suggested_context(
 @router.post("/api/albums/{album_id}/share")
 def share_album(
     album_id: int,
+    rotate: bool = Query(False),
     user: CurrentUser = Depends(require_edition),
 ):
-    """Generate a share token for public album access."""
+    """Generate a share token for public album access.
+
+    Reuses the album's existing token so repeated calls return a stable link.
+    Pass ``?rotate=true`` to mint a fresh token, invalidating any link handed
+    out earlier — the operation users expect when revoking a leaked link.
+    """
     with get_db() as conn:
         user_id = _get_user_id(user)
         album = _check_album_access(conn, album_id, user_id)
-        # Reuse existing token if already shared, otherwise generate a new random one
-        try:
-            existing_token = album['share_token']
-        except (IndexError, KeyError):
-            existing_token = None
+        existing_token = None
+        if not rotate:
+            try:
+                existing_token = album['share_token']
+            except (IndexError, KeyError):
+                existing_token = None
         token = existing_token or secrets.token_urlsafe(32)
         conn.execute("UPDATE albums SET share_token = ? WHERE id = ?", (token, album_id))
         conn.commit()

--- a/api/routers/burst_culling.py
+++ b/api/routers/burst_culling.py
@@ -103,12 +103,12 @@ class CullingConfirmBody(BaseModel):
 
 
 class CullingFacesBody(BaseModel):
-    paths: list[str]
+    paths: list[str] = Field(max_length=1000)
     profile: Optional[str] = None
 
 
 class CullingSubjectsBody(BaseModel):
-    paths: list[str]
+    paths: list[str] = Field(max_length=1000)
 
 
 class KeeperHintsBody(BaseModel):
@@ -1198,16 +1198,16 @@ async def api_culling_group_faces(
 
     user_id = user.user_id if user else None
     vis_sql, vis_params = get_visibility_clause(user_id)
-    placeholders = ",".join("?" * len(paths))
     with get_db() as conn:
-        rows = conn.execute(
+        rows = list(select_in_chunks(
+            conn,
             f"SELECT photo_path, id, face_index, bbox_x1, bbox_y1, bbox_x2, bbox_y2, "
             f"confidence, landmark_2d_106, eyes_open_score, smile_score "
-            f"FROM faces WHERE photo_path IN ({placeholders}) "
+            f"FROM faces WHERE photo_path IN ({{placeholders}}) "
             f"AND photo_path IN (SELECT path FROM photos WHERE {vis_sql}) "
             f"ORDER BY photo_path, face_index",
-            paths + vis_params,
-        ).fetchall()
+            paths, after=vis_params,
+        ))
 
     row_data = [
         (r['photo_path'], r['id'], r['face_index'],
@@ -1325,13 +1325,13 @@ async def api_culling_group_subjects(
 
     user_id = user.user_id if user else None
     vis_sql, vis_params = get_visibility_clause(user_id)
-    placeholders = ",".join("?" * len(paths))
     with get_db() as conn:
-        rows = conn.execute(
+        rows = list(select_in_chunks(
+            conn,
             f"SELECT path, thumbnail, subject_bbox, subject_sharpness, subject_prominence "
-            f"FROM photos WHERE path IN ({placeholders}) AND {vis_sql}",
-            paths + vis_params,
-        ).fetchall()
+            f"FROM photos WHERE path IN ({{placeholders}}) AND {vis_sql}",
+            paths, after=vis_params,
+        ))
 
     row_data = [
         (row['path'], row['thumbnail'], row['subject_bbox'],

--- a/api/routers/comparison.py
+++ b/api/routers/comparison.py
@@ -490,7 +490,7 @@ async def api_update_weights(
 
 @router.get("/api/config/category_priorities")
 def api_get_category_priorities(
-    user: Optional[CurrentUser] = Depends(require_edition),
+    user: CurrentUser = Depends(require_edition),
 ):
     """List categories in current evaluation (priority) order."""
     from config import ScoringConfig
@@ -671,9 +671,14 @@ def api_comparison_photo_metrics(
 @router.get("/api/comparison/category_weights")
 def api_comparison_category_weights(
     category: Optional[str] = Query(None),
-    user: Optional[CurrentUser] = Depends(get_optional_user),
+    user: CurrentUser = Depends(require_edition),
 ):
-    """Get weights for a category (or all categories)."""
+    """Get weights for a category (or all categories).
+
+    Edition-gated like the rest of the ``/api/comparison/*`` tuning surface and
+    its write counterpart (``POST /api/config/update_weights``); the public
+    stats page reads weights through ``/api/stats/categories/weights`` instead.
+    """
     from config import ScoringConfig
 
     config = ScoringConfig(validate=False)
@@ -1451,9 +1456,13 @@ def api_weight_snapshots(
     category: Optional[str] = Query(None),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
-    user: Optional[CurrentUser] = Depends(get_optional_user),
+    user: CurrentUser = Depends(require_edition),
 ):
-    """List weight configuration snapshots (paginated for infinite scroll)."""
+    """List weight configuration snapshots (paginated for infinite scroll).
+
+    Edition-gated to match its write counterparts (save/restore/delete snapshot),
+    so the tuning history is not disclosed to anonymous callers.
+    """
     try:
         with get_db() as conn:
             where = "WHERE category = ?" if category else ""

--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -529,6 +529,10 @@ def api_cull_apply(
         state = _reject_state_map(conn, paths, user_id)
     matching = [p for p in paths if state.get(p) == want_rejected]
     excluded_by_state = sum(1 for p in paths if p in state and state[p] != want_rejected)
+    # Not in state at all: invisible to this user, or not in the DB. Not acted
+    # on either way, but distinct from excluded_by_state — surface it so the
+    # totals (matching + excluded_by_state + not_visible) reconcile with len(paths).
+    not_visible = sum(1 for p in paths if p not in state)
 
     items, skipped = _resolve_cull_files(matching, body.include_companions)
     files = [f for _, fs in items for f in fs]
@@ -537,7 +541,8 @@ def api_cull_apply(
         safe_target = _validate_target_dir_required(body.target_dir)
         if body.dry_run:
             return {"action": body.action, "dry_run": True, "would_copy": files,
-                    "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": []}
+                    "skipped": skipped, "excluded_by_state": excluded_by_state,
+                    "not_visible": not_visible, "errors": []}
         copied = errors = 0
         os.makedirs(safe_target, exist_ok=True)
         for src in files:
@@ -548,16 +553,19 @@ def api_cull_apply(
                 logger.exception("Failed to copy %s into %s", src, safe_target)
                 errors += 1
         return {"action": body.action, "dry_run": False, "copied": copied,
-                "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": errors}
+                "skipped": skipped, "excluded_by_state": excluded_by_state,
+                "not_visible": not_visible, "errors": errors}
 
     if body.action == "move_rejects":
         safe_target = _validate_target_dir_required(body.target_dir)
         if body.dry_run:
             return {"action": body.action, "dry_run": True, "would_move": files,
-                    "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": []}
+                    "skipped": skipped, "excluded_by_state": excluded_by_state,
+                    "not_visible": not_visible, "errors": []}
         moved, errors = _move_into(files, safe_target)
         return {"action": body.action, "dry_run": False, "moved": moved,
-                "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": errors}
+                "skipped": skipped, "excluded_by_state": excluded_by_state,
+                "not_visible": not_visible, "errors": errors}
 
     # trash_rejects
     if not (VIEWER_CONFIG.get("cull", {}) or {}).get("allow_trash", False):
@@ -569,7 +577,8 @@ def api_cull_apply(
         raise HTTPException(status_code=400, detail="send2trash is not installed")
     if body.dry_run:
         return {"action": body.action, "dry_run": True, "would_trash": files,
-                "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": []}
+                "skipped": skipped, "excluded_by_state": excluded_by_state,
+                "not_visible": not_visible, "errors": []}
     trashed = errors = 0
     for src in files:
         try:
@@ -579,7 +588,8 @@ def api_cull_apply(
             logger.exception("Failed to trash %s", src)
             errors += 1
     return {"action": body.action, "dry_run": False, "trashed": trashed,
-            "skipped": skipped, "excluded_by_state": excluded_by_state, "errors": errors}
+            "skipped": skipped, "excluded_by_state": excluded_by_state,
+            "not_visible": not_visible, "errors": errors}
 
 
 def _validate_target_dir_required(target_dir):

--- a/api/routers/faces.py
+++ b/api/routers/faces.py
@@ -194,6 +194,13 @@ def api_assign_all_faces(
         try:
             assert_photo_visible(conn, user.user_id if user else None, body.photo_path)
 
+            # faces.person_id has no FK, so a stale target id would strand the
+            # faces on a dangling person. Validate the target exists first.
+            if not conn.execute(
+                "SELECT 1 FROM persons WHERE id = ?", (body.person_id,)
+            ).fetchone():
+                raise HTTPException(status_code=404, detail="Target person not found")
+
             faces = conn.execute("""
                 SELECT id FROM faces WHERE photo_path = ? AND person_id IS NULL
             """, (body.photo_path,)).fetchall()
@@ -231,6 +238,11 @@ def api_unassign_person(
     """Unassign all faces of a specific person from a photo."""
     with get_db() as conn:
         try:
+            # A directory-scoped edition user must not detach faces on a photo
+            # outside their directories (and thereby empty/delete a person the
+            # global gallery still shows). Gate on photo visibility first.
+            assert_photo_visible(conn, user.user_id if user else None, body.photo_path)
+
             faces = conn.execute("""
                 SELECT id FROM faces
                 WHERE photo_path = ? AND person_id = ?
@@ -255,6 +267,10 @@ def api_unassign_person(
             if new_count and new_count[0] == 0:
                 conn.execute("DELETE FROM persons WHERE id = ?", (body.person_id,))
                 person_deleted = True
+            else:
+                # The detached faces may have included this person's stored
+                # representative; repoint it at a remaining face.
+                repair_stale_representative(conn, body.person_id)
 
             conn.commit()
 
@@ -263,6 +279,9 @@ def api_unassign_person(
                 'unassigned_count': len(faces),
                 'person_deleted': person_deleted
             }
+        except LookupError:
+            conn.rollback()
+            raise HTTPException(status_code=404, detail="No faces found")
         except HTTPException:
             raise
         except sqlite3.Error:

--- a/api/routers/filter_options.py
+++ b/api/routers/filter_options.py
@@ -22,10 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 def _vis_where(user: Optional[CurrentUser]):
-    """Return (where_fragment, params) for visibility filtering."""
-    if not user or not user.user_id:
-        return '', []
-    vis_sql, vis_params = get_visibility_clause(user.user_id)
+    """Return (where_fragment, params) for visibility filtering.
+
+    Returns ('', []) on a fully open install. On an access-controlled deployment
+    (multi-user, or a single-user viewer password) an unauthenticated request
+    resolves to (' AND 0=1', []) so it sees nothing; ``get_visibility_clause``
+    owns that carve-out, so this must never short-circuit before calling it.
+    """
+    user_id = user.user_id if user else None
+    vis_sql, vis_params = get_visibility_clause(user_id)
     if vis_sql == '1=1':
         return '', []
     return f' AND {vis_sql}', vis_params

--- a/api/routers/map.py
+++ b/api/routers/map.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from api.auth import CurrentUser, get_optional_user, require_edition
 from api.database import get_async_db, get_db
-from api.db_helpers import get_existing_columns, get_visibility_clause
+from api.db_helpers import get_existing_columns, get_visibility_clause, to_exif_date
 
 _DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
@@ -42,10 +42,10 @@ async def _get_clustered_photos(conn, zoom, date_from, date_to, user_id,
     p2_params = list(p2_vis_params)
     if date_from:
         p2_where += " AND p2.date_taken >= ?"
-        p2_params.append(date_from)
+        p2_params.append(to_exif_date(date_from))
     if date_to:
         p2_where += " AND p2.date_taken <= ?"
-        p2_params.append(date_to + " 23:59:59")
+        p2_params.append(to_exif_date(date_to) + " 23:59:59")
 
     cur = await conn.execute(
         f"SELECT "
@@ -157,12 +157,12 @@ async def api_photos_map(
             if not _DATE_RE.match(date_from):
                 raise HTTPException(status_code=400, detail='Invalid date_from format. Expected: YYYY-MM-DD')
             base_where += " AND date_taken >= ?"
-            base_params.append(date_from)
+            base_params.append(to_exif_date(date_from))
         if date_to:
             if not _DATE_RE.match(date_to):
                 raise HTTPException(status_code=400, detail='Invalid date_to format. Expected: YYYY-MM-DD')
             base_where += " AND date_taken <= ?"
-            base_params.append(date_to + " 23:59:59")
+            base_params.append(to_exif_date(date_to) + " 23:59:59")
 
         if zoom < _get_cluster_zoom_threshold():
             return await _get_clustered_photos(

--- a/api/routers/merge_suggestions.py
+++ b/api/routers/merge_suggestions.py
@@ -11,7 +11,6 @@ from api.auth import CurrentUser, require_authenticated
 from api.config import VIEWER_CONFIG, is_multi_user_enabled
 from api.database import get_db
 from api.db_helpers import get_visibility_clause
-from db import DEFAULT_DB_PATH
 
 router = APIRouter(tags=["merge_suggestions"])
 
@@ -54,6 +53,65 @@ def _load_rejected_pairs():
         return set()
 
 
+def _pairwise_suggestions(threshold):
+    """Merge suggestions as true pairwise person comparisons.
+
+    Loads every non-hidden person's centroid and emits each person pair whose
+    OWN centroid cosine similarity clears ``threshold``, labelled with that
+    pair's real similarity.
+
+    Replaces a union-find grouping that emitted the *adjacent* pairs of a
+    transitively-connected group and stamped every one with the group's average
+    similarity -- so a pair merely linked through a chain (A~B~C, with A and C
+    themselves dissimilar) was shown as a confident match and an 'Accept all'
+    then merged different people irreversibly.
+    """
+    import numpy as np
+    from db import person_not_hidden_clause
+
+    with get_db() as conn:
+        rows = conn.execute(
+            f"SELECT id, name, face_count, centroid FROM persons "
+            f"WHERE centroid IS NOT NULL AND {person_not_hidden_clause()} "
+            f"ORDER BY face_count DESC"
+        ).fetchall()
+
+    persons, centroids = [], []
+    for row in rows:
+        if not row['centroid']:
+            continue
+        c = np.frombuffer(row['centroid'], dtype=np.float32)
+        c = c / (np.linalg.norm(c) + 1e-10)
+        persons.append({
+            'id': row['id'],
+            'name': row['name'],
+            'face_count': row['face_count'] or 0,
+        })
+        centroids.append(c)
+
+    suggestions = []
+    n = len(persons)
+    for i in range(n):
+        ci = centroids[i]
+        for j in range(i + 1, n):
+            similarity = float(np.dot(ci, centroids[j]))
+            if similarity >= threshold:
+                suggestions.append({
+                    "person1": {
+                        "id": persons[i]["id"],
+                        "name": persons[i]["name"],
+                        "face_count": persons[i]["face_count"],
+                    },
+                    "person2": {
+                        "id": persons[j]["id"],
+                        "name": persons[j]["name"],
+                        "face_count": persons[j]["face_count"],
+                    },
+                    "similarity": similarity,
+                })
+    return suggestions
+
+
 @router.get("/api/merge_suggestions")
 def get_merge_suggestions(
     threshold: float = Query(0.6, ge=0.0, le=1.0),
@@ -64,31 +122,7 @@ def get_merge_suggestions(
     if not VIEWER_CONFIG.get("features", {}).get("show_merge_suggestions", True):
         raise HTTPException(status_code=403, detail="Merge suggestions feature is disabled")
 
-    # Lazy import only when feature is used
-    from faces import get_merge_groups
-
-    groups = get_merge_groups(DEFAULT_DB_PATH, threshold)
-
-    # Convert groups to pairwise suggestions for the Angular component
-    suggestions = []
-    for group in groups:
-        persons = group.get("persons", [])
-        similarity = group.get("avg_similarity", 0.0)
-        # Create a pairwise suggestion for each adjacent pair in the group
-        for i in range(len(persons) - 1):
-            suggestions.append({
-                "person1": {
-                    "id": persons[i]["id"],
-                    "name": persons[i].get("name"),
-                    "face_count": persons[i].get("face_count", 0),
-                },
-                "person2": {
-                    "id": persons[i + 1]["id"],
-                    "name": persons[i + 1].get("name"),
-                    "face_count": persons[i + 1].get("face_count", 0),
-                },
-                "similarity": similarity,
-            })
+    suggestions = _pairwise_suggestions(threshold)
 
     # Drop pairs the user has already dismissed so they stop reappearing.
     rejected = _load_rejected_pairs()

--- a/api/routers/persons.py
+++ b/api/routers/persons.py
@@ -13,7 +13,10 @@ from pydantic import BaseModel, Field
 from api.auth import CurrentUser, require_edition, require_authenticated
 from api.config import VIEWER_CONFIG, invalidate_stats_cache
 from api.database import get_async_db, get_db
-from api.db_helpers import assert_faces_visible, reassign_faces_to_person, person_visibility_exists
+from api.db_helpers import (
+    assert_faces_visible, reassign_faces_to_person, person_visibility_exists,
+    recompute_person_centroid,
+)
 from db import person_not_hidden_clause
 
 logger = logging.getLogger(__name__)
@@ -221,6 +224,14 @@ def _do_merge(source_id: int, target_id: int, user_id):
 
     with get_db() as conn:
         try:
+            # faces.person_id has no foreign key, so a stale suggestion targeting
+            # a deleted person would silently move faces to a dangling id and make
+            # them vanish from the gallery. Validate both persons exist first.
+            for pid in (source_id, target_id):
+                if not conn.execute(
+                    "SELECT 1 FROM persons WHERE id = ?", (pid,)
+                ).fetchone():
+                    raise HTTPException(status_code=404, detail="Person not found")
             _assert_person_visible(conn, user_id, source_id)
             _assert_person_visible(conn, user_id, target_id)
             # 1. Move all faces from source to target
@@ -234,7 +245,11 @@ def _do_merge(source_id: int, target_id: int, user_id):
             conn.execute("UPDATE persons SET face_count = ? WHERE id = ?",
                          (count, target_id))
 
-            # 3. Delete source person
+            # 3. Recompute the target's centroid from its now-larger face set so
+            #    clustering and future merge suggestions match the merged person.
+            recompute_person_centroid(conn, target_id)
+
+            # 4. Delete source person
             conn.execute("DELETE FROM persons WHERE id = ?", (source_id,))
 
             conn.commit()
@@ -296,8 +311,18 @@ def merge_persons_batch(
     with get_db() as conn:
         try:
             for target_id, source_ids in groups.items():
+                # No FK on faces.person_id: a stale suggestion could target a
+                # deleted person and strand every folded face. Validate first.
+                if not conn.execute(
+                    "SELECT 1 FROM persons WHERE id = ?", (target_id,)
+                ).fetchone():
+                    raise HTTPException(status_code=404, detail=f"Person {target_id} not found")
                 _assert_person_visible(conn, user_id, target_id)
                 for source_id in source_ids:
+                    if not conn.execute(
+                        "SELECT 1 FROM persons WHERE id = ?", (source_id,)
+                    ).fetchone():
+                        raise HTTPException(status_code=404, detail=f"Person {source_id} not found")
                     _assert_person_visible(conn, user_id, source_id)
             merged_total = 0
             for target_id, source_ids in groups.items():
@@ -316,6 +341,8 @@ def merge_persons_batch(
                     "UPDATE persons SET face_count = ? WHERE id = ?",
                     (row[0] if row else 0, target_id),
                 )
+                # Recompute the surviving target's centroid over its merged faces.
+                recompute_person_centroid(conn, target_id)
                 # Delete the folded persons
                 conn.execute(
                     f"DELETE FROM persons WHERE id IN ({placeholders})", ids

--- a/api/routers/plugins.py
+++ b/api/routers/plugins.py
@@ -5,7 +5,6 @@ Exposes loaded plugins, webhook configuration, and a test-webhook helper.
 """
 
 import logging
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -46,7 +45,7 @@ class TestWebhookRequest(BaseModel):
 
 @router.get("/api/plugins")
 def list_plugins(
-    user: Optional[CurrentUser] = Depends(require_edition),
+    user: CurrentUser = Depends(require_edition),
 ):
     """List loaded plugins, webhooks, and configured actions."""
     mgr = _get_manager()
@@ -61,7 +60,7 @@ def list_plugins(
 @router.post("/api/plugins/test-webhook")
 def test_webhook(
     body: TestWebhookRequest,
-    user: Optional[CurrentUser] = Depends(require_edition),
+    user: CurrentUser = Depends(require_edition),
 ):
     """Send a test payload to *url* and report whether it succeeded."""
     mgr = _get_manager()

--- a/api/routers/ranker.py
+++ b/api/routers/ranker.py
@@ -25,8 +25,9 @@ async def api_ranker_status(
 ):
     """Training status for the personal ranker ("My Taste").
 
-    Defaults to the global pooled scope; pass ``?user=<id>`` to read a user's
-    per-user snapshot instead. ``coverage`` is the share of embedded photos that
+    The global pooled scope is deliberately open to any caller; only an explicit
+    ``?user=<id>`` scope is gated (403 unless it is the caller's own id or a
+    superadmin). Pass ``?user=<id>`` to read a user's per-user snapshot instead. ``coverage`` is the share of embedded photos that
     carry a ``learned_score`` in the requested scope (the sort the gallery
     exposes). The accuracy fields come from the last train's ``stats_cache``
     snapshot and are ``null`` until the ranker has trained at least once.

--- a/api/routers/scan.py
+++ b/api/routers/scan.py
@@ -149,12 +149,10 @@ def start_scan(
 
     try:
         if _scan_state['running']:
-            _scan_lock.release()
             raise HTTPException(status_code=409, detail="A scan is already running")
 
         conflict = _library_job_conflict_detail()
         if conflict:
-            _scan_lock.release()
             raise HTTPException(status_code=409, detail=conflict)
 
         directories = body.directories
@@ -162,11 +160,9 @@ def start_scan(
         all_configured = set(get_all_scan_directories())
         for d in directories:
             if d not in all_configured:
-                _scan_lock.release()
                 raise HTTPException(status_code=400, detail=f"Directory not configured: {d}")
 
         if not directories:
-            _scan_lock.release()
             raise HTTPException(status_code=400, detail="No directories specified")
 
         # Rebuild from canonical server-side list so subprocess args are provably server-origin
@@ -194,7 +190,6 @@ def start_scan(
         reader = threading.Thread(target=_read_scan_output, args=(proc,), daemon=True)
         reader.start()
 
-        _scan_lock.release()
         return {
             'success': True,
             'message': 'Scan spawned; poll /api/scan/status to see it run',
@@ -207,8 +202,9 @@ def start_scan(
     except (subprocess.SubprocessError, OSError):
         logger.exception("Scan failed to start")
         _scan_state['running'] = False
-        _scan_lock.release()
         raise HTTPException(status_code=500, detail='Scan failed to start')
+    finally:
+        _scan_lock.release()
 
 
 @router.get("/status")

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -417,11 +417,19 @@ async def _fts_search(conn, query, limit, scope=None):
     only hits words found *in* the image or its caption — not filenames,
     camera models, or tags.
     """
+    # Sanitize the raw user text into a safe FTS5 expression (shared with the
+    # gallery search): unbalanced parens/quotes or a bare NOT would otherwise
+    # raise OperationalError and silently degrade the endpoint. ``None`` means
+    # no safe token survived, so match nothing.
+    from api.routers.gallery import _fts5_query_from
+    safe_query = _fts5_query_from(query)
+    if not safe_query:
+        return {}
     if scope == 'text':
         # FTS5 column-filter syntax: {col1 col2} : query
-        match_expr = f"{{caption caption_translated ocr_text}} : ({query})"
+        match_expr = f"{{caption caption_translated ocr_text}} : ({safe_query})"
     else:
-        match_expr = query
+        match_expr = safe_query
     try:
         cur = await conn.execute(
             "SELECT path, rank FROM photos_fts WHERE photos_fts MATCH ? "

--- a/api/routers/stats.py
+++ b/api/routers/stats.py
@@ -101,10 +101,10 @@ def _stats_filter_where(user: Optional[CurrentUser],
     params = list(vp)
     if date_from:
         clause += ' AND date_taken >= ?'
-        params.append(date_from)
+        params.append(to_exif_date(date_from))
     if date_to:
         clause += ' AND date_taken <= ?'
-        params.append(date_to + ' 23:59:59')
+        params.append(to_exif_date(date_to) + ' 23:59:59')
     if category:
         clause += ' AND category = ?'
         params.append(category)

--- a/calibrate.py
+++ b/calibrate.py
@@ -417,10 +417,42 @@ def objective(w: np.ndarray, X: np.ndarray, y: np.ndarray) -> float:
     return -srcc if np.isfinite(srcc) else 0.0
 
 
+def load_current_category_weights(config_path: str, category: str, col_names: list[str]) -> np.ndarray:
+    """Read a category's live ``<key>_percent`` weights from scoring_config.json.
+
+    Maps each of ``col_names`` (DB column names) through METRIC_COLUMNS to its
+    config key, the inverse of the mapping ``apply_weights_to_config`` writes
+    back with. Normalized to sum to 1.0. Falls back to a uniform vector when
+    the config/category/weights can't be read, so a missing category degrades
+    gracefully rather than raising.
+    """
+    n = len(col_names)
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return np.ones(n) / n
+
+    weights_block = {}
+    for cat in config.get('categories', []):
+        if cat.get('name') == category:
+            weights_block = cat.get('weights', {})
+            break
+
+    w = np.array([
+        weights_block.get(f'{METRIC_COLUMNS.get(col, col)}_percent', 0.0)
+        for col in col_names
+    ], dtype=np.float64)
+    if w.sum() > 0:
+        return w / w.sum()
+    return np.ones(n) / n
+
+
 def optimize_weights(
     rows: list[dict],
     category: str,
     method: str = 'de',
+    config_path: str = SCORING_CONFIG_PATH,
 ) -> tuple[dict, dict]:
     """Optimize weights for a set of photos.
 
@@ -433,8 +465,10 @@ def optimize_weights(
     if len(rows) < MIN_PHOTOS_FOR_BASELINE:
         raise ValueError(f"Not enough photos for optimization (need {MIN_PHOTOS_FOR_BASELINE}, got {len(rows)})")
 
-    # Uniform initial weights
-    w0 = np.ones(n) / n
+    # Baseline = the weights actually live in scoring_config.json today, not a
+    # uniform strawman -- otherwise "before" SRCC and the persisted old_weights
+    # both compare against a vector nobody is running.
+    w0 = load_current_category_weights(config_path, category, col_names)
     bounds = [(0.0, 1.0)] * n
 
     # Sum-to-1 constraint: we enforce it by normalizing inside a wrapper
@@ -730,7 +764,6 @@ def _analyze_numeric_filters(
         if not correct_vals or not misclass_vals:
             continue
 
-        np.array(correct_vals)
         misclass_arr = np.array(misclass_vals)
 
         # Sweep thresholds to find better boundary
@@ -1160,7 +1193,10 @@ def print_optimization_result(info: dict, col_to_weight: dict) -> None:
 
 def log_run_to_db(db_path: str, info: dict, col_to_weight: dict, current_config_weights: dict) -> None:
     """Insert a row into weight_optimization_runs."""
-    old_w = {col: wb for col, wb in zip(info['col_names'], info['w_before'])}
+    # current_config_weights is the authoritative live-config baseline (see
+    # load_current_category_weights); falls back to info['w_before'] only for
+    # a caller that has none to offer.
+    old_w = current_config_weights or {col: wb for col, wb in zip(info['col_names'], info['w_before'])}
     new_w = col_to_weight
 
     conn = sqlite3.connect(db_path)
@@ -1378,7 +1414,7 @@ def main():
 
             logger.info("  Optimizing '%s' (%s photos)...", cat_label, f"{len(rows):,}")
             try:
-                info, col_to_weight = optimize_weights(rows, cat_key, method=method)
+                info, col_to_weight = optimize_weights(rows, cat_key, method=method, config_path=args.config)
             except Exception as e:
                 logger.error("  ERROR optimizing '%s': %s", cat_label, e)
                 continue
@@ -1388,7 +1424,8 @@ def main():
 
             # Log to DB
             try:
-                log_run_to_db(args.db, info, col_to_weight, current_config_weights={})
+                current_config_weights = dict(zip(info['col_names'], info['w_before']))
+                log_run_to_db(args.db, info, col_to_weight, current_config_weights=current_config_weights)
             except Exception as e:
                 logger.warning("  Could not log run to DB: %s", e)
 

--- a/client/scripts/migrate-i18n.mjs
+++ b/client/scripts/migrate-i18n.mjs
@@ -32,10 +32,23 @@ function importPath(fromFile) {
   return rel;
 }
 
-// Files kept on literal keys: their spec renders right after a Leaflet map spec,
-// and this builder shares one module registry per worker -- the map spec's module
-// mock resets it and nulls the component's I18N import binding for the next file.
-const SKIP = new Set(['photo-tooltip.component.ts']);
+// Files kept on literal keys instead of the shared `I18N` accessor: under the
+// Vitest unit-test builder, `I18N` (a plain module-const) reads back `undefined`
+// the first time these components render via TestBed, because the keys module
+// lands on both the static and dynamic-import side of a code-split boundary and
+// duplicates. Literal `'key' | translate` strings sidestep the captured binding
+// entirely. The codemod MUST NOT rewrite them back to `I18N.key` accessors.
+const SKIP = new Set([
+  'photo-tooltip.component.ts',
+  'album-scoring-context-dialog.component.ts',
+  'comparison-priority-tab.component.ts',
+  'gear-chart-card.component.ts',
+  'person-card.component.ts',
+  'photo-card.component.ts',
+  'albums.component.ts',
+  'folder-picker-dialog.component.ts',
+  'compare-selected-dialog.component.ts',
+]);
 
 function listFiles(dir, acc = []) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/client/src/app/core/services/photo-actions.service.spec.ts
+++ b/client/src/app/core/services/photo-actions.service.spec.ts
@@ -28,7 +28,7 @@ describe('PhotoActionsService', () => {
         { id: 1, name: 'Alice', face_count: 5 },
         { id: 2, name: null, face_count: 1 },
       ]),
-      assignFace: vi.fn().mockResolvedValue(undefined),
+      assignFace: vi.fn().mockResolvedValue(true),
       createPerson: vi.fn().mockResolvedValue({ id: 99, name: 'New Person', face_count: 1 }),
     };
 
@@ -48,7 +48,7 @@ describe('PhotoActionsService', () => {
     it('should open PhotoCritiqueDialogComponent with photo path and vlmAvailable', async () => {
       service.openCritique(mockPhoto);
       // The dialog component is lazy-loaded via dynamic import; wait for it to resolve.
-      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled(), { timeout: 5000 });
 
       expect(mockDialog.open).toHaveBeenCalledWith(
         expect.any(Function),
@@ -63,7 +63,7 @@ describe('PhotoActionsService', () => {
     it('should pass vlmAvailable=true when show_vlm_critique is true', async () => {
       mockStore.config.mockReturnValue({ features: { show_vlm_critique: true } });
       service.openCritique(mockPhoto);
-      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled(), { timeout: 5000 });
 
       const call = mockDialog.open.mock.calls[0][1];
       expect(call.data.vlmAvailable).toBe(true);
@@ -73,7 +73,7 @@ describe('PhotoActionsService', () => {
   describe('openAddPerson', () => {
     it('should open FaceSelectorDialogComponent first', async () => {
       service.openAddPerson(mockPhoto);
-      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled(), { timeout: 5000 });
 
       expect(mockDialog.open).toHaveBeenCalledWith(
         expect.any(Function),
@@ -93,10 +93,28 @@ describe('PhotoActionsService', () => {
         .mockReturnValueOnce({ afterClosed: () => of(selectedResult) });
 
       service.openAddPerson(mockPhoto, onAssigned);
-      await vi.waitFor(() => expect(mockStore.assignFace).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockStore.assignFace).toHaveBeenCalled(), { timeout: 5000 });
 
       expect(mockStore.assignFace).toHaveBeenCalledWith(10, 1, '/photos/test.jpg', 'Alice');
       expect(onAssigned).toHaveBeenCalled();
+    });
+
+    it('should NOT call onAssigned or show a success toast when assignFace fails', async () => {
+      mockStore.assignFace.mockResolvedValue(false);
+      const selectedFace = { id: 10 };
+      const selectedResult = { kind: 'select', person: { id: 1, name: 'Alice' } };
+      const onAssigned = vi.fn();
+
+      mockDialog.open
+        .mockReturnValueOnce({ afterClosed: () => of(selectedFace) })
+        .mockReturnValueOnce({ afterClosed: () => of(selectedResult) });
+
+      service.openAddPerson(mockPhoto, onAssigned);
+      await vi.waitFor(() => expect(mockStore.assignFace).toHaveBeenCalled(), { timeout: 5000 });
+      await vi.waitFor(() => expect(mockSnackBar.open).toHaveBeenCalled(), { timeout: 5000 });
+
+      expect(onAssigned).not.toHaveBeenCalled();
+      expect(mockSnackBar.open).toHaveBeenCalledWith('errors.action_failed', '', { duration: 3000 });
     });
 
     it('should create a new person when dialog returns kind="create"', async () => {
@@ -109,7 +127,7 @@ describe('PhotoActionsService', () => {
         .mockReturnValueOnce({ afterClosed: () => of(createResult) });
 
       service.openAddPerson(mockPhoto, onAssigned);
-      await vi.waitFor(() => expect(mockStore.createPerson).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockStore.createPerson).toHaveBeenCalled(), { timeout: 5000 });
 
       expect(mockStore.createPerson).toHaveBeenCalledWith('NewPerson', [10], '/photos/test.jpg');
       expect(mockStore.assignFace).not.toHaveBeenCalled();
@@ -120,7 +138,7 @@ describe('PhotoActionsService', () => {
       mockDialog.open.mockReturnValue({ afterClosed: () => of(null) });
 
       service.openAddPerson(mockPhoto);
-      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalled(), { timeout: 5000 });
 
       // Only the face selector should have been opened
       expect(mockDialog.open).toHaveBeenCalledTimes(1);
@@ -134,7 +152,7 @@ describe('PhotoActionsService', () => {
         .mockReturnValueOnce({ afterClosed: () => of(null) });
 
       service.openAddPerson(mockPhoto);
-      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(mockDialog.open).toHaveBeenCalledTimes(2), { timeout: 5000 });
 
       // PersonSelector receives only named persons
       const personSelectorCall = mockDialog.open.mock.calls[1];

--- a/client/src/app/core/services/photo-actions.service.ts
+++ b/client/src/app/core/services/photo-actions.service.ts
@@ -60,9 +60,13 @@ export class PhotoActionsService {
                 this.snackBar.open(this.i18n.t(I18N.persons.create_error), '', { duration: 3000 });
               }
             } else if (result.kind === 'select') {
-              await this.store.assignFace(face.id, result.person.id, photo.path, result.person.name);
-              this.snackBar.open(this.i18n.t(I18N.notifications.faces_assigned), '', { duration: 2000 });
-              onAssigned?.();
+              const assigned = await this.store.assignFace(face.id, result.person.id, photo.path, result.person.name);
+              if (assigned) {
+                this.snackBar.open(this.i18n.t(I18N.notifications.faces_assigned), '', { duration: 2000 });
+                onAssigned?.();
+              } else {
+                this.snackBar.open(this.i18n.t(I18N.errors.action_failed), '', { duration: 3000 });
+              }
             }
           });
         });

--- a/client/src/app/features/albums/album-scoring-context-dialog.component.ts
+++ b/client/src/app/features/albums/album-scoring-context-dialog.component.ts
@@ -13,7 +13,6 @@ import { I18nService } from '../../core/services/i18n.service';
 import { AlbumService, AlbumScoringContextResult, AlbumSuggestedContext } from '../../core/services/album.service';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ScoringContextLabelPipe, resolveScoringContextLabel } from '../../shared/pipes/scoring-context-label.pipe';
-import { I18N } from '../../core/i18n/keys';
 
 export interface AlbumScoringContextDialogData {
   albumId: number;
@@ -58,17 +57,17 @@ const DEFAULT_CONTEXT = 'default';
     MatProgressSpinnerModule, MatProgressBarModule, TranslatePipe, ScoringContextLabelPipe,
   ],
   template: `
-    <h2 mat-dialog-title class="truncate">{{ I18N.albums.scoring_context.dialog_title | translate:{ name: data.albumName } }}</h2>
+    <h2 mat-dialog-title class="truncate">{{ 'albums.scoring_context.dialog_title' | translate:{ name: data.albumName } }}</h2>
     <mat-dialog-content class="!pt-2 min-w-[20rem] max-w-[28rem]">
       @if (loading()) {
         <div class="flex justify-center py-6">
           <mat-spinner diameter="28" />
         </div>
       } @else {
-        <p class="text-sm opacity-70 mb-3">{{ I18N.albums.scoring_context.description | translate }}</p>
+        <p class="text-sm opacity-70 mb-3">{{ 'albums.scoring_context.description' | translate }}</p>
 
         <mat-form-field class="w-full">
-          <mat-label>{{ I18N.albums.scoring_context.label | translate }}</mat-label>
+          <mat-label>{{ 'albums.scoring_context.label' | translate }}</mat-label>
           <mat-select [value]="selectedContext()" [disabled]="phase() !== 'select'"
                       (selectionChange)="selectedContext.set($event.value)">
             @for (context of contexts(); track context.name) {
@@ -81,10 +80,10 @@ const DEFAULT_CONTEXT = 'default';
           @if (s.suggested && s.moment && s.suggested !== selectedContext()) {
             <div class="flex items-center gap-2 text-xs opacity-70 -mt-2 mb-3">
               <span>
-                {{ I18N.albums.scoring_context.suggested_hint | translate:{ context: suggestedLabel(), percent: '' + suggestedPercent(), moment: s.moment } }}
+                {{ 'albums.scoring_context.suggested_hint' | translate:{ context: suggestedLabel(), percent: '' + suggestedPercent(), moment: s.moment } }}
               </span>
               <button mat-button class="!min-w-0 !px-2" (click)="selectedContext.set(s.suggested!)">
-                {{ I18N.albums.scoring_context.apply_suggestion | translate }}
+                {{ 'albums.scoring_context.apply_suggestion' | translate }}
               </button>
             </div>
           }
@@ -97,44 +96,44 @@ const DEFAULT_CONTEXT = 'default';
             }
             @if (conflicts() > 0) {
               <p class="text-amber-400 mb-2">
-                {{ I18N.albums.scoring_context.conflict_warning | translate:{ count: '' + conflicts() } }}
+                {{ 'albums.scoring_context.conflict_warning' | translate:{ count: '' + conflicts() } }}
               </p>
             }
             @if (manualSkipped() > 0) {
               <p class="text-amber-400 mb-2">
-                {{ I18N.albums.scoring_context.manual_skipped_note | translate:{ count: '' + manualSkipped() } }}
+                {{ 'albums.scoring_context.manual_skipped_note' | translate:{ count: '' + manualSkipped() } }}
               </p>
             }
             <p class="opacity-70 mb-2">
-              {{ (cleared() ? I18N.albums.scoring_context.cleared_success : I18N.albums.scoring_context.saved_success) | translate:{ count: '' + updatedCount() } }}
+              {{ (cleared() ? 'albums.scoring_context.cleared_success' : 'albums.scoring_context.saved_success') | translate:{ count: '' + updatedCount() } }}
             </p>
-            <p class="opacity-60 text-xs mb-2">{{ I18N.albums.scoring_context.membership_note | translate }}</p>
+            <p class="opacity-60 text-xs mb-2">{{ 'albums.scoring_context.membership_note' | translate }}</p>
 
             @if (phase() === 'saved') {
-              <p class="mb-2">{{ I18N.albums.scoring_context.recompute_prompt | translate }}</p>
+              <p class="mb-2">{{ 'albums.scoring_context.recompute_prompt' | translate }}</p>
               @if (recomputeError(); as e) {
                 <p class="text-red-400 text-xs mb-2">
-                  {{ (e === 'busy' ? I18N.albums.scoring_context.recompute_busy : I18N.albums.scoring_context.recompute_failed) | translate }}
+                  {{ (e === 'busy' ? 'albums.scoring_context.recompute_busy' : 'albums.scoring_context.recompute_failed') | translate }}
                 </p>
               }
               <div class="flex gap-2 justify-end">
-                <button mat-button (click)="close()">{{ I18N.albums.scoring_context.recompute_skip | translate }}</button>
-                <button mat-flat-button (click)="recompute()">{{ I18N.albums.scoring_context.recompute_button | translate }}</button>
+                <button mat-button (click)="close()">{{ 'albums.scoring_context.recompute_skip' | translate }}</button>
+                <button mat-flat-button (click)="recompute()">{{ 'albums.scoring_context.recompute_button' | translate }}</button>
               </div>
             }
 
             @if (phase() === 'recomputing') {
-              <p class="mb-2">{{ I18N.albums.scoring_context.recomputing | translate }}</p>
+              <p class="mb-2">{{ 'albums.scoring_context.recomputing' | translate }}</p>
               <mat-progress-bar [mode]="progressValue() === null ? 'indeterminate' : 'determinate'"
                                 [value]="progressValue() ?? 0" />
             }
 
             @if (phase() === 'recompute_done') {
-              <p class="text-green-400">{{ I18N.albums.scoring_context.recompute_done | translate }}</p>
+              <p class="text-green-400">{{ 'albums.scoring_context.recompute_done' | translate }}</p>
             }
 
             @if (phase() === 'recompute_error') {
-              <p class="text-red-400">{{ I18N.albums.scoring_context.recompute_failed | translate }}</p>
+              <p class="text-red-400">{{ 'albums.scoring_context.recompute_failed' | translate }}</p>
             }
           </div>
         }
@@ -142,23 +141,22 @@ const DEFAULT_CONTEXT = 'default';
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       @if (phase() === 'select' || phase() === 'saving') {
-        <button mat-button (click)="cancel()">{{ I18N.ui.buttons.cancel | translate }}</button>
+        <button mat-button (click)="cancel()">{{ 'ui.buttons.cancel' | translate }}</button>
         @if (data.currentContext) {
           <button mat-button [disabled]="loading() || phase() === 'saving'" (click)="clear()">
-            {{ I18N.albums.scoring_context.clear_button | translate }}
+            {{ 'albums.scoring_context.clear_button' | translate }}
           </button>
         }
         <button mat-flat-button [disabled]="loading() || phase() === 'saving'" (click)="save()">
-          {{ phase() === 'saving' ? (I18N.ui.buttons.saving | translate) : (I18N.ui.buttons.save | translate) }}
+          {{ phase() === 'saving' ? ('ui.buttons.saving' | translate) : ('ui.buttons.save' | translate) }}
         </button>
       } @else {
-        <button mat-button (click)="close()">{{ I18N.albums.scoring_context.close | translate }}</button>
+        <button mat-button (click)="close()">{{ 'albums.scoring_context.close' | translate }}</button>
       }
     </mat-dialog-actions>
   `,
 })
 export class AlbumScoringContextDialogComponent implements OnInit {
-  protected readonly I18N = I18N;
   private readonly api = inject(ApiService);
   private readonly i18n = inject(I18nService);
   private readonly albumService = inject(AlbumService);
@@ -212,8 +210,8 @@ export class AlbumScoringContextDialogComponent implements OnInit {
     try {
       this.contexts.set((await contextsPromise).contexts);
     } catch {
-      this.contexts.set([{ name: DEFAULT_CONTEXT, label_key: I18N.albums.scoring_context.label }]);
-      this.snackBar.open(this.i18n.t(I18N.notifications.connection_error), '', { duration: 3000 });
+      this.contexts.set([{ name: DEFAULT_CONTEXT, label_key: 'albums.scoring_context.label' }]);
+      this.snackBar.open(this.i18n.t('notifications.connection_error'), '', { duration: 3000 });
     }
 
     this.suggestion.set(await suggestionPromise);
@@ -225,7 +223,7 @@ export class AlbumScoringContextDialogComponent implements OnInit {
     this.updatedCount.set(res.updated);
     this.conflicts.set(res.conflicts);
     this.manualSkipped.set(res.manual_skipped);
-    this.warning.set(res.warning ? I18N.albums.scoring_context.empty_warning : null);
+    this.warning.set(res.warning ? 'albums.scoring_context.empty_warning' : null);
     this.cleared.set(cleared);
     this.persistedContext = context;
     this.persisted = true;
@@ -242,7 +240,7 @@ export class AlbumScoringContextDialogComponent implements OnInit {
     } catch {
       this.phase.set('select');
       if (!this.closeRequested) {
-        this.snackBar.open(this.i18n.t(I18N.errors.action_failed), '', { duration: 3000 });
+        this.snackBar.open(this.i18n.t('errors.action_failed'), '', { duration: 3000 });
       }
     }
     if (this.closeRequested) this.close();
@@ -257,7 +255,7 @@ export class AlbumScoringContextDialogComponent implements OnInit {
     } catch {
       this.phase.set('select');
       if (!this.closeRequested) {
-        this.snackBar.open(this.i18n.t(I18N.errors.action_failed), '', { duration: 3000 });
+        this.snackBar.open(this.i18n.t('errors.action_failed'), '', { duration: 3000 });
       }
     }
     if (this.closeRequested) this.close();

--- a/client/src/app/features/albums/albums.component.ts
+++ b/client/src/app/features/albums/albums.component.ts
@@ -23,7 +23,6 @@ import { AlbumScoringContextDialogComponent, AlbumScoringContextDialogData } fro
 import { AlbumsFiltersService } from './albums-filters.service';
 import { ShareDialogComponent, ShareDialogData } from '../../shared/components/share-dialog/share-dialog.component';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
-import { I18N } from '../../core/i18n/keys';
 import { PageHelpService } from '../../core/services/page-help.service';
 import { HeaderSlotService } from '../../core/services/header-slot.service';
 
@@ -40,28 +39,28 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
   template: `
     <ng-template #albumsToolbar>
       <mat-form-field class="!hidden lg:!inline-flex w-52" subscriptSizing="dynamic">
-        <mat-label>{{ I18N.albums.search | translate }}</mat-label>
+        <mat-label>{{ 'albums.search' | translate }}</mat-label>
         <input matInput [value]="albumsFilters.search()" (input)="albumsFilters.search.set($any($event.target).value)" />
         <mat-icon matPrefix class="opacity-60">search</mat-icon>
       </mat-form-field>
       <mat-form-field class="!hidden lg:!inline-flex w-36" subscriptSizing="dynamic">
-        <mat-label>{{ I18N.albums.filter_type | translate }}</mat-label>
+        <mat-label>{{ 'albums.filter_type' | translate }}</mat-label>
         <mat-select [value]="albumsFilters.typeFilter()" (selectionChange)="albumsFilters.typeFilter.set($event.value)">
-          <mat-option value="">{{ I18N.albums.type_all | translate }}</mat-option>
-          <mat-option value="manual">{{ I18N.albums.type_manual | translate }}</mat-option>
-          <mat-option value="smart">{{ I18N.albums.type_smart | translate }}</mat-option>
+          <mat-option value="">{{ 'albums.type_all' | translate }}</mat-option>
+          <mat-option value="manual">{{ 'albums.type_manual' | translate }}</mat-option>
+          <mat-option value="smart">{{ 'albums.type_smart' | translate }}</mat-option>
         </mat-select>
       </mat-form-field>
       <mat-form-field class="!hidden lg:!inline-flex w-40" subscriptSizing="dynamic">
-        <mat-label>{{ I18N.albums.sort_by | translate }}</mat-label>
+        <mat-label>{{ 'albums.sort_by' | translate }}</mat-label>
         <mat-select [value]="albumsFilters.sort()" (selectionChange)="albumsFilters.sort.set($event.value)">
-          <mat-option value="updated_at">{{ I18N.albums.sort_recent | translate }}</mat-option>
-          <mat-option value="name">{{ I18N.albums.sort_name | translate }}</mat-option>
-          <mat-option value="photo_count">{{ I18N.albums.sort_photos | translate }}</mat-option>
+          <mat-option value="updated_at">{{ 'albums.sort_recent' | translate }}</mat-option>
+          <mat-option value="name">{{ 'albums.sort_name' | translate }}</mat-option>
+          <mat-option value="photo_count">{{ 'albums.sort_photos' | translate }}</mat-option>
         </mat-select>
       </mat-form-field>
       @if (auth.isEdition()) {
-        <button mat-icon-button class="!hidden lg:!inline-flex" [matTooltip]="I18N.albums.create | translate" [attr.aria-label]="I18N.albums.create | translate" (click)="albumsFilters.createRequested.set(albumsFilters.createRequested() + 1)">
+        <button mat-icon-button class="!hidden lg:!inline-flex" [matTooltip]="'albums.create' | translate" [attr.aria-label]="'albums.create' | translate" (click)="albumsFilters.createRequested.set(albumsFilters.createRequested() + 1)">
           <mat-icon>add</mat-icon>
         </button>
       }
@@ -76,7 +75,7 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
     @if (albums().length === 0 && !loading()) {
       <div class="text-center py-16 opacity-60">
         <mat-icon class="!text-5xl !w-12 !h-12 mb-4">photo_library</mat-icon>
-        <p>{{ I18N.albums.empty | translate }}</p>
+        <p>{{ 'albums.empty' | translate }}</p>
       </div>
     }
 
@@ -93,8 +92,8 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
                 <span class="text-white text-xs font-medium truncate">{{ album.name }}</span>
                 @if (album.is_smart) {
                   <mat-icon class="!text-xs !w-3 !h-3 !leading-3 text-white/80 shrink-0 pointer-events-auto"
-                            [matTooltip]="I18N.albums.smart_tooltip | translate"
-                            [attr.aria-label]="I18N.albums.smart_tooltip | translate">auto_awesome</mat-icon>
+                            [matTooltip]="'albums.smart_tooltip' | translate"
+                            [attr.aria-label]="'albums.smart_tooltip' | translate">auto_awesome</mat-icon>
                 }
               </div>
             </div>
@@ -105,8 +104,8 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
                 <span class="text-white text-xs font-medium truncate">{{ album.name }}</span>
                 @if (album.is_smart) {
                   <mat-icon class="!text-xs !w-3 !h-3 !leading-3 text-white/80 shrink-0 pointer-events-auto"
-                            [matTooltip]="I18N.albums.smart_tooltip | translate"
-                            [attr.aria-label]="I18N.albums.smart_tooltip | translate">auto_awesome</mat-icon>
+                            [matTooltip]="'albums.smart_tooltip' | translate"
+                            [attr.aria-label]="'albums.smart_tooltip' | translate">auto_awesome</mat-icon>
                 }
               </div>
             </div>
@@ -120,7 +119,7 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
             <div class="flex items-center shrink-0">
               @if (!album.is_smart) {
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.scenes | translate"
+                        [matTooltip]="'albums.scenes' | translate"
                         (click)="openScoped($event, '/scenes', album)">
                   <mat-icon class="opacity-60">movie_filter</mat-icon>
                 </button>
@@ -128,40 +127,40 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
               @if (auth.isEdition()) {
                 @if (!album.is_smart && proofingEnabled()) {
                   <button mat-icon-button
-                          [matTooltip]="I18N.proofing.client_picks | translate"
+                          [matTooltip]="'proofing.client_picks' | translate"
                           (click)="openClientPicks($event, album)">
                     <mat-icon class="opacity-60">how_to_vote</mat-icon>
                   </button>
                 }
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.cull | translate"
+                        [matTooltip]="'albums.cull' | translate"
                         (click)="openScoped($event, '/culling', album)">
                   <mat-icon class="opacity-60">auto_delete</mat-icon>
                 </button>
                 @if (!album.is_smart && portfolioEnabled()) {
                   <button mat-icon-button
-                          [matTooltip]="I18N.albums.portfolio | translate"
+                          [matTooltip]="'albums.portfolio' | translate"
                           (click)="exportPortfolio($event, album)">
                     <mat-icon class="opacity-60">web</mat-icon>
                   </button>
                 }
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.scoring_context.action | translate"
+                        [matTooltip]="'albums.scoring_context.action' | translate"
                         (click)="openScoringContext($event, album)">
                   <mat-icon class="opacity-60">tune</mat-icon>
                 </button>
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.edit | translate"
+                        [matTooltip]="'albums.edit' | translate"
                         (click)="editAlbum($event, album)">
                   <mat-icon class="opacity-60">edit</mat-icon>
                 </button>
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.share | translate"
+                        [matTooltip]="'albums.share' | translate"
                         (click)="shareAlbum($event, album)">
                   <mat-icon class="opacity-60">{{ album.is_shared ? 'link' : 'share' }}</mat-icon>
                 </button>
                 <button mat-icon-button
-                        [matTooltip]="I18N.albums.delete | translate"
+                        [matTooltip]="'albums.delete' | translate"
                         (click)="deleteAlbum($event, album)">
                   <mat-icon class="opacity-60">delete</mat-icon>
                 </button>
@@ -181,7 +180,6 @@ import { HeaderSlotService } from '../../core/services/header-slot.service';
   `,
 })
 export class AlbumsComponent {
-  protected readonly I18N = I18N;
   private readonly albumService = inject(AlbumService);
   private readonly dialog = inject(MatDialog);
   private readonly i18n = inject(I18nService);
@@ -203,7 +201,7 @@ export class AlbumsComponent {
   protected readonly portfolioEnabled = computed(() => this.auth.hasFeature('show_portfolio_export'));
 
   constructor() {
-    this.pageHelp.setDescription(I18N.albums.help);
+    this.pageHelp.setDescription('albums.help');
     effect(() => {
       const t = this.albumsToolbar();
       if (t) this.headerSlot.set(t);
@@ -297,8 +295,8 @@ export class AlbumsComponent {
     event.stopPropagation();
     const ref = this.dialog.open(ConfirmDialogComponent, {
       data: {
-        title: this.i18n.t(I18N.albums.confirm_delete_title),
-        message: this.i18n.t(I18N.albums.confirm_delete_message, { name: album.name }),
+        title: this.i18n.t('albums.confirm_delete_title'),
+        message: this.i18n.t('albums.confirm_delete_message', { name: album.name }),
       },
     });
     const confirmed = await firstValueFrom(ref.afterClosed());

--- a/client/src/app/features/comparison/comparison-priority-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-priority-tab.component.ts
@@ -17,7 +17,6 @@ import { I18nService } from '../../core/services/i18n.service';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ScoringContextLabelPipe } from '../../shared/pipes/scoring-context-label.pipe';
 import { EtaDurationPipe, FilterValueFormatPipe } from './comparison.pipes';
-import { I18N } from '../../core/i18n/keys';
 
 const DEFAULT_CATEGORY_NAME = 'default';
 const JOB_KIND_RECOMPUTE = 'recompute';
@@ -145,12 +144,12 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
       <!-- Context picker -->
       <mat-card>
         <mat-card-header>
-          <mat-card-title>{{ I18N.comparison.context.tab_label | translate }}</mat-card-title>
-          <mat-card-subtitle>{{ I18N.comparison.context.picker_description | translate }}</mat-card-subtitle>
+          <mat-card-title>{{ 'comparison.context.tab_label' | translate }}</mat-card-title>
+          <mat-card-subtitle>{{ 'comparison.context.picker_description' | translate }}</mat-card-subtitle>
         </mat-card-header>
         <mat-card-content class="!pt-4">
           <mat-form-field class="w-full max-w-sm">
-            <mat-label>{{ I18N.comparison.context.context_picker | translate }}</mat-label>
+            <mat-label>{{ 'comparison.context.context_picker' | translate }}</mat-label>
             <mat-select [value]="selectedContext()" [disabled]="savingContext()"
                         (selectionChange)="selectContext($event.value)">
               @for (ctx of contexts(); track ctx.name) {
@@ -166,22 +165,22 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
         <mat-card>
           <mat-card-header class="!flex !items-start">
             <div class="flex-1">
-              <mat-card-title>{{ I18N.comparison.context.global_order_title | translate }}</mat-card-title>
-              <mat-card-subtitle>{{ I18N.comparison.context.global_order_description | translate }}</mat-card-subtitle>
+              <mat-card-title>{{ 'comparison.context.global_order_title' | translate }}</mat-card-title>
+              <mat-card-subtitle>{{ 'comparison.context.global_order_description' | translate }}</mat-card-subtitle>
             </div>
             <div class="flex gap-1 shrink-0">
               <button mat-icon-button
                 [disabled]="!hasOrderChanges() || saving()"
                 (click)="resetOrder()"
-                [matTooltip]="I18N.comparison.reset | translate"
-                [attr.aria-label]="I18N.comparison.reset | translate">
+                [matTooltip]="'comparison.reset' | translate"
+                [attr.aria-label]="'comparison.reset' | translate">
                 <mat-icon>refresh</mat-icon>
               </button>
               <button mat-icon-button
                 [disabled]="saveDisabled()"
                 (click)="saveOrder()"
-                [matTooltip]="I18N.comparison.save | translate"
-                [attr.aria-label]="I18N.comparison.save | translate">
+                [matTooltip]="'comparison.save' | translate"
+                [attr.aria-label]="'comparison.save' | translate">
                 @if (saving()) {
                   <mat-spinner diameter="20" />
                 } @else {
@@ -213,7 +212,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                     <mat-icon class="text-gray-400 shrink-0">lock</mat-icon>
                     <span class="w-8 shrink-0 text-xs font-mono text-gray-400">{{ orderedCategories().length + 1 }}</span>
                     <span class="w-40 shrink-0 text-sm font-medium">{{ ('category_names.' + def.name) | translate }}</span>
-                    <span class="text-xs text-gray-500">{{ I18N.comparison.context.pinned_default_note | translate }}</span>
+                    <span class="text-xs text-gray-500">{{ 'comparison.context.pinned_default_note' | translate }}</span>
                   </div>
                 }
               </div>
@@ -226,21 +225,21 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
           <mat-card-header class="!flex !items-start">
             <div class="flex-1">
               <mat-card-title>{{ ctx | scoringContextLabel }}</mat-card-title>
-              <mat-card-subtitle>{{ I18N.comparison.context.delta_description | translate }}</mat-card-subtitle>
+              <mat-card-subtitle>{{ 'comparison.context.delta_description' | translate }}</mat-card-subtitle>
             </div>
             <div class="flex gap-1 shrink-0">
               <button mat-icon-button
                 [disabled]="!hasContextChanges() || savingContext()"
                 (click)="resetContextDraft()"
-                [matTooltip]="I18N.comparison.reset | translate"
-                [attr.aria-label]="I18N.comparison.reset | translate">
+                [matTooltip]="'comparison.reset' | translate"
+                [attr.aria-label]="'comparison.reset' | translate">
                 <mat-icon>refresh</mat-icon>
               </button>
               <button mat-icon-button
                 [disabled]="contextSaveDisabled()"
                 (click)="saveContext()"
-                [matTooltip]="I18N.comparison.save | translate"
-                [attr.aria-label]="I18N.comparison.save | translate">
+                [matTooltip]="'comparison.save' | translate"
+                [attr.aria-label]="'comparison.save' | translate">
                 @if (savingContext()) {
                   <mat-spinner diameter="20" />
                 } @else {
@@ -254,8 +253,8 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <mat-card>
             <mat-card-header>
-              <mat-card-title>{{ I18N.comparison.context.promote_title | translate }}</mat-card-title>
-              <mat-card-subtitle>{{ I18N.comparison.context.promote_description | translate }}</mat-card-subtitle>
+              <mat-card-title>{{ 'comparison.context.promote_title' | translate }}</mat-card-title>
+              <mat-card-subtitle>{{ 'comparison.context.promote_description' | translate }}</mat-card-subtitle>
             </mat-card-header>
             <mat-card-content class="!pt-4">
               @if (draftPromote().length > 0) {
@@ -268,32 +267,32 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                       <button mat-icon-button class="shrink-0"
                         [disabled]="i === 0"
                         (click)="movePromotedUp(i)"
-                        [matTooltip]="I18N.comparison.context.move_up | translate"
-                        [attr.aria-label]="I18N.comparison.context.move_up | translate">
+                        [matTooltip]="'comparison.context.move_up' | translate"
+                        [attr.aria-label]="'comparison.context.move_up' | translate">
                         <mat-icon>arrow_upward</mat-icon>
                       </button>
                       <button mat-icon-button class="shrink-0"
                         [disabled]="i === draftPromote().length - 1"
                         (click)="movePromotedDown(i)"
-                        [matTooltip]="I18N.comparison.context.move_down | translate"
-                        [attr.aria-label]="I18N.comparison.context.move_down | translate">
+                        [matTooltip]="'comparison.context.move_down' | translate"
+                        [attr.aria-label]="'comparison.context.move_down' | translate">
                         <mat-icon>arrow_downward</mat-icon>
                       </button>
                       <button mat-icon-button class="shrink-0"
                         (click)="unpromoteCategory(name)"
-                        [matTooltip]="I18N.comparison.context.remove_promotion | translate"
-                        [attr.aria-label]="I18N.comparison.context.remove_promotion | translate">
+                        [matTooltip]="'comparison.context.remove_promotion' | translate"
+                        [attr.aria-label]="'comparison.context.remove_promotion' | translate">
                         <mat-icon>close</mat-icon>
                       </button>
                     </div>
                   }
                 </div>
               } @else {
-                <p class="text-sm text-gray-500">{{ I18N.comparison.context.no_promotions | translate }}</p>
+                <p class="text-sm text-gray-500">{{ 'comparison.context.no_promotions' | translate }}</p>
               }
               @if (promotableCategories().length > 0) {
                 <div class="mt-4 pt-3 border-t border-[var(--mat-sys-outline-variant)]">
-                  <h4 class="text-xs uppercase tracking-wide text-gray-500 mb-2">{{ I18N.comparison.context.add_promotion | translate }}</h4>
+                  <h4 class="text-xs uppercase tracking-wide text-gray-500 mb-2">{{ 'comparison.context.add_promotion' | translate }}</h4>
                   <div class="flex flex-wrap gap-2">
                     @for (name of promotableCategories(); track name) {
                       <button type="button"
@@ -310,8 +309,8 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
 
           <mat-card>
             <mat-card-header>
-              <mat-card-title>{{ I18N.comparison.context.excluded_title | translate }}</mat-card-title>
-              <mat-card-subtitle>{{ I18N.comparison.context.excluded_description | translate }}</mat-card-subtitle>
+              <mat-card-title>{{ 'comparison.context.excluded_title' | translate }}</mat-card-title>
+              <mat-card-subtitle>{{ 'comparison.context.excluded_description' | translate }}</mat-card-subtitle>
             </mat-card-header>
             <mat-card-content class="!pt-4">
               <div class="flex flex-wrap gap-2">
@@ -327,7 +326,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                 }
               </div>
               @if (draftExcluded().length === 0) {
-                <p class="mt-3 text-sm text-gray-500">{{ I18N.comparison.context.no_exclusions | translate }}</p>
+                <p class="mt-3 text-sm text-gray-500">{{ 'comparison.context.no_exclusions' | translate }}</p>
               }
             </mat-card-content>
           </mat-card>
@@ -335,7 +334,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
 
         <mat-card>
           <mat-card-header>
-            <mat-card-title>{{ I18N.comparison.context.effective_order_title | translate }}</mat-card-title>
+            <mat-card-title>{{ 'comparison.context.effective_order_title' | translate }}</mat-card-title>
           </mat-card-header>
           <mat-card-content class="!pt-4">
             <div class="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-400">
@@ -354,7 +353,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
           <mat-card-content class="!py-4 flex flex-col gap-3">
             <div class="flex items-center gap-2 text-sm text-amber-400">
               <mat-icon class="!text-base !w-4 !h-4">warning</mat-icon>
-              {{ I18N.comparison.context.stale_notice | translate }}
+              {{ 'comparison.context.stale_notice' | translate }}
             </div>
             @if (recomputeMessageKey(); as messageKey) {
               <div class="text-sm text-red-400">{{ messageKey | translate }}</div>
@@ -365,9 +364,9 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                   [value]="recomputeProgressPercent() ?? 0" />
                 @if (recomputeStatus()?.progress; as p) {
                   <span class="text-xs text-gray-500">
-                    {{ I18N.comparison.context.recompute_progress | translate:{ current: p.current ?? 0, total: p.total ?? 0 } }}
+                    {{ 'comparison.context.recompute_progress' | translate:{ current: p.current ?? 0, total: p.total ?? 0 } }}
                     @if (p.eta_seconds !== null && p.eta_seconds !== undefined) {
-                      &middot; {{ I18N.comparison.context.recompute_eta | translate:{ time: (p.eta_seconds | etaDuration) } }}
+                      &middot; {{ 'comparison.context.recompute_eta' | translate:{ time: (p.eta_seconds | etaDuration) } }}
                     }
                   </span>
                 }
@@ -378,7 +377,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                 (click)="startRecompute()">
                 <span class="inline-flex items-center gap-1.5">
                   <mat-icon class="!m-0">calculate</mat-icon>
-                  {{ I18N.comparison.context.recompute_now | translate }}
+                  {{ 'comparison.context.recompute_now' | translate }}
                 </span>
               </button>
             }
@@ -390,14 +389,14 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
       <mat-card>
         <mat-card-header class="!flex !items-start">
           <div class="flex-1">
-            <mat-card-title>{{ I18N.comparison.context.overlap_title | translate }}</mat-card-title>
-            <mat-card-subtitle>{{ I18N.comparison.context.overlap_description | translate }}</mat-card-subtitle>
+            <mat-card-title>{{ 'comparison.context.overlap_title' | translate }}</mat-card-title>
+            <mat-card-subtitle>{{ 'comparison.context.overlap_description' | translate }}</mat-card-subtitle>
           </div>
           <button mat-icon-button class="shrink-0"
             [disabled]="overlapLoading()"
             (click)="refreshOverlap()"
-            [matTooltip]="I18N.comparison.context.refresh_overlap | translate"
-            [attr.aria-label]="I18N.comparison.context.refresh_overlap | translate">
+            [matTooltip]="'comparison.context.refresh_overlap' | translate"
+            [attr.aria-label]="'comparison.context.refresh_overlap' | translate">
             <mat-icon>refresh</mat-icon>
           </button>
         </mat-card-header>
@@ -408,10 +407,10 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
             <table class="w-full text-sm">
               <thead>
                 <tr class="text-gray-400 text-left border-b border-[var(--mat-sys-outline-variant)]">
-                  <th class="pb-2 pr-4">{{ I18N.comparison.context.overlap_column_category | translate }}</th>
-                  <th class="pb-2 pr-4">{{ I18N.comparison.context.overlap_column_assigned | translate }}</th>
-                  <th class="pb-2 pr-4">{{ I18N.comparison.context.overlap_column_matched | translate }}</th>
-                  <th class="pb-2">{{ I18N.comparison.context.overlap_column_captured | translate }}</th>
+                  <th class="pb-2 pr-4">{{ 'comparison.context.overlap_column_category' | translate }}</th>
+                  <th class="pb-2 pr-4">{{ 'comparison.context.overlap_column_assigned' | translate }}</th>
+                  <th class="pb-2 pr-4">{{ 'comparison.context.overlap_column_matched' | translate }}</th>
+                  <th class="pb-2">{{ 'comparison.context.overlap_column_captured' | translate }}</th>
                 </tr>
               </thead>
               <tbody>
@@ -428,11 +427,11 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
               </tbody>
             </table>
           } @else if (overlapLoaded()) {
-            <p class="text-sm text-gray-500">{{ I18N.comparison.context.overlap_empty | translate }}</p>
+            <p class="text-sm text-gray-500">{{ 'comparison.context.overlap_empty' | translate }}</p>
           }
           @if (topOverlapPairs().length > 0) {
             <div class="mt-4 pt-3 border-t border-[var(--mat-sys-outline-variant)]">
-              <h4 class="text-xs uppercase tracking-wide text-gray-500 mb-2">{{ I18N.comparison.context.overlap_pairs_title | translate }}</h4>
+              <h4 class="text-xs uppercase tracking-wide text-gray-500 mb-2">{{ 'comparison.context.overlap_pairs_title' | translate }}</h4>
               <ul class="flex flex-col gap-1 text-sm">
                 @for (pair of topOverlapPairs(); track pair.pair[0] + pair.pair[1]) {
                   <li class="flex items-center justify-between gap-2">
@@ -451,7 +450,6 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
   `,
 })
 export class ComparisonPriorityTabComponent {
-  protected readonly I18N = I18N;
   protected readonly auth = inject(AuthService);
   private readonly api = inject(ApiService);
   private readonly i18n = inject(I18nService);
@@ -634,7 +632,7 @@ export class ComparisonPriorityTabComponent {
         this.resetContextDraft();
       }
     } catch {
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.error_loading_contexts), '', { duration: 4000 });
+      this.snackBar.open(this.i18n.t('comparison.context.error_loading_contexts'), '', { duration: 4000 });
     }
   }
 
@@ -651,10 +649,10 @@ export class ComparisonPriorityTabComponent {
       );
       this.stale.set(true);
       this.recomputeMessageKey.set(null);
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.context_saved), '', { duration: 3000 });
+      this.snackBar.open(this.i18n.t('comparison.context.context_saved'), '', { duration: 3000 });
       await this.loadContexts(ctx.name);
     } catch {
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.error_saving_context), '', { duration: 4000 });
+      this.snackBar.open(this.i18n.t('comparison.context.error_saving_context'), '', { duration: 4000 });
     } finally {
       this.savingContext.set(false);
     }
@@ -672,7 +670,7 @@ export class ComparisonPriorityTabComponent {
       this.orderedCategories.set(nonDefault);
       this.savedOrder.set(nonDefault.map(c => c.name));
     } catch {
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.error_loading_categories), '', { duration: 4000 });
+      this.snackBar.open(this.i18n.t('comparison.context.error_loading_categories'), '', { duration: 4000 });
     } finally {
       this.categoriesLoading.set(false);
     }
@@ -688,11 +686,11 @@ export class ComparisonPriorityTabComponent {
       this.savedOrder.set(this.orderedCategories().map(c => c.name));
       this.stale.set(true);
       this.recomputeMessageKey.set(null);
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.priorities_saved), '', { duration: 3000 });
+      this.snackBar.open(this.i18n.t('comparison.context.priorities_saved'), '', { duration: 3000 });
       void this.loadCategories();
       this.overlapLoaded.set(false);
     } catch {
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.error_saving_priorities), '', { duration: 4000 });
+      this.snackBar.open(this.i18n.t('comparison.context.error_saving_priorities'), '', { duration: 4000 });
     } finally {
       this.saving.set(false);
     }
@@ -706,7 +704,7 @@ export class ComparisonPriorityTabComponent {
       this.overlap.set(data);
       this.overlapLoaded.set(true);
     } catch {
-      this.snackBar.open(this.i18n.t(I18N.comparison.context.error_loading_overlap), '', { duration: 4000 });
+      this.snackBar.open(this.i18n.t('comparison.context.error_loading_overlap'), '', { duration: 4000 });
     } finally {
       this.overlapLoading.set(false);
     }
@@ -729,9 +727,9 @@ export class ComparisonPriorityTabComponent {
     } catch (err) {
       this.recomputing.set(false);
       if (err instanceof HttpErrorResponse && err.status === 409) {
-        this.recomputeMessageKey.set(I18N.comparison.context.recompute_conflict);
+        this.recomputeMessageKey.set('comparison.context.recompute_conflict');
       } else {
-        this.recomputeMessageKey.set(I18N.comparison.context.error_recompute);
+        this.recomputeMessageKey.set('comparison.context.error_recompute');
       }
     }
   }
@@ -749,18 +747,18 @@ export class ComparisonPriorityTabComponent {
         // cannot be trusted as either success or failure -- report it as
         // indeterminate rather than guessing.
         if (status.kind !== JOB_KIND_RECOMPUTE || status.exit_code === null) {
-          this.recomputeMessageKey.set(I18N.comparison.context.recompute_unknown);
+          this.recomputeMessageKey.set('comparison.context.recompute_unknown');
         } else if (status.exit_code === 0) {
           this.stale.set(false);
-          this.snackBar.open(this.i18n.t(I18N.comparison.context.recompute_done), '', { duration: 4000 });
+          this.snackBar.open(this.i18n.t('comparison.context.recompute_done'), '', { duration: 4000 });
         } else {
-          this.recomputeMessageKey.set(I18N.comparison.context.recompute_failed);
+          this.recomputeMessageKey.set('comparison.context.recompute_failed');
         }
       }
     } catch {
       this.stopRecomputePolling();
       this.recomputing.set(false);
-      this.recomputeMessageKey.set(I18N.comparison.context.recompute_unknown);
+      this.recomputeMessageKey.set('comparison.context.recompute_unknown');
     }
   }
 

--- a/client/src/app/features/comparison/comparison-weights-tab.component.spec.ts
+++ b/client/src/app/features/comparison/comparison-weights-tab.component.spec.ts
@@ -449,23 +449,6 @@ describe('ComparisonWeightsTabComponent', () => {
     });
   });
 
-  describe('getFilterTags', () => {
-    it('should join array as comma-separated', () => {
-      component.filters.set({ required_tags: ['landscape', 'mountain'] });
-      expect(component.getFilterTags('required_tags')).toBe('landscape, mountain');
-    });
-
-    it('should return empty string for missing key', () => {
-      component.filters.set({});
-      expect(component.getFilterTags('required_tags')).toBe('');
-    });
-
-    it('should return empty string for non-array value', () => {
-      component.filters.set({ required_tags: 'not-an-array' });
-      expect(component.getFilterTags('required_tags')).toBe('');
-    });
-  });
-
   describe('setFilterBool', () => {
     it('should set true for "true" string', () => {
       component.filters.set({});
@@ -489,23 +472,6 @@ describe('ComparisonWeightsTabComponent', () => {
       component.filters.set({ has_face: true, iso_min: 100 });
       component.setFilterBool('has_face', '');
       expect(component.filters()['iso_min']).toBe(100);
-    });
-  });
-
-  describe('getFilterBoolValue', () => {
-    it('should return "true" for true', () => {
-      component.filters.set({ has_face: true });
-      expect(component.getFilterBoolValue('has_face')).toBe('true');
-    });
-
-    it('should return "false" for false', () => {
-      component.filters.set({ has_face: false });
-      expect(component.getFilterBoolValue('has_face')).toBe('false');
-    });
-
-    it('should return empty string for missing key', () => {
-      component.filters.set({});
-      expect(component.getFilterBoolValue('has_face')).toBe('');
     });
   });
 
@@ -784,30 +750,6 @@ describe('ComparisonWeightsTabComponent', () => {
     it('should return empty array for empty weights', () => {
       component.weights.set({});
       expect(component.weightKeys()).toEqual([]);
-    });
-  });
-
-  describe('getModifierNum', () => {
-    it('should return numeric value when set', () => {
-      component.modifiers.set({ bonus: 2.5 });
-      expect(component.getModifierNum('bonus')).toBe(2.5);
-    });
-
-    it('should return null for missing key', () => {
-      component.modifiers.set({});
-      expect(component.getModifierNum('bonus')).toBeNull();
-    });
-  });
-
-  describe('getFilterNum', () => {
-    it('should return numeric value when set', () => {
-      component.filters.set({ face_ratio_min: 0.3 });
-      expect(component.getFilterNum('face_ratio_min')).toBe(0.3);
-    });
-
-    it('should return null for missing key', () => {
-      component.filters.set({});
-      expect(component.getFilterNum('face_ratio_min')).toBeNull();
     });
   });
 

--- a/client/src/app/features/comparison/comparison-weights-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-weights-tab.component.ts
@@ -25,7 +25,10 @@ import { FixedPipe } from '../../shared/pipes/fixed.pipe';
 import { ThumbnailUrlPipe } from '../../shared/pipes/thumbnail-url.pipe';
 import { CompareFiltersService } from './compare-filters.service';
 import { CategoryRecomputeService } from './category-recompute.service';
-import { WeightIconPipe, WeightLabelKeyPipe, FilterValueFormatPipe, ModifierValueFormatPipe } from './comparison.pipes';
+import {
+  WeightIconPipe, WeightLabelKeyPipe, FilterValueFormatPipe, ModifierValueFormatPipe,
+  RecordValuePipe, FilterTagsPipe, FilterBoolValuePipe,
+} from './comparison.pipes';
 import { I18N } from '../../core/i18n/keys';
 
 interface CategoryWeights {
@@ -100,6 +103,9 @@ class SignalErrorMatcher {
     WeightLabelKeyPipe,
     FilterValueFormatPipe,
     ModifierValueFormatPipe,
+    RecordValuePipe,
+    FilterTagsPipe,
+    FilterBoolValuePipe,
   ],
   template: `
     <ng-template #weightsActions>
@@ -240,9 +246,9 @@ class SignalErrorMatcher {
                 <mat-icon class="text-gray-400 shrink-0">add_circle</mat-icon>
                 <span class="w-40 shrink-0 text-sm">{{ I18N.comparison.modifier.bonus | translate }}</span>
                 <mat-slider class="grow" [min]="-5" [max]="5" [step]="0.1" [discrete]="true" [displayWith]="displayBonus">
-                  <input matSliderThumb [value]="getModifierNum('bonus') ?? 0" (valueChange)="setModifierNum('bonus', $event)" [attr.aria-label]="I18N.comparison.modifier.bonus | translate" />
+                  <input matSliderThumb [value]="(modifiers() | recordValue:'bonus') ?? 0" (valueChange)="setModifierNum('bonus', $event)" [attr.aria-label]="I18N.comparison.modifier.bonus | translate" />
                 </mat-slider>
-                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ getModifierNum('bonus') | modifierValueFormat:'bonus' }}</span>
+                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ (modifiers() | recordValue:'bonus') | modifierValueFormat:'bonus' }}</span>
               </div>
               <p class="text-xs text-gray-500 ml-11 mt-0.5">{{ I18N.comparison.modifier.bonus_hint | translate }}</p>
             </div>
@@ -251,9 +257,9 @@ class SignalErrorMatcher {
                 <mat-icon class="text-gray-400 shrink-0">grain</mat-icon>
                 <span class="w-40 shrink-0 text-sm">{{ I18N.comparison.modifier.noise_tolerance | translate }}</span>
                 <mat-slider class="grow" [min]="0" [max]="200" [step]="5" [discrete]="true" [displayWith]="displayPercent">
-                  <input matSliderThumb [value]="(getModifierNum('noise_tolerance_multiplier') ?? 1) * 100" (valueChange)="setModifierNum('noise_tolerance_multiplier', $event / 100)" [attr.aria-label]="I18N.comparison.modifier.noise_tolerance | translate" />
+                  <input matSliderThumb [value]="((modifiers() | recordValue:'noise_tolerance_multiplier') ?? 1) * 100" (valueChange)="setModifierNum('noise_tolerance_multiplier', $event / 100)" [attr.aria-label]="I18N.comparison.modifier.noise_tolerance | translate" />
                 </mat-slider>
-                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ getModifierNum('noise_tolerance_multiplier') | modifierValueFormat:'noise_tolerance_multiplier' }}</span>
+                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ (modifiers() | recordValue:'noise_tolerance_multiplier') | modifierValueFormat:'noise_tolerance_multiplier' }}</span>
               </div>
               <p class="text-xs text-gray-500 ml-11 mt-0.5">{{ I18N.comparison.modifier.noise_tolerance_hint | translate }}</p>
             </div>
@@ -262,9 +268,9 @@ class SignalErrorMatcher {
                 <mat-icon class="text-gray-400 shrink-0">highlight</mat-icon>
                 <span class="w-40 shrink-0 text-sm">{{ I18N.comparison.modifier.clipping_multiplier | translate }}</span>
                 <mat-slider class="grow" [min]="0" [max]="500" [step]="10" [discrete]="true" [displayWith]="displayPercent">
-                  <input matSliderThumb [value]="(getModifierNum('_clipping_multiplier') ?? 1) * 100" (valueChange)="setModifierNum('_clipping_multiplier', $event / 100)" [attr.aria-label]="I18N.comparison.modifier.clipping_multiplier | translate" />
+                  <input matSliderThumb [value]="((modifiers() | recordValue:'_clipping_multiplier') ?? 1) * 100" (valueChange)="setModifierNum('_clipping_multiplier', $event / 100)" [attr.aria-label]="I18N.comparison.modifier.clipping_multiplier | translate" />
                 </mat-slider>
-                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ getModifierNum('_clipping_multiplier') | modifierValueFormat:'_clipping_multiplier' }}</span>
+                <span class="w-16 text-right text-sm font-mono tabular-nums">{{ (modifiers() | recordValue:'_clipping_multiplier') | modifierValueFormat:'_clipping_multiplier' }}</span>
               </div>
               <p class="text-xs text-gray-500 ml-11 mt-0.5">{{ I18N.comparison.modifier.clipping_multiplier_hint | translate }}</p>
             </div>
@@ -302,13 +308,13 @@ class SignalErrorMatcher {
             <mat-form-field>
               <mat-label>{{ I18N.comparison.filter.required_tags | translate }}</mat-label>
               <input matInput type="text" [placeholder]="I18N.comparison.filter.tags_placeholder | translate"
-                [ngModel]="getFilterTags('required_tags')" (ngModelChange)="setFilterTags('required_tags', $event)" />
+                [ngModel]="filters() | filterTags:'required_tags'" (ngModelChange)="setFilterTags('required_tags', $event)" />
               <mat-hint>{{ I18N.comparison.filter.required_tags_hint | translate }}</mat-hint>
             </mat-form-field>
             <mat-form-field>
               <mat-label>{{ I18N.comparison.filter.excluded_tags | translate }}</mat-label>
               <input matInput type="text" [placeholder]="I18N.comparison.filter.tags_placeholder | translate"
-                [ngModel]="getFilterTags('excluded_tags')" (ngModelChange)="setFilterTags('excluded_tags', $event)" />
+                [ngModel]="filters() | filterTags:'excluded_tags'" (ngModelChange)="setFilterTags('excluded_tags', $event)" />
               <mat-hint>{{ I18N.comparison.filter.excluded_tags_hint | translate }}</mat-hint>
             </mat-form-field>
             <mat-form-field>
@@ -323,7 +329,7 @@ class SignalErrorMatcher {
             @for (boolKey of booleanFilterKeys; track boolKey) {
               <mat-form-field>
                 <mat-label>{{ ('comparison.filter.' + boolKey) | translate }}</mat-label>
-                <mat-select [value]="getFilterBoolValue(boolKey)" (selectionChange)="setFilterBool(boolKey, $event.value)">
+                <mat-select [value]="filters() | filterBoolValue:boolKey" (selectionChange)="setFilterBool(boolKey, $event.value)">
                   <mat-option value="">{{ I18N.comparison.filter.any | translate }}</mat-option>
                   <mat-option value="true">{{ I18N.comparison.filter.boolean_true | translate }}</mat-option>
                   <mat-option value="false">{{ I18N.comparison.filter.boolean_false | translate }}</mat-option>
@@ -340,8 +346,8 @@ class SignalErrorMatcher {
                     <mat-label>{{ I18N.comparison.filter.min | translate }}</mat-label>
                     <input matInput type="number" [step]="range.step" [placeholder]="range.placeholder[0]"
                       [errorStateMatcher]="filterMatchers[range.minKey]"
-                      [ngModel]="getFilterNum(range.minKey)" (ngModelChange)="setFilterNum(range.minKey, $event)" />
-                    <span matTextSuffix class="text-xs text-gray-400 ml-1">{{ getFilterNum(range.minKey) | filterValueFormat:range.minKey }}</span>
+                      [ngModel]="filters() | recordValue:range.minKey" (ngModelChange)="setFilterNum(range.minKey, $event)" />
+                    <span matTextSuffix class="text-xs text-gray-400 ml-1">{{ (filters() | recordValue:range.minKey) | filterValueFormat:range.minKey }}</span>
                     @if (filterErrors()[range.minKey]) {
                       <mat-error>{{ filterErrors()[range.minKey] | translate }}</mat-error>
                     }
@@ -350,8 +356,8 @@ class SignalErrorMatcher {
                     <mat-label>{{ I18N.comparison.filter.max | translate }}</mat-label>
                     <input matInput type="number" [step]="range.step" [placeholder]="range.placeholder[1]"
                       [errorStateMatcher]="filterMatchers[range.maxKey]"
-                      [ngModel]="getFilterNum(range.maxKey)" (ngModelChange)="setFilterNum(range.maxKey, $event)" />
-                    <span matTextSuffix class="text-xs text-gray-400 ml-1">{{ getFilterNum(range.maxKey) | filterValueFormat:range.maxKey }}</span>
+                      [ngModel]="filters() | recordValue:range.maxKey" (ngModelChange)="setFilterNum(range.maxKey, $event)" />
+                    <span matTextSuffix class="text-xs text-gray-400 ml-1">{{ (filters() | recordValue:range.maxKey) | filterValueFormat:range.maxKey }}</span>
                     @if (filterErrors()[range.maxKey]) {
                       <mat-error>{{ filterErrors()[range.maxKey] | translate }}</mat-error>
                     }
@@ -604,11 +610,6 @@ export class ComparisonWeightsTabComponent {
     this.weights.set(normalized);
   }
 
-  getModifierNum(key: string): number | null {
-    const v = this.modifiers()[key];
-    return v !== undefined && v !== null ? (v as number) : null;
-  }
-
   setModifierNum(key: string, value: number | null): void {
     this.modifiers.update(m => {
       const next = { ...m };
@@ -627,12 +628,6 @@ export class ComparisonWeightsTabComponent {
     });
   }
 
-  getFilterTags(key: string): string {
-    const v = this.filters()[key];
-    if (Array.isArray(v)) return v.join(', ');
-    return '';
-  }
-
   setFilterTags(key: string, value: string): void {
     this.filters.update(f => {
       const next = { ...f };
@@ -643,13 +638,6 @@ export class ComparisonWeightsTabComponent {
     });
   }
 
-  getFilterBoolValue(key: string): string {
-    const v = this.filters()[key];
-    if (v === true) return 'true';
-    if (v === false) return 'false';
-    return '';
-  }
-
   setFilterBool(key: string, value: string): void {
     this.filters.update(f => {
       const next = { ...f };
@@ -658,11 +646,6 @@ export class ComparisonWeightsTabComponent {
       else delete next[key];
       return next;
     });
-  }
-
-  getFilterNum(key: string): number | null {
-    const v = this.filters()[key];
-    return v !== undefined && v !== null ? (v as number) : null;
   }
 
   setFilterNum(key: string, value: number | null): void {

--- a/client/src/app/features/comparison/comparison.pipes.spec.ts
+++ b/client/src/app/features/comparison/comparison.pipes.spec.ts
@@ -1,4 +1,7 @@
-import { EtaDurationPipe, FilterValueFormatPipe, ModifierValueFormatPipe, WeightIconPipe, WeightLabelKeyPipe } from './comparison.pipes';
+import {
+  EtaDurationPipe, FilterValueFormatPipe, ModifierValueFormatPipe, WeightIconPipe, WeightLabelKeyPipe,
+  RecordValuePipe, FilterTagsPipe, FilterBoolValuePipe,
+} from './comparison.pipes';
 
 describe('WeightIconPipe', () => {
   const pipe = new WeightIconPipe();
@@ -190,5 +193,65 @@ describe('ModifierValueFormatPipe', () => {
 
   it('returns empty string for unknown key', () => {
     expect(pipe.transform(42, 'unknown_modifier')).toBe('');
+  });
+});
+
+describe('RecordValuePipe', () => {
+  const pipe = new RecordValuePipe();
+
+  it('returns numeric value when set', () => {
+    expect(pipe.transform({ bonus: 2.5 }, 'bonus')).toBe(2.5);
+    expect(pipe.transform({ face_ratio_min: 0.3 }, 'face_ratio_min')).toBe(0.3);
+  });
+
+  it('returns null for a missing key', () => {
+    expect(pipe.transform({}, 'bonus')).toBeNull();
+  });
+
+  it('returns null for a null/undefined record', () => {
+    expect(pipe.transform(null, 'bonus')).toBeNull();
+    expect(pipe.transform(undefined, 'bonus')).toBeNull();
+  });
+});
+
+describe('FilterTagsPipe', () => {
+  const pipe = new FilterTagsPipe();
+
+  it('joins array as comma-separated', () => {
+    expect(pipe.transform({ required_tags: ['landscape', 'mountain'] }, 'required_tags')).toBe('landscape, mountain');
+  });
+
+  it('returns empty string for missing key', () => {
+    expect(pipe.transform({}, 'required_tags')).toBe('');
+  });
+
+  it('returns empty string for non-array value', () => {
+    expect(pipe.transform({ required_tags: 'not-an-array' }, 'required_tags')).toBe('');
+  });
+
+  it('returns empty string for a null/undefined record', () => {
+    expect(pipe.transform(null, 'required_tags')).toBe('');
+    expect(pipe.transform(undefined, 'required_tags')).toBe('');
+  });
+});
+
+describe('FilterBoolValuePipe', () => {
+  const pipe = new FilterBoolValuePipe();
+
+  it('returns "true" for true', () => {
+    expect(pipe.transform({ has_face: true }, 'has_face')).toBe('true');
+  });
+
+  it('returns "false" for false', () => {
+    expect(pipe.transform({ has_face: false }, 'has_face')).toBe('false');
+  });
+
+  it('returns empty string for missing key', () => {
+    expect(pipe.transform({}, 'has_face')).toBe('');
+  });
+
+  it('returns empty string for a null/undefined record', () => {
+    expect(pipe.transform(null, 'has_face')).toBe('');
+    expect(pipe.transform(undefined, 'has_face')).toBe('');
   });
 });

--- a/client/src/app/features/comparison/comparison.pipes.ts
+++ b/client/src/app/features/comparison/comparison.pipes.ts
@@ -108,3 +108,39 @@ export class ModifierValueFormatPipe implements PipeTransform {
     return '';
   }
 }
+
+/**
+ * Pure numeric lookup out of a modifiers/filters record snapshot, for use
+ * directly in template bindings instead of a component getter method
+ * (CLAUDE.md: no method calls in templates -- a pure pipe only re-evaluates
+ * when its record/key inputs change identity, unlike a method invoked on
+ * every change-detection pass).
+ */
+@Pipe({ name: 'recordValue', standalone: true, pure: true })
+export class RecordValuePipe implements PipeTransform {
+  transform(record: Record<string, unknown> | null | undefined, key: string): number | null {
+    if (!record) return null;
+    const v = record[key];
+    return v !== undefined && v !== null ? (v as number) : null;
+  }
+}
+
+/** Pure lookup of a filters record's tag-array field as a comma-joined string. */
+@Pipe({ name: 'filterTags', standalone: true, pure: true })
+export class FilterTagsPipe implements PipeTransform {
+  transform(filters: Record<string, unknown> | null | undefined, key: string): string {
+    const v = filters?.[key];
+    return Array.isArray(v) ? v.join(', ') : '';
+  }
+}
+
+/** Pure lookup of a filters record's tri-state boolean as a mat-select value (''|'true'|'false'). */
+@Pipe({ name: 'filterBoolValue', standalone: true, pure: true })
+export class FilterBoolValuePipe implements PipeTransform {
+  transform(filters: Record<string, unknown> | null | undefined, key: string): string {
+    const v = filters?.[key];
+    if (v === true) return 'true';
+    if (v === false) return 'false';
+    return '';
+  }
+}

--- a/client/src/app/features/gallery/compare-selected-dialog.component.ts
+++ b/client/src/app/features/gallery/compare-selected-dialog.component.ts
@@ -7,7 +7,6 @@ import { Photo } from '../../shared/models/photo.model';
 import { ThumbnailUrlPipe, ImageUrlPipe } from '../../shared/pipes/thumbnail-url.pipe';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { SyncedZoomComponent, ZoomState, FIT_ZOOM, MAX_COMPARE_PANES } from './synced-zoom.component';
-import { I18N } from '../../core/i18n/keys';
 
 export interface CompareSelectedData {
   photos: Photo[];
@@ -34,18 +33,18 @@ export interface CompareSelectedData {
     <div class="flex flex-col h-full bg-black">
       <div class="flex items-center gap-2 px-3 py-2 text-white/90 text-sm shrink-0">
         <mat-icon class="!text-base !w-5 !h-5 !leading-5">compare</mat-icon>
-        <span class="flex-1 truncate">{{ I18N.gallery.compare.title | translate:{ count: panes().length } }}</span>
+        <span class="flex-1 truncate">{{ 'gallery.compare.title' | translate:{ count: panes().length } }}</span>
         @if (zoomed()) {
           <button mat-icon-button class="!text-white"
-                  [matTooltip]="I18N.gallery.compare.reset_zoom | translate"
-                  [attr.aria-label]="I18N.gallery.compare.reset_zoom | translate"
+                  [matTooltip]="'gallery.compare.reset_zoom' | translate"
+                  [attr.aria-label]="'gallery.compare.reset_zoom' | translate"
                   (click)="resetZoom()">
             <mat-icon>zoom_out_map</mat-icon>
           </button>
         }
         <button mat-icon-button class="!text-white"
-                [matTooltip]="I18N.dialog.close | translate"
-                [attr.aria-label]="I18N.dialog.close | translate"
+                [matTooltip]="'dialog.close' | translate"
+                [attr.aria-label]="'dialog.close' | translate"
                 (click)="close()">
           <mat-icon>close</mat-icon>
         </button>
@@ -70,14 +69,13 @@ export interface CompareSelectedData {
       </div>
 
       <div class="px-3 py-2 text-center text-white/60 text-xs shrink-0">
-        {{ I18N.gallery.compare.hint | translate }}
+        {{ 'gallery.compare.hint' | translate }}
       </div>
     </div>
   `,
   host: { class: 'block h-full' },
 })
 export class CompareSelectedDialogComponent {
-  protected readonly I18N = I18N;
   private readonly dialogRef = inject(MatDialogRef<CompareSelectedDialogComponent>);
   private readonly data = inject<CompareSelectedData>(MAT_DIALOG_DATA);
 

--- a/client/src/app/features/gallery/folder-picker-dialog.component.ts
+++ b/client/src/app/features/gallery/folder-picker-dialog.component.ts
@@ -9,7 +9,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { firstValueFrom } from 'rxjs';
 import { ApiService } from '../../core/services/api.service';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
-import { I18N } from '../../core/i18n/keys';
 import {
   buildFolderBreadcrumbs,
   folderDisplayName,
@@ -35,12 +34,12 @@ export interface FolderPickerData {
     TranslatePipe,
   ],
   template: `
-    <h2 mat-dialog-title>{{ I18N.gallery.choose_folder | translate }}</h2>
+    <h2 mat-dialog-title>{{ 'gallery.choose_folder' | translate }}</h2>
     <mat-dialog-content class="!flex !flex-col gap-2 min-w-[320px]">
       <nav class="flex items-center gap-1 text-sm flex-wrap">
         <button mat-button class="!min-w-0 !px-2" (click)="navigateTo('')">
           <mat-icon class="!text-base !w-4 !h-4 !leading-4 mr-1">home</mat-icon>
-          {{ I18N.folders.root | translate }}
+          {{ 'folders.root' | translate }}
         </button>
         @for (crumb of breadcrumbs(); track crumb.path) {
           <mat-icon class="!text-base !w-4 !h-4 !leading-4 opacity-40">chevron_right</mat-icon>
@@ -54,12 +53,12 @@ export interface FolderPickerData {
 
       <div class="flex items-center gap-2 rounded-lg bg-[var(--mat-sys-surface-container-high)] px-3 py-2">
         <mat-icon class="!text-base !w-5 !h-5 !leading-5 opacity-60">filter_alt</mat-icon>
-        <span class="text-xs opacity-70">{{ I18N.gallery.use_this_folder | translate }}</span>
+        <span class="text-xs opacity-70">{{ 'gallery.use_this_folder' | translate }}</span>
         <span class="text-sm font-medium truncate">
           @if (prefix()) {
             {{ currentName() }}
           } @else {
-            {{ I18N.gallery.all_folders | translate }}
+            {{ 'gallery.all_folders' | translate }}
           }
         </span>
       </div>
@@ -68,8 +67,8 @@ export interface FolderPickerData {
         <mat-form-field subscriptSizing="dynamic" class="w-full">
           <mat-icon matPrefix class="mr-1 opacity-60">search</mat-icon>
           <input matInput
-                 [placeholder]="I18N.folders.find_folder | translate"
-                 [attr.aria-label]="I18N.folders.find_folder | translate"
+                 [placeholder]="'folders.find_folder' | translate"
+                 [attr.aria-label]="'folders.find_folder' | translate"
                  [value]="query()"
                  (input)="query.set($any($event.target).value)" />
         </mat-form-field>
@@ -81,14 +80,14 @@ export interface FolderPickerData {
         </div>
       } @else if (loadError()) {
         <div class="flex flex-col items-center gap-2 px-1 py-6">
-          <p class="text-xs opacity-70 text-center">{{ I18N.folders.load_error.message | translate }}</p>
+          <p class="text-xs opacity-70 text-center">{{ 'folders.load_error.message' | translate }}</p>
           <button mat-stroked-button (click)="retry()">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 mr-1">refresh</mat-icon>
-            {{ I18N.gallery.load_error.retry | translate }}
+            {{ 'gallery.load_error.retry' | translate }}
           </button>
         </div>
       } @else if (!filteredChildren().length) {
-        <p class="text-xs opacity-50 px-1 py-6 text-center">{{ I18N.folders.empty | translate }}</p>
+        <p class="text-xs opacity-50 px-1 py-6 text-center">{{ 'folders.empty' | translate }}</p>
       } @else {
         <div class="flex flex-col gap-1 max-h-[360px] overflow-y-auto">
           @for (folder of filteredChildren(); track folder.path) {
@@ -106,13 +105,12 @@ export interface FolderPickerData {
       }
     </mat-dialog-content>
     <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>{{ I18N.ui.buttons.cancel | translate }}</button>
-      <button mat-flat-button (click)="dialogRef.close(prefix())">{{ I18N.ui.buttons.apply | translate }}</button>
+      <button mat-button mat-dialog-close>{{ 'ui.buttons.cancel' | translate }}</button>
+      <button mat-flat-button (click)="dialogRef.close(prefix())">{{ 'ui.buttons.apply' | translate }}</button>
     </mat-dialog-actions>
   `,
 })
 export class FolderPickerDialogComponent {
-  protected readonly I18N = I18N;
   private readonly api = inject(ApiService);
   readonly dialogRef = inject(MatDialogRef<FolderPickerDialogComponent>);
   private readonly data: FolderPickerData = inject(MAT_DIALOG_DATA, { optional: true }) ?? {};

--- a/client/src/app/features/gallery/gallery.store.spec.ts
+++ b/client/src/app/features/gallery/gallery.store.spec.ts
@@ -1104,6 +1104,46 @@ describe('GalleryStore optimistic mutations', () => {
     expect(store.photos()[1].is_favorite).toBe(false);
   });
 
+  it('ignores a second toggleFavorite call for the same path while the first is still in flight', async () => {
+    const response = new Subject<{ is_favorite: boolean }>();
+    apiPost.mockReturnValue(response.asObservable());
+
+    const first = store.toggleFavorite('/a.jpg');
+    const second = store.toggleFavorite('/a.jpg'); // dropped -- a call for this path is already in flight
+
+    response.next({ is_favorite: true });
+    response.complete();
+    await Promise.all([first, second]);
+
+    expect(apiPost).toHaveBeenCalledTimes(1);
+    expect(store.photos()[0].is_favorite).toBe(true);
+  });
+
+  it('does not let an in-flight toggleFavorite block a later call once it has settled', async () => {
+    apiPost.mockReturnValue(of({ is_favorite: true }));
+    await store.toggleFavorite('/a.jpg');
+    apiPost.mockReturnValue(of({ is_favorite: false }));
+    await store.toggleFavorite('/a.jpg');
+
+    expect(apiPost).toHaveBeenCalledTimes(2);
+    expect(store.photos()[0].is_favorite).toBe(false);
+  });
+
+  it('a pending toggleFavorite also blocks a toggleRejected for the same path (shared guard)', async () => {
+    const response = new Subject<{ is_favorite: boolean }>();
+    apiPost.mockReturnValue(response.asObservable());
+
+    const first = store.toggleFavorite('/a.jpg');
+    const second = store.toggleRejected('/a.jpg'); // dropped -- overlapping fields, same path in flight
+
+    response.next({ is_favorite: true });
+    response.complete();
+    await Promise.all([first, second]);
+
+    expect(apiPost).toHaveBeenCalledTimes(1);
+    expect(store.photos()[0].is_rejected).toBe(false);
+  });
+
   it('batchReject returns the pre-mutation snapshot on success', async () => {
     const snap = await store.batchReject(['/a.jpg', '/b.jpg']);
     expect(snap).not.toBeNull();
@@ -1140,9 +1180,11 @@ describe('GalleryStore optimistic mutations', () => {
 describe('GalleryStore restoreSnapshot', () => {
   let store: GalleryStore;
   let apiPost: Mock;
+  let snackOpen: Mock;
 
   beforeEach(() => {
     apiPost = vi.fn(() => of({}));
+    snackOpen = vi.fn();
     TestBed.configureTestingModule({
       providers: [
         GalleryStore,
@@ -1151,7 +1193,7 @@ describe('GalleryStore restoreSnapshot', () => {
         { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },
         { provide: AuthService, useValue: { isEdition: vi.fn(() => false) } },
         { provide: AlbumService, useValue: { list: vi.fn(() => of({ albums: [] })), update: vi.fn(() => of({})) } },
-        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MatSnackBar, useValue: { open: snackOpen } },
         { provide: I18nService, useValue: { t: (k: string) => k } },
       ],
     });
@@ -1205,6 +1247,33 @@ describe('GalleryStore restoreSnapshot', () => {
       ['/a.jpg', { is_favorite: false, is_rejected: false, star_rating: null }],
     ]));
     expect(apiPost).not.toHaveBeenCalled();
+  });
+
+  it('reverts only the photos whose restore call succeeded, and notifies on partial failure', async () => {
+    store.photos.set([
+      makePhoto({ path: '/a.jpg', is_rejected: true, is_favorite: false, star_rating: null }),
+      makePhoto({ path: '/b.jpg', is_rejected: true, is_favorite: false, star_rating: null }),
+    ]);
+    const snap = new Map([
+      ['/a.jpg', { is_favorite: false, is_rejected: false, star_rating: null }],
+      ['/b.jpg', { is_favorite: false, is_rejected: false, star_rating: null }],
+    ]);
+    // /b.jpg's inverse call fails server-side; /a.jpg's succeeds.
+    apiPost.mockImplementation((url: string, body: { photo_path?: string }) => {
+      if (url === '/photo/toggle_rejected' && body.photo_path === '/b.jpg') {
+        return throwError(() => new Error('boom'));
+      }
+      return of({});
+    });
+
+    await store.restoreSnapshot(snap);
+
+    // /a.jpg's call succeeded server-side, so local state is reverted to match.
+    expect(store.photos().find(p => p.path === '/a.jpg')!.is_rejected).toBe(false);
+    // /b.jpg's call failed server-side (still rejected there), so local state must
+    // NOT be blindly reverted to "unrejected" -- that would disagree with the server.
+    expect(store.photos().find(p => p.path === '/b.jpg')!.is_rejected).toBe(true);
+    expect(snackOpen).toHaveBeenCalled();
   });
 });
 

--- a/client/src/app/features/gallery/gallery.store.ts
+++ b/client/src/app/features/gallery/gallery.store.ts
@@ -740,51 +740,75 @@ export class GalleryStore {
     }
   }
 
+  /**
+   * Paths with an in-flight toggleFavorite/toggleRejected call. Shared between
+   * both methods (not just per-method) because they mutate overlapping fields
+   * (rejecting clears favorite and vice versa): a reject fired while a favorite
+   * call for the same photo is still pending is just as much a race as a second
+   * favorite click. A second call for a path already in flight is dropped
+   * rather than queued -- the in-flight call's own response reconciliation
+   * already brings local state to server truth, so queuing would only replay
+   * a now-stale intent.
+   */
+  private readonly toggleInFlight = new Set<string>();
+
   /** Toggle favorite flag for a photo. Optimistic, reconciled with server truth. */
   async toggleFavorite(photoPath: string): Promise<void> {
-    const snap = this.snapshotFlags([photoPath]);
-    const prev = snap.get(photoPath);
-    if (!prev) return;
-    const next = !prev.is_favorite;
-    this.patchPhoto(photoPath, {
-      is_favorite: next,
-      is_rejected: next ? false : prev.is_rejected,
-    });
+    if (this.toggleInFlight.has(photoPath)) return;
+    this.toggleInFlight.add(photoPath);
     try {
-      const res = await firstValueFrom(
-        this.api.post<{ is_favorite: boolean }>('/photo/toggle_favorite', { photo_path: photoPath }),
-      );
+      const snap = this.snapshotFlags([photoPath]);
+      const prev = snap.get(photoPath);
+      if (!prev) return;
+      const next = !prev.is_favorite;
       this.patchPhoto(photoPath, {
-        is_favorite: res.is_favorite,
-        is_rejected: res.is_favorite ? false : prev.is_rejected,
+        is_favorite: next,
+        is_rejected: next ? false : prev.is_rejected,
       });
-    } catch {
-      this.revertSnapshot(snap);
-      this.notifyActionFailed();
+      try {
+        const res = await firstValueFrom(
+          this.api.post<{ is_favorite: boolean }>('/photo/toggle_favorite', { photo_path: photoPath }),
+        );
+        this.patchPhoto(photoPath, {
+          is_favorite: res.is_favorite,
+          is_rejected: res.is_favorite ? false : prev.is_rejected,
+        });
+      } catch {
+        this.revertSnapshot(snap);
+        this.notifyActionFailed();
+      }
+    } finally {
+      this.toggleInFlight.delete(photoPath);
     }
   }
 
   /** Toggle rejected flag for a photo. Optimistic, reconciled with server truth. */
   async toggleRejected(photoPath: string): Promise<void> {
-    const snap = this.snapshotFlags([photoPath]);
-    const prev = snap.get(photoPath);
-    if (!prev) return;
-    const next = !prev.is_rejected;
-    this.patchPhoto(photoPath, {
-      is_rejected: next,
-      is_favorite: next ? false : prev.is_favorite,
-    });
+    if (this.toggleInFlight.has(photoPath)) return;
+    this.toggleInFlight.add(photoPath);
     try {
-      const res = await firstValueFrom(
-        this.api.post<{ is_rejected: boolean }>('/photo/toggle_rejected', { photo_path: photoPath }),
-      );
+      const snap = this.snapshotFlags([photoPath]);
+      const prev = snap.get(photoPath);
+      if (!prev) return;
+      const next = !prev.is_rejected;
       this.patchPhoto(photoPath, {
-        is_rejected: res.is_rejected,
-        is_favorite: res.is_rejected ? false : prev.is_favorite,
+        is_rejected: next,
+        is_favorite: next ? false : prev.is_favorite,
       });
-    } catch {
-      this.revertSnapshot(snap);
-      this.notifyActionFailed();
+      try {
+        const res = await firstValueFrom(
+          this.api.post<{ is_rejected: boolean }>('/photo/toggle_rejected', { photo_path: photoPath }),
+        );
+        this.patchPhoto(photoPath, {
+          is_rejected: res.is_rejected,
+          is_favorite: res.is_rejected ? false : prev.is_favorite,
+        });
+      } catch {
+        this.revertSnapshot(snap);
+        this.notifyActionFailed();
+      }
+    } finally {
+      this.toggleInFlight.delete(photoPath);
     }
   }
 
@@ -869,16 +893,27 @@ export class GalleryStore {
     }
   }
 
-  /** Run up to `limit` async tasks concurrently. */
-  private async runChunked(tasks: (() => Promise<unknown>)[], limit = 10): Promise<void> {
+  /** Run up to `limit` path-keyed async tasks concurrently. Returns the paths whose task rejected. */
+  private async runChunked(tasks: { path: string; run: () => Promise<unknown> }[], limit = 10): Promise<Set<string>> {
+    const failed = new Set<string>();
     for (let i = 0; i < tasks.length; i += limit) {
-      await Promise.allSettled(tasks.slice(i, i + limit).map(t => t()));
+      const batch = tasks.slice(i, i + limit);
+      const results = await Promise.allSettled(batch.map(t => t.run()));
+      results.forEach((r, idx) => { if (r.status === 'rejected') failed.add(batch[idx].path); });
     }
+    return failed;
   }
 
   /**
    * Restore photos to a previously captured flag snapshot via inverse API
    * calls, then patch local state. Powers undo of batch operations.
+   *
+   * Each API call's outcome is tracked per photo path: only paths whose calls
+   * all succeeded are reverted locally to the snapshot's target state. A path
+   * with any failed call keeps its current (unreverted) local state, since we
+   * cannot know how much of its restore actually landed server-side, and the
+   * user is notified rather than left with a UI that silently disagrees with
+   * the server.
    */
   async restoreSnapshot(snap: Map<string, PhotoFlagSnapshot>): Promise<void> {
     const current = new Map(this.photos().map(p => [p.path, p]));
@@ -906,23 +941,35 @@ export class GalleryStore {
       }
     }
 
+    const failed = new Set<string>();
+    const runBatch = async (paths: string[], post: () => Promise<unknown>): Promise<void> => {
+      if (!paths.length) return;
+      try {
+        await post();
+      } catch {
+        paths.forEach(p => failed.add(p));
+      }
+    };
+
     // Order matters: clear rejected first (rejecting wipes rating+favorite
     // server-side), then re-apply rejected/favorite/rating states
-    await this.runChunked(toUnreject.map(path => () =>
-      firstValueFrom(this.api.post('/photo/toggle_rejected', { photo_path: path }))));
-    if (toReject.length) {
-      await firstValueFrom(this.api.post('/photos/batch_reject', { photo_paths: toReject }));
-    }
-    if (toFavorite.length) {
-      await firstValueFrom(this.api.post('/photos/batch_favorite', { photo_paths: toFavorite }));
-    }
-    await this.runChunked(toUnfavorite.map(path => () =>
-      firstValueFrom(this.api.post('/photo/toggle_favorite', { photo_path: path }))));
+    (await this.runChunked(toUnreject.map(path => ({
+      path,
+      run: () => firstValueFrom(this.api.post('/photo/toggle_rejected', { photo_path: path })),
+    })))).forEach(p => failed.add(p));
+    await runBatch(toReject, () => firstValueFrom(this.api.post('/photos/batch_reject', { photo_paths: toReject })));
+    await runBatch(toFavorite, () => firstValueFrom(this.api.post('/photos/batch_favorite', { photo_paths: toFavorite })));
+    (await this.runChunked(toUnfavorite.map(path => ({
+      path,
+      run: () => firstValueFrom(this.api.post('/photo/toggle_favorite', { photo_path: path })),
+    })))).forEach(p => failed.add(p));
     for (const [rating, paths] of ratingGroups) {
-      await firstValueFrom(this.api.post('/photos/batch_rating', { photo_paths: paths, rating }));
+      await runBatch(paths, () => firstValueFrom(this.api.post('/photos/batch_rating', { photo_paths: paths, rating })));
     }
 
-    this.revertSnapshot(snap);
+    const succeeded = new Map([...snap].filter(([path]) => !failed.has(path)));
+    if (succeeded.size > 0) this.revertSnapshot(succeeded);
+    if (failed.size > 0) this.notifyActionFailed();
   }
 
   /** Unassign a person from a photo */
@@ -971,8 +1018,8 @@ export class GalleryStore {
     }
   }
 
-  /** Assign a single face to a person */
-  async assignFace(faceId: number, personId: number, photoPath: string, personName: string): Promise<void> {
+  /** Assign a single face to a person. Returns true on success, false on failure. */
+  async assignFace(faceId: number, personId: number, photoPath: string, personName: string): Promise<boolean> {
     try {
       await firstValueFrom(this.api.post(`/face/${faceId}/assign`, { person_id: personId }));
       this.photos.update(photos =>
@@ -986,7 +1033,10 @@ export class GalleryStore {
           };
         }),
       );
-    } catch { /* ignore */ }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /** Sync current filters to URL query params */

--- a/client/src/app/features/map/map.component.spec.ts
+++ b/client/src/app/features/map/map.component.spec.ts
@@ -25,9 +25,13 @@ describe('MapComponent', () => {
   let component: any;
   let mockApi: { get: Mock; thumbnailUrl: Mock };
 
+  // Explicit hook timeout above the default 10s: under full-suite load, many
+  // workers resolving dynamic import() chunks concurrently can contend for
+  // longer than that, and this hook flaking looks like a broken suite rather
+  // than the load-dependent timing issue it actually is.
   beforeAll(async () => {
     ({ MapComponent } = await import('./map.component'));
-  });
+  }, 20000);
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -60,8 +64,16 @@ describe('MapComponent', () => {
     it('should escape HTML special characters', () => {
       expect(component.escapeHtml('<script>alert("xss")</script>')).not.toContain('<script>');
       expect(component.escapeHtml('a & b')).toBe('a &amp; b');
-      // textContent/innerHTML does not escape quotes, but does escape <, >, &
+      // textContent/innerHTML escapes <, >, & natively.
       expect(component.escapeHtml('<b>bold</b>')).not.toContain('<b>');
+    });
+
+    it('should escape quote characters so they cannot break out of a double-quoted HTML attribute', () => {
+      // Every caller interpolates this into src="...", alt="..." or
+      // data-photo-path="...". An unescaped `"` would close the attribute
+      // early, letting the rest of the string inject a new attribute/handler.
+      expect(component.escapeHtml('photo".onerror="alert(1)')).toBe('photo&quot;.onerror=&quot;alert(1)');
+      expect(component.escapeHtml("it's a test")).toBe('it&#39;s a test');
     });
 
     it('should return plain text unchanged', () => {

--- a/client/src/app/features/map/map.component.ts
+++ b/client/src/app/features/map/map.component.ts
@@ -97,11 +97,21 @@ export class MapComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Escape HTML special characters to prevent XSS in Leaflet popups. */
+  /**
+   * Escape HTML special characters to prevent XSS in Leaflet popups.
+   *
+   * The textContent -> innerHTML round trip escapes `&`, `<` and `>`, but
+   * quotes are syntactically inert inside a text node so the browser leaves
+   * them alone. Every caller here interpolates the result into a
+   * double-quoted HTML attribute (src="...", alt="...", data-photo-path="..."),
+   * so an unescaped `"` in a filename/caption/tag would close the attribute
+   * early and let the rest of the string inject a new one (e.g. an
+   * onload handler). Encode both quote characters explicitly to close that gap.
+   */
   private escapeHtml(text: string): string {
     const div = document.createElement('div');
     div.textContent = text;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   /** Translate a category key via i18n, falling back to title-cased name. */

--- a/client/src/app/features/photo-detail/photo-detail.component.spec.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.spec.ts
@@ -75,9 +75,13 @@ describe('PhotoDetailComponent', () => {
     component = TestBed.inject(PhotoDetailComponent);
   }
 
+  // Explicit hook timeout above the default 10s: under full-suite load, many
+  // workers resolving dynamic import() chunks concurrently can contend for
+  // longer than that, and this hook flaking looks like a broken suite rather
+  // than the load-dependent timing issue it actually is.
   beforeAll(async () => {
     ({ PhotoDetailComponent } = await import('./photo-detail.component'));
-  });
+  }, 20000);
 
   beforeEach(() => {
     mockApi = {

--- a/client/src/app/features/photo-detail/photo-detail.component.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, effect, OnInit, HostListener, DestroyRef, ElementRef, viewChild, afterNextRender } from '@angular/core';
+import { Component, inject, signal, computed, effect, OnInit, HostListener, DestroyRef, ElementRef, viewChild } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -625,6 +625,24 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
   private locationMap: L.Map | null = null;
   private locationMapTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  // Register wheel and touchmove as non-passive so preventDefault() works. Keyed
+  // on imagePanel() (not afterNextRender()) so the async query-param load path
+  // -- where photo() is still null on first paint and #imagePanel doesn't exist
+  // yet -- re-attaches once the @if-gated element actually appears, instead of
+  // permanently missing the listeners.
+  private zoomListenersEffect = effect((onCleanup) => {
+    const el = this.imagePanel()?.nativeElement;
+    if (!el) return;
+    const wheelHandler = (e: WheelEvent) => this.onWheel(e);
+    const touchMoveHandler = (e: TouchEvent) => this.onTouchMove(e);
+    el.addEventListener('wheel', wheelHandler, { passive: false });
+    el.addEventListener('touchmove', touchMoveHandler, { passive: false });
+    onCleanup(() => {
+      el.removeEventListener('wheel', wheelHandler);
+      el.removeEventListener('touchmove', touchMoveHandler);
+    });
+  });
+
   private locationMapEffect = effect(() => {
     const container = this.locationMapContainer();
     const p = this.photo();
@@ -660,13 +678,6 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
     this.destroyRef.onDestroy(() => {
       if (this.locationMapTimeout !== null) clearTimeout(this.locationMapTimeout);
       if (this.locationMap) { this.locationMap.remove(); this.locationMap = null; }
-    });
-    // Register wheel and touchmove as non-passive so preventDefault() works
-    afterNextRender(() => {
-      const el = this.imagePanel()?.nativeElement;
-      if (!el) return;
-      el.addEventListener('wheel', (e: WheelEvent) => this.onWheel(e), { passive: false });
-      el.addEventListener('touchmove', (e: TouchEvent) => this.onTouchMove(e), { passive: false });
     });
   }
 

--- a/client/src/app/features/stats/gear-chart-card.component.ts
+++ b/client/src/app/features/stats/gear-chart-card.component.ts
@@ -13,7 +13,6 @@ import { ThemeService } from '../../core/services/theme.service';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ChartHeightPipe } from './chart-height.pipe';
 import { downloadCsv } from '../../shared/utils/csv';
-import { I18N } from '../../core/i18n/keys';
 
 export interface GearItem {
   name: string;
@@ -73,8 +72,8 @@ const GEAR_METRIC_OPTIONS = [
           </mat-select>
         </mat-form-field>
         <button mat-icon-button class="shrink-0" [disabled]="items().length === 0"
-          [matTooltip]="I18N.stats.export_csv | translate"
-          [attr.aria-label]="I18N.stats.export_csv | translate" (click)="exportCsv()">
+          [matTooltip]="'stats.export_csv' | translate"
+          [attr.aria-label]="'stats.export_csv' | translate" (click)="exportCsv()">
           <mat-icon>download</mat-icon>
         </button>
       </mat-card-header>
@@ -91,7 +90,6 @@ const GEAR_METRIC_OPTIONS = [
   `,
 })
 export class GearChartCardComponent {
-  protected readonly I18N = I18N;
   private readonly destroyRef = inject(DestroyRef);
   private readonly themeService = inject(ThemeService);
   private chart: Chart | null = null;

--- a/client/src/app/shared/components/person-card/person-card.component.ts
+++ b/client/src/app/shared/components/person-card/person-card.component.ts
@@ -7,7 +7,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 import { PersonThumbnailUrlPipe } from '../../pipes/thumbnail-url.pipe';
-import { I18N } from '../../../core/i18n/keys';
 
 export interface Person {
   id: number;
@@ -38,7 +37,7 @@ export interface Person {
       [class.opacity-50]="person().is_hidden"
       role="button"
       tabindex="0"
-      [attr.aria-label]="person().name || (I18N.persons.unnamed | translate)"
+      [attr.aria-label]="person().name || ('persons.unnamed' | translate)"
       (click)="selected.emit(person().id)"
       (keydown.enter)="selected.emit(person().id)"
       (keydown.space)="selected.emit(person().id); $event.preventDefault()"
@@ -59,15 +58,15 @@ export interface Person {
         }
         <!-- Name overlay (top-left over a darkened gradient, gallery-card style) -->
         <div class="absolute inset-x-0 top-0 z-[5] flex items-start gap-1 bg-gradient-to-b from-black/70 to-transparent px-2 pt-1.5 pb-4 pointer-events-none">
-          <span class="text-white text-xs font-medium truncate">{{ person().name || (I18N.persons.unnamed | translate) }}</span>
+          <span class="text-white text-xs font-medium truncate">{{ person().name || ('persons.unnamed' | translate) }}</span>
           @if (person().is_hidden) {
-            <mat-icon class="!text-sm !w-4 !h-4 !leading-4 text-white/80 shrink-0" [matTooltip]="I18N.persons.hidden | translate">visibility_off</mat-icon>
+            <mat-icon class="!text-sm !w-4 !h-4 !leading-4 text-white/80 shrink-0" [matTooltip]="'persons.hidden' | translate">visibility_off</mat-icon>
           }
         </div>
         <!-- Photo/face count badge (top-right) -->
         <span class="absolute top-1.5 right-1.5 z-10 px-2 py-0.5 rounded-full bg-black/60 text-white text-xs font-semibold leading-none"
-              [matTooltip]="I18N.persons.face_count | translate:{ count: person().face_count }"
-              [attr.aria-label]="I18N.persons.face_count | translate:{ count: person().face_count }">
+              [matTooltip]="'persons.face_count' | translate:{ count: person().face_count }"
+              [attr.aria-label]="'persons.face_count' | translate:{ count: person().face_count }">
           {{ person().face_count }}
         </span>
       </div>
@@ -97,12 +96,12 @@ export interface Person {
                   [value]="person().name ?? ''"
                   (keyup.enter)="onSave()"
                   (keyup.escape)="editCancel.emit()"
-                  [attr.aria-label]="I18N.persons.rename | translate"
+                  [attr.aria-label]="'persons.rename' | translate"
                 />
-                <button mat-icon-button class="!w-7 !h-7" [matTooltip]="I18N.dialog.confirm | translate" (click)="onSave()">
+                <button mat-icon-button class="!w-7 !h-7" [matTooltip]="'dialog.confirm' | translate" (click)="onSave()">
                   <mat-icon class="!text-base">check</mat-icon>
                 </button>
-                <button mat-icon-button class="!w-7 !h-7" [matTooltip]="I18N.dialog.cancel | translate" (click)="editCancel.emit()">
+                <button mat-icon-button class="!w-7 !h-7" [matTooltip]="'dialog.cancel' | translate" (click)="editCancel.emit()">
                   <mat-icon class="!text-base">close</mat-icon>
                 </button>
               </div>
@@ -116,25 +115,25 @@ export interface Person {
                  tabindex="-1"
                  (click)="$event.stopPropagation()"
                  (keydown)="$event.stopPropagation()">
-              <button mat-icon-button [matTooltip]="I18N.persons.rename | translate" (click)="editStart.emit(person().id)">
+              <button mat-icon-button [matTooltip]="'persons.rename' | translate" (click)="editStart.emit(person().id)">
                 <mat-icon class="opacity-60">edit</mat-icon>
               </button>
-              <button mat-icon-button [matTooltip]="I18N.persons.view_photos | translate" (click)="viewPhotos.emit(person().id)">
+              <button mat-icon-button [matTooltip]="'persons.view_photos' | translate" (click)="viewPhotos.emit(person().id)">
                 <mat-icon class="opacity-60">photo_library</mat-icon>
               </button>
-              <button mat-icon-button [matTooltip]="I18N.persons.split | translate" [attr.aria-label]="I18N.persons.split | translate" (click)="split.emit(person().id)">
+              <button mat-icon-button [matTooltip]="'persons.split' | translate" [attr.aria-label]="'persons.split' | translate" (click)="split.emit(person().id)">
                 <mat-icon class="opacity-60">call_split</mat-icon>
               </button>
               @if (person().is_hidden) {
-                <button mat-icon-button [matTooltip]="I18N.persons.unhide | translate" [attr.aria-label]="I18N.persons.unhide | translate" (click)="unhidden.emit(person().id)">
+                <button mat-icon-button [matTooltip]="'persons.unhide' | translate" [attr.aria-label]="'persons.unhide' | translate" (click)="unhidden.emit(person().id)">
                   <mat-icon class="opacity-60">visibility</mat-icon>
                 </button>
               } @else {
-                <button mat-icon-button [matTooltip]="I18N.persons.hide | translate" [attr.aria-label]="I18N.persons.hide | translate" (click)="hidden.emit(person().id)">
+                <button mat-icon-button [matTooltip]="'persons.hide' | translate" [attr.aria-label]="'persons.hide' | translate" (click)="hidden.emit(person().id)">
                   <mat-icon class="opacity-60">visibility_off</mat-icon>
                 </button>
               }
-              <button mat-icon-button [matTooltip]="I18N.persons.delete | translate" (click)="deleted.emit(person().id)">
+              <button mat-icon-button [matTooltip]="'persons.delete' | translate" (click)="deleted.emit(person().id)">
                 <mat-icon class="opacity-60">delete</mat-icon>
               </button>
             </div>
@@ -145,7 +144,6 @@ export interface Person {
   `,
 })
 export class PersonCardComponent {
-  protected readonly I18N = I18N;
   readonly person = input.required<Person>();
   readonly isSelected = input(false);
   readonly isEditing = input(false);

--- a/client/src/app/shared/components/photo-card/photo-card.component.ts
+++ b/client/src/app/shared/components/photo-card/photo-card.component.ts
@@ -11,7 +11,6 @@ import { FixedPipe } from '../../pipes/fixed.pipe';
 import { ShutterSpeedPipe } from '../../pipes/shutter-speed.pipe';
 import { ScoreClassPipe, SortScorePipe } from '../../pipes/score.pipes';
 import { SortPersonsPipe } from '../../pipes/sort-persons.pipe';
-import { I18N } from '../../../core/i18n/keys';
 
 interface AppConfig {
   quality_thresholds?: { excellent: number; great: number; good: number };
@@ -54,7 +53,7 @@ interface AppConfig {
       [class.ring-[var(--mat-sys-primary)]]="isSelected()"
       [class.md:hover:ring-2]="!isSelected()"
       [class.md:hover:ring-[var(--mat-sys-outline-variant)]]="!isSelected()"
-      [attr.aria-label]="photo().keeper_hint?.has_better ? photo().filename + ', ' + (I18N.culling.reason.better_shot | translate) : photo().filename"
+      [attr.aria-label]="photo().keeper_hint?.has_better ? photo().filename + ', ' + ('culling.reason.better_shot' | translate) : photo().filename"
       [attr.aria-pressed]="isSelected()"
       (click)="onSelect($event)"
       (keydown.enter)="onKeyOpen($event)"
@@ -97,7 +96,7 @@ interface AppConfig {
              control does. -->
         @if (isEditionMode() && photo().star_rating) {
           <div class="absolute bottom-1 left-1.5 w-7 h-7 z-20 pointer-events-none inline-flex items-center justify-center transition-opacity md:group-hover/img:opacity-0"
-               [attr.aria-label]="I18N.rating.rating_badge | translate:{ stars: photo().star_rating ?? 0 }">
+               [attr.aria-label]="'rating.rating_badge' | translate:{ stars: photo().star_rating ?? 0 }">
             <mat-icon class="!text-lg !w-[18px] !h-[18px] !leading-[18px] !text-yellow-400 drop-shadow-md"
                       aria-hidden="true">star</mat-icon>
             <span class="absolute -top-0.5 -right-0.5 min-w-3.5 h-3.5 rounded-full bg-yellow-500 text-black text-[10px] font-bold flex items-center justify-center leading-none">{{ photo().star_rating }}</span>
@@ -131,8 +130,8 @@ interface AppConfig {
              collapsed behind anything, so a hide toggle says nothing about it. -->
         @if (photo().sequence_override_pending && photo().sequence_override; as pending) {
           <div class="absolute bottom-1 left-[4.5rem] w-7 h-7 z-30 inline-flex items-center justify-center"
-               [matTooltip]="(pending === 'suppressed' ? I18N.gallery.sequence_override.badge_suppressed : I18N.gallery.sequence_override.badge) | translate"
-               [attr.aria-label]="(pending === 'suppressed' ? I18N.gallery.sequence_override.badge_suppressed : I18N.gallery.sequence_override.badge) | translate">
+               [matTooltip]="(pending === 'suppressed' ? 'gallery.sequence_override.badge_suppressed' : 'gallery.sequence_override.badge') | translate"
+               [attr.aria-label]="(pending === 'suppressed' ? 'gallery.sequence_override.badge_suppressed' : 'gallery.sequence_override.badge') | translate">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-amber-300 drop-shadow-md"
                       aria-hidden="true">schedule</mat-icon>
           </div>
@@ -146,7 +145,7 @@ interface AppConfig {
              nothing at all on an already-monochrome photo. -->
         @if (isEditionMode() && photo().is_rejected) {
           <div class="absolute bottom-1 right-9 w-7 h-7 z-20 pointer-events-none inline-flex items-center justify-center transition-opacity md:group-hover/img:opacity-0"
-               [attr.aria-label]="I18N.rating.rejected_badge | translate">
+               [attr.aria-label]="'rating.rejected_badge' | translate">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-red-400 drop-shadow-md" aria-hidden="true">thumb_down</mat-icon>
           </div>
         }
@@ -166,29 +165,29 @@ interface AppConfig {
               <button
                 class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
                 [matMenuTriggerFor]="similarMenu"
-                [matTooltip]="I18N.similar.find_similar | translate"
+                [matTooltip]="'similar.find_similar' | translate"
                 (click)="$event.stopPropagation()">
                 <mat-icon class="!text-base !w-4 !h-4 !leading-4">image_search</mat-icon>
               </button>
               <mat-menu #similarMenu="matMenu">
                 <button mat-menu-item (click)="openSimilarClicked.emit({photo: photo(), mode: 'visual'})">
                   <mat-icon>image_search</mat-icon>
-                  {{ I18N.similar.mode_visual | translate }}
+                  {{ 'similar.mode_visual' | translate }}
                 </button>
                 <button mat-menu-item (click)="openSimilarClicked.emit({photo: photo(), mode: 'color'})">
                   <mat-icon>palette</mat-icon>
-                  {{ I18N.similar.mode_color | translate }}
+                  {{ 'similar.mode_color' | translate }}
                 </button>
                 <button mat-menu-item (click)="openSimilarClicked.emit({photo: photo(), mode: 'person'})">
                   <mat-icon>person_search</mat-icon>
-                  {{ I18N.similar.mode_person | translate }}
+                  {{ 'similar.mode_person' | translate }}
                 </button>
               </mat-menu>
             }
             @if (config()?.features?.show_critique) {
               <button
                 class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
-                [matTooltip]="I18N.critique.title | translate"
+                [matTooltip]="'critique.title' | translate"
                 (click)="openCritiqueClicked.emit(photo()); $event.stopPropagation()">
                 <mat-icon class="!text-base !w-4 !h-4 !leading-4">analytics</mat-icon>
               </button>
@@ -196,8 +195,8 @@ interface AppConfig {
             @if (isEditionMode() && config()?.features?.show_embed_metadata) {
               <button
                 class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
-                [matTooltip]="I18N.photoCard.embed_to_file | translate"
-                [attr.aria-label]="I18N.photoCard.embed_to_file | translate"
+                [matTooltip]="'photoCard.embed_to_file' | translate"
+                [attr.aria-label]="'photoCard.embed_to_file' | translate"
                 (click)="embedMetadataClicked.emit(photo()); $event.stopPropagation()">
                 <mat-icon class="!text-base !w-4 !h-4 !leading-4">save</mat-icon>
               </button>
@@ -205,7 +204,7 @@ interface AppConfig {
             @if (isEditionMode() && photo().unassigned_faces > 0) {
               <button
                 class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
-                [matTooltip]="I18N.manage_persons.assign_face | translate"
+                [matTooltip]="'manage_persons.assign_face' | translate"
                 (click)="openAddPersonClicked.emit(photo()); $event.stopPropagation()">
                 <mat-icon class="!text-base !w-4 !h-4 !leading-4">person_add</mat-icon>
               </button>
@@ -219,7 +218,7 @@ interface AppConfig {
               @if (config()?.features?.show_rating_controls) {
                 <button
                   class="relative w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-yellow-400"
-                  [matTooltip]="I18N.rating.set_rating | translate"
+                  [matTooltip]="'rating.set_rating' | translate"
                   (click)="cycleStarRating(); $event.stopPropagation()"
                   (dblclick)="$event.stopPropagation()">
                   <mat-icon class="!text-lg !w-[18px] !h-[18px] !leading-[18px]">{{ photo().star_rating ? 'star' : 'star_border' }}</mat-icon>
@@ -274,15 +273,15 @@ interface AppConfig {
             <span class="font-medium text-neutral-200 truncate">{{ photo().filename }}</span>
             <span class="ml-auto flex items-center gap-1 shrink-0">
               @if (photo().is_best_of_burst) {
-                <span class="px-1 py-0.5 rounded text-[10px] font-bold bg-[var(--facet-accent-dim)] text-white">{{ I18N.ui.badges.best | translate }}</span>
+                <span class="px-1 py-0.5 rounded text-[10px] font-bold bg-[var(--facet-accent-dim)] text-white">{{ 'ui.badges.best' | translate }}</span>
               }
               @if (currentSort() !== 'aggregate') {
-                <span class="text-neutral-400 font-medium" [matTooltip]="I18N.gallery.aggregate_score | translate">{{ photo().aggregate | fixed:1 }}</span>
+                <span class="text-neutral-400 font-medium" [matTooltip]="'gallery.aggregate_score' | translate">{{ photo().aggregate | fixed:1 }}</span>
               }
               <span
                 class="px-1 py-0.5 rounded text-xs font-bold"
                 [class]="(photo() | sortScore:currentSort()) | scoreClass:config()"
-                [matTooltip]="(currentSort() === 'aggregate' ? (I18N.gallery.aggregate_score | translate) : (I18N.gallery.sort_score | translate) + ' (' + currentSort() + ')')"
+                [matTooltip]="(currentSort() === 'aggregate' ? ('gallery.aggregate_score' | translate) : ('gallery.sort_score' | translate) + ' (' + currentSort() + ')')"
               >{{ (photo() | sortScore:currentSort()) | fixed:1 }}</span>
             </span>
           </div>
@@ -316,7 +315,7 @@ interface AppConfig {
                 @if (isEditionMode() && personFilterId() === '' + person.id) {
                   <button
                     class="w-8 h-8 rounded-full bg-red-900/60 inline-flex items-center justify-center hover:bg-red-800 transition-colors"
-                    [matTooltip]="(I18N.ui.buttons.remove | translate) + ': ' + person.name"
+                    [matTooltip]="('ui.buttons.remove' | translate) + ': ' + person.name"
                     (click)="personRemoveClicked.emit({photo: photo(), personId: person.id}); $event.stopPropagation()">
                     <mat-icon class="!text-base !w-4 !h-4 !leading-4 text-red-300">close</mat-icon>
                   </button>
@@ -340,7 +339,6 @@ interface AppConfig {
   `,
 })
 export class PhotoCardComponent {
-  protected readonly I18N = I18N;
   // Data
   readonly photo = input.required<Photo>();
   readonly config = input<AppConfig | null>(null);

--- a/comparison/comparison_manager.py
+++ b/comparison/comparison_manager.py
@@ -44,8 +44,8 @@ class ComparisonManager:
             raise ValueError(f"Invalid winner value: {winner}")
 
         # Canonicalize pair order so swapped (A,B)/(B,A) submissions hit the same
-        # UNIQUE(photo_a_path, photo_b_path) row instead of storing contradictory
-        # duplicates (mirrors record_culling_pairs).
+        # UNIQUE(photo_a_path, photo_b_path, user_id) row instead of storing
+        # contradictory duplicates (mirrors record_culling_pairs).
         if photo_a_path > photo_b_path:
             photo_a_path, photo_b_path = photo_b_path, photo_a_path
             if winner == 'a':
@@ -55,11 +55,32 @@ class ComparisonManager:
 
         with get_connection(self.db_path, row_factory=False) as conn:
             try:
-                conn.execute("""
-                    INSERT OR REPLACE INTO comparisons
-                    (photo_a_path, photo_b_path, winner, category, session_id, user_id)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                """, (photo_a_path, photo_b_path, winner, category, self._session_id, user_id))
+                # Upsert scoped to (pair, user_id): one user's revote updates only
+                # their own row, never another user's. INSERT OR REPLACE cannot be
+                # used because the UNIQUE is now user-scoped and SQLite treats NULL
+                # user_id (single-user / legacy) as distinct, so a REPLACE would
+                # never match and would accumulate duplicate rows. Match with IS so
+                # the NULL user_id case dedups too.
+                existing = conn.execute(
+                    "SELECT id FROM comparisons "
+                    "WHERE photo_a_path = ? AND photo_b_path = ? AND user_id IS ?",
+                    (photo_a_path, photo_b_path, user_id),
+                ).fetchone()
+                if existing:
+                    conn.execute(
+                        "UPDATE comparisons SET winner = ?, category = ?, "
+                        "session_id = ?, source = 'vote', timestamp = datetime('now') "
+                        "WHERE id = ?",
+                        (winner, category, self._session_id, existing[0]),
+                    )
+                else:
+                    conn.execute(
+                        "INSERT INTO comparisons "
+                        "(photo_a_path, photo_b_path, winner, category, session_id, user_id) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (photo_a_path, photo_b_path, winner, category,
+                         self._session_id, user_id),
+                    )
                 conn.commit()
                 return True
             except sqlite3.Error as e:
@@ -423,8 +444,12 @@ def record_culling_pairs(
     max_pairs_per_group rows per call so large groups don't flood the
     comparisons table. Pairs are stored canonically ordered
     (photo_a_path < photo_b_path) with source='culling' and never overwrite
-    an existing comparison: INSERT OR IGNORE lets the
-    UNIQUE(photo_a_path, photo_b_path) constraint keep explicit votes intact.
+    an existing comparison. Pairs already recorded for this (pair, user_id) are
+    filtered out up front: the UNIQUE is now user-scoped
+    (photo_a_path, photo_b_path, user_id) and SQLite treats a NULL user_id
+    (single-user / legacy) as distinct, so INSERT OR IGNORE alone would not
+    dedup the NULL case — the pre-filter keeps explicit votes intact for every
+    user, and INSERT OR IGNORE remains a backstop against concurrent inserts.
 
     Runs inside the caller's transaction - does not commit.
 
@@ -461,6 +486,24 @@ def record_culling_pairs(
             ))
         if len(rows) >= max_pairs_per_group:
             break
+    if not rows:
+        return 0
+    # Drop pairs already recorded for this (pair, user_id). The user-scoped
+    # UNIQUE treats NULL user_id as distinct, so INSERT OR IGNORE would not skip
+    # them in single-user mode and could duplicate an existing explicit vote.
+    pair_paths = list({p for r in rows for p in (r[0], r[1])})
+    ph = ','.join('?' * len(pair_paths))
+    existing = {
+        (a, b) for a, b in conn.execute(
+            f"SELECT photo_a_path, photo_b_path FROM comparisons "
+            f"WHERE user_id IS ? "
+            f"AND photo_a_path IN ({ph}) AND photo_b_path IN ({ph})",
+            [user_id, *pair_paths, *pair_paths],
+        ).fetchall()
+    }
+    rows = [r for r in rows if (r[0], r[1]) not in existing]
+    if not rows:
+        return 0
     before = conn.total_changes
     conn.executemany("""
         INSERT OR IGNORE INTO comparisons

--- a/config/category_filter.py
+++ b/config/category_filter.py
@@ -45,8 +45,16 @@ VALID_TAG_FILTERS = [
 ]
 
 # All valid weight column names (without _percent suffix)
+#
+# processing.scorer.SCORING_METRIC_KEYS is the canonical list of metrics the
+# aggregate scorer actually weights (plus 'quality', 'symmetry', 'balance',
+# 'edge_entropy', 'fractal', 'color_harmony', which are valid config weights
+# outside that optimizer feature set) — keep this list in sync with it by
+# hand. It cannot be imported here: processing.scorer imports `config` at
+# module scope, so `config` importing `processing.scorer` would be circular.
 VALID_WEIGHT_COLUMNS = [
     "aesthetic", "face_quality", "eye_sharpness", "tech_sharpness",
+    "face_sharpness", "power_point", "saturation", "noise",
     "exposure", "composition", "color", "quality", "contrast",
     "dynamic_range", "isolation", "leading_lines",
     # Supplementary PyIQA metrics

--- a/config/scoring_config.py
+++ b/config/scoring_config.py
@@ -279,6 +279,11 @@ class ScoringConfig:
             if not percent_items:
                 continue
 
+            # Snapshot which keys the user actually set, before 0b below zero-pads
+            # percent_items out to every valid column — the decimal heuristic in
+            # step 1 must judge ambiguity only on what the user provided.
+            user_set_keys = set(percent_items)
+
             corrections = []
 
             # === 0. Remove invalid weight keys ===
@@ -295,11 +300,16 @@ class ScoringConfig:
                     corrections.append(f"  {key}: added (default 0)")
 
             # === 1. Convert decimals to percentages ===
-            # If all values are <= 1 and sum <= 1, assume they're decimals
-            all_small = all(v <= 1 for v in percent_items.values())
-            total_small = sum(percent_items.values()) <= 1.01
-            if all_small and total_small and len(percent_items) > 1:
-                for key, value in percent_items.items():
+            # If all *user-set* values are <= 1 and sum <= 1, assume they're decimals.
+            # Must judge only user_set_keys, not the post-0b percent_items: 0b zero-pads
+            # every valid column, which would make len(...) > 1 always true and
+            # misinterpret a single small user-set value (e.g. {"tech_sharpness_percent": 1})
+            # as a decimal fraction and inflate it to 100.
+            user_set_items = {k: percent_items[k] for k in user_set_keys}
+            all_small = all(v <= 1 for v in user_set_items.values())
+            total_small = sum(user_set_items.values()) <= 1.01
+            if all_small and total_small and len(user_set_items) > 1:
+                for key, value in user_set_items.items():
                     new_value = round(value * 100)
                     if new_value != value:
                         corrections.append(f"  {key}: {value} -> {new_value} (decimal to percent)")
@@ -509,8 +519,8 @@ class ScoringConfig:
     def get_face_detection_settings(self):
         """Get face detection settings (confidence threshold, min face size)."""
         return self.config.get('face_detection', {
-            'min_confidence_percent': 70,
-            'min_face_size': 30
+            'min_confidence_percent': 65,
+            'min_face_size': 20
         })
 
     def get_monochrome_settings(self):
@@ -543,9 +553,9 @@ class ScoringConfig:
     def get_burst_detection_settings(self):
         """Get burst detection settings (similarity threshold percent, time window, rapid burst)."""
         return self.config.get('burst_detection', {
-            'similarity_threshold_percent': 88,
-            'time_window_minutes': 60,
-            'rapid_burst_seconds': 5
+            'similarity_threshold_percent': 70,
+            'time_window_minutes': 0.8,
+            'rapid_burst_seconds': 0.4
         })
 
     def get_sequence_detection_settings(self):
@@ -931,12 +941,52 @@ class ScoringConfig:
 
         return True, current_profile, "OK"
 
+    def _tag_vocabulary_collisions(self):
+        """Find tag names redefined with a *different* synonym list.
+
+        Used by get_tag_vocabulary() to warn instead of silently overwriting
+        — plain dict.update() has no collision check on its own, so two
+        categories (or a category and standalone_tags) claiming the same tag
+        name would otherwise drop a synonym list library-wide without a trace.
+
+        Returns:
+            List of human-readable collision descriptions.
+        """
+        vocabulary = {}
+        collisions = []
+        for cat in self.config.get('categories', []):
+            tags = cat.get('tags', {})
+            if not isinstance(tags, dict):
+                continue
+            for tag_name, synonyms in tags.items():
+                if tag_name in vocabulary and vocabulary[tag_name] != synonyms:
+                    collisions.append(
+                        f"tag '{tag_name}': category '{cat.get('name', 'unnamed')}' "
+                        f"redefines synonyms {vocabulary[tag_name]!r} -> {synonyms!r}"
+                    )
+                vocabulary[tag_name] = synonyms
+        standalone = self.config.get('standalone_tags', {})
+        if isinstance(standalone, dict):
+            for tag_name, synonyms in standalone.items():
+                if tag_name in vocabulary and vocabulary[tag_name] != synonyms:
+                    collisions.append(
+                        f"tag '{tag_name}': standalone_tags redefines synonyms "
+                        f"{vocabulary[tag_name]!r} -> {synonyms!r}"
+                    )
+                vocabulary[tag_name] = synonyms
+        return collisions
+
     def get_tag_vocabulary(self):
         """Build tag vocabulary from all category tags and standalone tags.
 
         Returns dict: {tag_name: [synonyms]} aggregated from all categories
-        plus any standalone_tags defined at the top level.
+        plus any standalone_tags defined at the top level. When two entries
+        claim the same tag name with different synonyms, the last one
+        encountered wins (dict.update() semantics) and a warning is logged —
+        see _tag_vocabulary_collisions().
         """
+        for collision in self._tag_vocabulary_collisions():
+            logger.warning("get_tag_vocabulary: %s (last definition wins)", collision)
         vocabulary = {}
         # Add tags from categories
         for cat in self.config.get('categories', []):

--- a/database.py
+++ b/database.py
@@ -161,16 +161,38 @@ LIBRARY_REWRITING_ARGS = (
     'vacuum',
 )
 
+# Flags that route to a branch OTHER than the default init/upgrade. When none of
+# these is set the command falls through to init_database, which runs
+# ALTER/CREATE INDEX/ANALYZE DDL and so rewrites the library like any other job.
+_NON_INIT_ARGS = (
+    'stats_info', 'refresh_stats', 'info', 'migrate_tags', 'rebuild_fts',
+    'populate_vec', 'optimize', 'vacuum', 'analyze', 'backup',
+    'cleanup_orphaned_persons', 'cleanup_missing_photos', 'export_viewer_db',
+    'add_user', 'migrate_user_preferences', 'migrate_storage_fs',
+    'migrate_storage_db',
+)
+
+
+def _is_default_init(args):
+    """True when the parsed args select the default init/upgrade (schema) path."""
+    return not any(getattr(args, name, None) for name in _NON_INIT_ARGS)
+
 
 def _hold_library_lock(args):
     """Take the library mutex when the selected command rewrites the database.
 
-    VACUUM takes SQLite's exclusive lock and the migrations rewrite whole
-    columns of ``photos``, so any of these landing inside a scan or a
-    ``--recompute-average`` transaction dies with ``database is locked``.
+    VACUUM takes SQLite's exclusive lock and the migrations (including the
+    default init/upgrade's ALTER/CREATE INDEX/ANALYZE DDL) rewrite the
+    ``photos`` schema, so any of these landing inside a scan or a
+    ``--recompute-average`` transaction dies with ``database is locked`` — or,
+    worse for a DDL step that auto-commits, leaves a half-applied schema.
     A ``--dry-run`` inspection writes nothing and stays unguarded.
     """
-    if args.dry_run or not any(getattr(args, name, False) for name in LIBRARY_REWRITING_ARGS):
+    if args.dry_run:
+        return None
+    rewrites = (_is_default_init(args)
+                or any(getattr(args, name, False) for name in LIBRARY_REWRITING_ARGS))
+    if not rewrites:
         return None
     from facet import LIBRARY_JOB_MAINTENANCE, hold_library_lock_or_exit
     return hold_library_lock_or_exit(args.db, LIBRARY_JOB_MAINTENANCE)

--- a/db/info.py
+++ b/db/info.py
@@ -8,18 +8,16 @@ from db.schema import (
     PHOTOS_COLUMNS, FACES_COLUMNS, PERSONS_COLUMNS,
     PHOTO_TAGS_COLUMNS, COMPARISONS_COLUMNS, LEARNED_SCORES_COLUMNS,
     WEIGHT_OPTIMIZATION_RUNS_COLUMNS, WEIGHT_CONFIG_SNAPSHOTS_COLUMNS,
-    INDEXES, PHOTO_TAGS_INDEXES, COMPARISONS_INDEXES,
-    LEARNED_SCORES_INDEXES, WEIGHT_OPTIMIZATION_RUNS_INDEXES,
-    WEIGHT_CONFIG_SNAPSHOTS_INDEXES, SCHEMA_VERSION,
+    ALL_INDEX_GROUPS, SCHEMA_VERSION,
 )
 
 
 def get_schema_info():
     """Return schema information for debugging/display."""
-    total_indexes = (len(INDEXES) + len(PHOTO_TAGS_INDEXES) +
-                     len(COMPARISONS_INDEXES) + len(LEARNED_SCORES_INDEXES) +
-                     len(WEIGHT_OPTIMIZATION_RUNS_INDEXES) +
-                     len(WEIGHT_CONFIG_SNAPSHOTS_INDEXES))
+    # Count from the same registry init_database creates from, so the reported
+    # total can never drift from what the schema actually declares (it used to
+    # omit the scan-runs / recommendation / album / user-preference groups).
+    total_indexes = sum(len(group) for group in ALL_INDEX_GROUPS)
     return {
         'photos_columns': len(PHOTOS_COLUMNS),
         'faces_columns': len(FACES_COLUMNS),

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -12,6 +12,8 @@ import sqlite3
 from datetime import datetime
 from io import BytesIO
 
+from db.connection import apply_pragmas
+
 logger = logging.getLogger("facet.db_maintenance")
 
 _PATH_PRESENT = 'present'
@@ -65,6 +67,11 @@ def vacuum_database(db_path='photo_scores_pro.db', verbose=True):
         logger.info("  Before: %.2f MB", old_size / 1024 / 1024)
 
     conn = sqlite3.connect(db_path)
+    # busy_timeout lets VACUUM wait for a concurrent viewer reader instead of
+    # failing instantly with "database is locked"; isolation_level=None keeps
+    # VACUUM out of an implicit transaction (it cannot run inside one).
+    conn.isolation_level = None
+    apply_pragmas(conn)
     conn.execute("VACUUM")
     conn.close()
 
@@ -92,6 +99,7 @@ def analyze_database(db_path='photo_scores_pro.db', verbose=True):
         logger.info("Running ANALYZE on %s...", db_path)
 
     conn = sqlite3.connect(db_path)
+    apply_pragmas(conn)  # busy_timeout so ANALYZE waits out a concurrent reader
     conn.execute("ANALYZE")
     conn.close()
 
@@ -381,6 +389,10 @@ def cleanup_orphaned_persons(db_path='photo_scores_pro.db', verbose=True):
         logger.info("Cleaning up orphaned persons in %s...", db_path)
 
     conn = sqlite3.connect(db_path)
+    # foreign_keys=ON so deleting a person cascades to rejected_merge_suggestions
+    # (its person_a_id/person_b_id FKs are ON DELETE CASCADE); without it those
+    # dismissed-merge rows would be left orphaned. busy_timeout comes along too.
+    apply_pragmas(conn)
     cursor = conn.cursor()
 
     # Count orphaned persons before deletion
@@ -697,6 +709,46 @@ def _incremental_update_viewer_db(source_db, output_path, thumbnail_size, verbos
         if verbose:
             count = dest_conn.execute("SELECT COUNT(*) FROM main.user_preferences").fetchone()[0]
             logger.info("  Synced user preferences (%d rows)", count)
+
+    # --- Sync photos_vec (sqlite-vec KNN index; no FK/trigger, hand-synced) ---
+    # The viewer DB nulls out photos.clip_embedding, so photos_vec is the ONLY
+    # place embeddings survive on the deployment — the NumPy search fallback has
+    # no data there. An incremental export that added new photos but left the
+    # vec index untouched made those photos invisible to semantic search while
+    # the index still looked healthy. Mirror the photos delta into it: drop the
+    # deleted paths, add the new ones from src (which keeps clip_embedding).
+    from db.connection import HAS_SQLITE_VEC, load_sqlite_vec
+    if HAS_SQLITE_VEC and 'photos_vec' in dest_tables:
+        load_sqlite_vec(dest_conn)
+        try:
+            for i in range(0, len(deleted_paths), batch_size):
+                chunk = deleted_paths[i:i + batch_size]
+                placeholders = ','.join('?' * len(chunk))
+                dest_conn.execute(
+                    f"DELETE FROM main.photos_vec WHERE path IN ({placeholders})", chunk)
+            for i in range(0, len(new_paths), batch_size):
+                chunk = new_paths[i:i + batch_size]
+                placeholders = ','.join('?' * len(chunk))
+                records = dest_conn.execute(
+                    f"SELECT path, clip_embedding FROM src.photos "
+                    f"WHERE path IN ({placeholders}) AND clip_embedding IS NOT NULL",
+                    chunk,
+                ).fetchall()
+                if records:
+                    # DELETE-then-INSERT (vec0 has no OR REPLACE/IGNORE); new
+                    # paths are not yet in the index, so this is just an insert.
+                    dest_conn.execute(
+                        f"DELETE FROM main.photos_vec WHERE path IN ({placeholders})", chunk)
+                    dest_conn.executemany(
+                        "INSERT INTO main.photos_vec (path, embedding) VALUES (?, ?)",
+                        records)
+            dest_conn.commit()
+            if verbose and (new_paths or deleted_paths):
+                logger.info("  Synced photos_vec (+%d, -%d)", len(new_paths), len(deleted_paths))
+        except sqlite3.Error as ex:
+            logger.warning(
+                "Could not sync photos_vec in viewer export "
+                "(rebuild with --populate-vec): %s", ex)
 
     # --- Clear stats_cache (viewer regenerates on demand) ---
     if 'stats_cache' in dest_tables:

--- a/db/schema.py
+++ b/db/schema.py
@@ -5,6 +5,7 @@ Single source of truth for all table and index definitions.
 """
 
 import logging
+import re
 import sqlite3
 
 from db.connection import apply_pragmas, HAS_SQLITE_VEC
@@ -570,6 +571,25 @@ USER_PREFERENCES_INDEXES = [
     ('idx_user_prefs_rating', 'user_preferences', 'user_id, star_rating'),
 ]
 
+# Authoritative registry of every CREATE INDEX group. init_database creates all
+# of these and db.info.get_schema_info counts them, so the two can never
+# disagree on how many indexes the schema declares (they did before: info
+# under-reported by the scan-runs / recommendation / album / user-preference
+# groups). INDEXES stays first so init can special-case it (the post-create
+# ANALYZE gate keys off idx_moment_confidence).
+ALL_INDEX_GROUPS = [
+    INDEXES,
+    PHOTO_TAGS_INDEXES,
+    COMPARISONS_INDEXES,
+    LEARNED_SCORES_INDEXES,
+    WEIGHT_OPTIMIZATION_RUNS_INDEXES,
+    WEIGHT_CONFIG_SNAPSHOTS_INDEXES,
+    SCAN_RUNS_INDEXES,
+    RECOMMENDATION_HISTORY_INDEXES,
+    ALBUM_INDEXES,
+    USER_PREFERENCES_INDEXES,
+]
+
 # Sticky per-photo scoring context / category override — a side table, not
 # columns on `photos`, because save_photo/save_photos_batch write photos via
 # INSERT OR REPLACE (processing/scorer.py), which would silently wipe any new
@@ -724,6 +744,94 @@ def _migrate_add_missing_columns(conn, table_name, columns):
                         logger.warning("  Could not add %s.%s: %s", table_name, col_name, e)
 
 
+# Every base (non-virtual) table and its column list. The additive-column sweep
+# in init_database walks this registry so a new column added to ANY table lands
+# on upgrade — previously only a subset of tables were swept, so a future column
+# on the others would have been created on fresh DBs but never on existing ones.
+# Virtual tables (photos_fts, photos_vec) are excluded: they are recreated, not
+# ALTERed. Order mirrors the CREATE TABLE order in init_database.
+_MIGRATED_TABLES = [
+    ('photos', PHOTOS_COLUMNS),
+    ('faces', FACES_COLUMNS),
+    ('persons', PERSONS_COLUMNS),
+    ('photo_tags', PHOTO_TAGS_COLUMNS),
+    ('comparisons', COMPARISONS_COLUMNS),
+    ('learned_scores', LEARNED_SCORES_COLUMNS),
+    ('rejected_merge_suggestions', REJECTED_MERGE_SUGGESTIONS_COLUMNS),
+    ('weight_optimization_runs', WEIGHT_OPTIMIZATION_RUNS_COLUMNS),
+    ('stats_cache', STATS_CACHE_COLUMNS),
+    ('weight_config_snapshots', WEIGHT_CONFIG_SNAPSHOTS_COLUMNS),
+    ('recommendation_history', RECOMMENDATION_HISTORY_COLUMNS),
+    ('albums', ALBUMS_COLUMNS),
+    ('album_photos', ALBUM_PHOTOS_COLUMNS),
+    ('album_client_picks', ALBUM_CLIENT_PICKS_COLUMNS),
+    ('location_names', LOCATION_NAMES_COLUMNS),
+    ('user_preferences', USER_PREFERENCES_COLUMNS),
+    ('photo_scoring_overrides', PHOTO_SCORING_OVERRIDES_COLUMNS),
+    ('photo_sequence_overrides', PHOTO_SEQUENCE_OVERRIDES_COLUMNS),
+    ('scan_runs', SCAN_RUNS_COLUMNS),
+    ('scan_failures', SCAN_FAILURES_COLUMNS),
+]
+
+
+def _comparisons_unique_has_user_id(conn):
+    """True if the comparisons UNIQUE constraint already scopes by user_id.
+
+    Reads the stored CREATE SQL rather than guessing from a version stamp, so
+    the recreate below is idempotent regardless of how a DB reached its state.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='comparisons'"
+    ).fetchone()
+    if not row or not row[0]:
+        return True  # no table yet — the fresh CREATE already uses the new shape
+    match = re.search(r'unique\s*\(([^)]*)\)', row[0], re.IGNORECASE)
+    return bool(match) and 'user_id' in match.group(1).lower()
+
+
+def _migrate_comparisons_user_id(conn):
+    """Widen comparisons UNIQUE to (photo_a_path, photo_b_path, user_id).
+
+    The original UNIQUE(photo_a_path, photo_b_path) is user-blind, so a second
+    user's INSERT OR REPLACE vote on the same pair evicted the first user's row.
+    SQLite cannot ALTER a constraint, so rebuild the table and copy every row
+    (the old 2-column unique is strictly tighter than the new 3-column one, so
+    no copied row can collide). Guarded by _comparisons_unique_has_user_id, so
+    it is a no-op once applied and safe to re-run. Must run before the
+    comparisons indexes are (re)created in init_database.
+
+    Foreign keys are disabled around the copy (the standard SQLite table-rebuild
+    recipe): the recreate only relocates rows that already existed, so it must
+    preserve them verbatim rather than newly enforcing the photos FK against a
+    row an older, FK-off write may have orphaned.
+    """
+    if _comparisons_unique_has_user_id(conn):
+        return
+    logger.info("Migrating comparisons UNIQUE constraint to include user_id...")
+    old_cols = {r[1] for r in conn.execute("PRAGMA table_info(comparisons)").fetchall()}
+    common = [name for name, _ in COMPARISONS_COLUMNS if name in old_cols]
+    col_list = ', '.join(common)
+
+    fk_on = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    if fk_on:
+        conn.commit()  # PRAGMA foreign_keys is a no-op inside a transaction
+        conn.execute("PRAGMA foreign_keys=OFF")
+    try:
+        conn.execute("DROP TABLE IF EXISTS comparisons_new")
+        conn.execute(_build_create_table_sql(
+            'comparisons_new', COMPARISONS_COLUMNS,
+            constraints=['UNIQUE(photo_a_path, photo_b_path, user_id)']))
+        conn.execute(
+            f"INSERT INTO comparisons_new ({col_list}) SELECT {col_list} FROM comparisons")
+        conn.execute("DROP TABLE comparisons")
+        conn.execute("ALTER TABLE comparisons_new RENAME TO comparisons")
+    finally:
+        if fk_on:
+            conn.commit()
+            conn.execute("PRAGMA foreign_keys=ON")
+    logger.info("comparisons table rebuilt with user-scoped UNIQUE (rows preserved)")
+
+
 # Schema version stamped into PRAGMA user_version. The additive column sweep
 # (_migrate_add_missing_columns) still bootstraps every DB to the current
 # column shape; this ladder exists ONLY for non-additive ops the sweep cannot
@@ -789,9 +897,6 @@ def init_database(db_path='photo_scores_pro.db'):
         # Create photos table
         conn.execute(_build_create_table_sql('photos', PHOTOS_COLUMNS))
 
-        # Migrate existing tables - add any missing columns
-        _migrate_add_missing_columns(conn, 'photos', PHOTOS_COLUMNS)
-
         # Create faces table with unique constraint
         conn.execute(_build_create_table_sql(
             'faces',
@@ -799,14 +904,8 @@ def init_database(db_path='photo_scores_pro.db'):
             constraints=['UNIQUE(photo_path, face_index)']
         ))
 
-        # Migrate existing faces table - add any missing columns
-        _migrate_add_missing_columns(conn, 'faces', FACES_COLUMNS)
-
         # Create persons table
         conn.execute(_build_create_table_sql('persons', PERSONS_COLUMNS))
-
-        # Migrate existing persons table - add any missing columns (e.g. is_hidden)
-        _migrate_add_missing_columns(conn, 'persons', PERSONS_COLUMNS)
 
         # Create photo_tags lookup table for fast tag queries
         conn.execute(_build_create_table_sql(
@@ -815,11 +914,14 @@ def init_database(db_path='photo_scores_pro.db'):
             constraints=['PRIMARY KEY (photo_path, tag)']
         ))
 
-        # Create comparisons table for pairwise comparison feedback
+        # Create comparisons table for pairwise comparison feedback. The UNIQUE
+        # is user-scoped so one user's vote never clobbers another's; existing
+        # DBs on the old user-blind constraint are rebuilt by
+        # _migrate_comparisons_user_id below.
         conn.execute(_build_create_table_sql(
             'comparisons',
             COMPARISONS_COLUMNS,
-            constraints=['UNIQUE(photo_a_path, photo_b_path)']
+            constraints=['UNIQUE(photo_a_path, photo_b_path, user_id)']
         ))
 
         # Create learned_scores table for Bradley-Terry derived scores
@@ -861,21 +963,18 @@ def init_database(db_path='photo_scores_pro.db'):
 
         # Create albums and album_photos tables
         conn.execute(_build_create_table_sql('albums', ALBUMS_COLUMNS))
-        _migrate_add_missing_columns(conn, 'albums', ALBUMS_COLUMNS)
 
         conn.execute(_build_create_table_sql(
             'album_photos',
             ALBUM_PHOTOS_COLUMNS,
             constraints=['UNIQUE(album_id, photo_path)']
         ))
-        _migrate_add_missing_columns(conn, 'album_photos', ALBUM_PHOTOS_COLUMNS)
 
         conn.execute(_build_create_table_sql(
             'album_client_picks',
             ALBUM_CLIENT_PICKS_COLUMNS,
             constraints=['UNIQUE(album_id, photo_path)']
         ))
-        _migrate_add_missing_columns(conn, 'album_client_picks', ALBUM_CLIENT_PICKS_COLUMNS)
 
         # Create location_names cache table for reverse geocoding
         conn.execute(_build_create_table_sql(
@@ -896,36 +995,37 @@ def init_database(db_path='photo_scores_pro.db'):
         conn.execute(_build_create_table_sql(
             'photo_scoring_overrides', PHOTO_SCORING_OVERRIDES_COLUMNS
         ))
-        _migrate_add_missing_columns(conn, 'photo_scoring_overrides', PHOTO_SCORING_OVERRIDES_COLUMNS)
 
         # Create photo_sequence_overrides table for sticky per-set panorama
         # corrections, which must outlive the detector's clear-and-rewrite pass
         conn.execute(_build_create_table_sql(
             'photo_sequence_overrides', PHOTO_SEQUENCE_OVERRIDES_COLUMNS
         ))
-        _migrate_add_missing_columns(
-            conn, 'photo_sequence_overrides', PHOTO_SEQUENCE_OVERRIDES_COLUMNS)
-
-        # Create photos_vec virtual table for vector search (requires sqlite-vec)
-        if HAS_SQLITE_VEC:
-            _init_vec_table(conn)
 
         # Create scan bookkeeping tables
         conn.execute(_build_create_table_sql('scan_runs', SCAN_RUNS_COLUMNS))
-        _migrate_add_missing_columns(conn, 'scan_runs', SCAN_RUNS_COLUMNS)
         conn.execute(_build_create_table_sql(
             'scan_failures', SCAN_FAILURES_COLUMNS,
             constraints=['PRIMARY KEY (scan_run_id, path)']
         ))
-        for idx_name, table, column_expr in SCAN_RUNS_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
 
-        # Migrate existing tables before index creation - new indexes may
-        # target columns added here (e.g., comparisons.source)
-        _migrate_add_missing_columns(conn, 'comparisons', COMPARISONS_COLUMNS)
-        _migrate_add_missing_columns(conn, 'learned_scores', LEARNED_SCORES_COLUMNS)
+        # Non-additive rebuild before the additive sweep and index creation:
+        # widen the comparisons UNIQUE to include user_id on DBs still carrying
+        # the user-blind constraint (rows preserved, no-op once applied).
+        _migrate_comparisons_user_id(conn)
+
+        # Additive column sweep across EVERY base table (registry-driven, so a
+        # future column on any table lands on upgrade). Runs before index
+        # creation because new indexes may target columns added here (e.g.
+        # comparisons.source), and before the photos_vec init below because that
+        # reads photos.clip_embedding, which the sweep backfills on old DBs.
+        for table_name, columns in _MIGRATED_TABLES:
+            _migrate_add_missing_columns(conn, table_name, columns)
+
+        # Create photos_vec virtual table for vector search (requires sqlite-vec).
+        # After the sweep so detect_embedding_dim can see clip_embedding.
+        if HAS_SQLITE_VEC:
+            _init_vec_table(conn)
 
         # Drop indexes that were superseded by a different shape, so DBs that
         # received the earlier version don't keep a now-unused index. The moment /
@@ -935,7 +1035,10 @@ def init_database(db_path='photo_scores_pro.db'):
         for stale_idx in ('idx_burst_moment', 'idx_burst_learned'):
             conn.execute(f'DROP INDEX IF EXISTS {stale_idx}')
 
-        # Create all indexes
+        # Create the photos-table indexes first so the ANALYZE gate below can
+        # observe idx_moment_confidence, then every other group. All groups come
+        # from the single ALL_INDEX_GROUPS registry that db.info also counts, so
+        # the two can never disagree.
         for idx_name, table, column_expr in INDEXES:
             conn.execute(
                 f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
@@ -955,41 +1058,16 @@ def init_database(db_path='photo_scores_pro.db'):
         if 'idx_moment_confidence' not in analyzed:
             conn.execute("ANALYZE photos")
 
-        # Create photo_tags indexes
-        for idx_name, table, column_expr in PHOTO_TAGS_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-
-        # Create comparison-related indexes
-        for idx_name, table, column_expr in COMPARISONS_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in LEARNED_SCORES_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in WEIGHT_OPTIMIZATION_RUNS_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in WEIGHT_CONFIG_SNAPSHOTS_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in RECOMMENDATION_HISTORY_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in ALBUM_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
-        for idx_name, table, column_expr in USER_PREFERENCES_INDEXES:
-            conn.execute(
-                f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
-            )
+        # Create every remaining index group (photo_tags, comparisons,
+        # learned_scores, weight-optimization, snapshots, scan_runs,
+        # recommendation_history, albums, user_preferences).
+        for group in ALL_INDEX_GROUPS:
+            if group is INDEXES:
+                continue
+            for idx_name, table, column_expr in group:
+                conn.execute(
+                    f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})'
+                )
 
         # Create FTS5 full-text search table and sync triggers. If a previous
         # narrower schema is detected (caption+tags only), drop it so the

--- a/db/sequence_overrides.py
+++ b/db/sequence_overrides.py
@@ -14,7 +14,9 @@ from 1 on every pass and would otherwise re-attach an override to an unrelated
 set.
 """
 
-from db.connection import get_connection
+import sqlite3
+
+from db.connection import DEFAULT_DB_PATH, apply_pragmas
 
 _UPSERT_SQL = """
     INSERT INTO photo_sequence_overrides
@@ -29,6 +31,19 @@ _UPSERT_SQL = """
 """
 
 
+def open_connection(db_path=DEFAULT_DB_PATH):
+    """Open a bare connection (with standard pragmas) that the caller closes.
+
+    ``db.connection.get_connection`` is a context manager and cannot be used
+    here: these helpers hand the connection back through ``_connection_for`` and
+    close it themselves in a ``finally``, so they need a real
+    ``sqlite3.Connection``, not the CM object ``get_connection(...)`` returns.
+    """
+    conn = sqlite3.connect(db_path)
+    apply_pragmas(conn)
+    return conn
+
+
 def _connection_for(db):
     """Return ``(connection, owned)`` whether ``db`` is one already or a path/None.
 
@@ -38,7 +53,7 @@ def _connection_for(db):
     """
     if hasattr(db, 'execute'):
         return db, False
-    return get_connection(db), True
+    return open_connection(db if db is not None else DEFAULT_DB_PATH), True
 
 
 def get_sequence_overrides(db, paths=None):

--- a/db/stats_cache.py
+++ b/db/stats_cache.py
@@ -103,15 +103,25 @@ def refresh_stats_cache(db_path='photo_scores_pro.db', verbose=True):
             pass
 
         # 5. Person counts (for face recognition dropdown)
+        # Mirror the live /api/filter_options/persons query exactly: exclude
+        # hidden persons and apply the same min_photos / max_persons bounds.
+        # Without this the cached list resurrects hidden persons in the filter
+        # for the cache TTL after --refresh-stats.
         try:
-            persons = conn.execute("""
+            from api.config import VIEWER_CONFIG
+            from db.schema import person_not_hidden_clause
+            min_photos = VIEWER_CONFIG['dropdowns'].get('min_photos_for_person', 1)
+            max_persons = VIEWER_CONFIG['dropdowns']['max_persons']
+            persons = conn.execute(f"""
                 SELECT p.id, p.name, COUNT(DISTINCT f.photo_path) as photo_count
                 FROM persons p
                 JOIN faces f ON f.person_id = p.id
+                WHERE {person_not_hidden_clause('p')}
                 GROUP BY p.id
-                HAVING photo_count > 0
+                HAVING photo_count >= ?
                 ORDER BY photo_count DESC
-            """).fetchall()
+                LIMIT ?
+            """, (min_photos, max_persons)).fetchall()
             person_data = [(r[0], r[1], r[2]) for r in persons]
             stats['persons'] = person_data
             _cache_stat(conn, 'persons', json.dumps(person_data), now)
@@ -298,7 +308,7 @@ def get_cached_stat(db_path='photo_scores_pro.db', key=None, max_age_seconds=300
                 return result
 
         except sqlite3.OperationalError:
-            return None, False if key else {}
+            return (None, False) if key else {}
 
 
 def get_stats_cache_info(db_path='photo_scores_pro.db'):

--- a/db/tags.py
+++ b/db/tags.py
@@ -17,10 +17,20 @@ from db.schema import (
 
 def migrate_tags_to_lookup(db_path='photo_scores_pro.db', batch_size=10000):
     """
-    Populate the photo_tags lookup table from the existing tags column.
+    (Re)build the photo_tags lookup table from the current tags column.
 
     This enables fast exact-match tag queries instead of slow LIKE '%tag%' scans.
-    Creates a backup before migration and can be safely re-run (uses INSERT OR IGNORE).
+    It is a full resync: the table is cleared first and repopulated from the live
+    photos.tags values, so re-running it after tags change (rescan, XMP import,
+    re-tag) drops tags no longer present and adds new ones. Appending only, as an
+    earlier version did, left readers preferring a stale table with removed tags
+    still in it.
+
+    No DB backup is taken: photo_tags is a derived index fully reconstructible
+    from photos.tags, and this runs under the library lock (database.py holds it
+    for --migrate-tags). The previous naive ``shutil.copy2`` of the whole DB was
+    WAL-unsafe (dropped the -wal/-shm sidecars) and copied the entire multi-GB
+    file on every run with no disk check or rotation.
 
     Args:
         db_path: Path to the SQLite database file
@@ -29,14 +39,6 @@ def migrate_tags_to_lookup(db_path='photo_scores_pro.db', batch_size=10000):
     Returns:
         Tuple of (total_tags_inserted, total_photos_processed)
     """
-    import shutil
-    from datetime import datetime
-
-    # Create backup first
-    backup_path = f"{db_path}.backup.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-    shutil.copy2(db_path, backup_path)
-    logger.info("Created backup: %s", backup_path)
-
     with get_connection(db_path, row_factory=False) as conn:
         # Ensure table exists
         conn.execute(_build_create_table_sql(
@@ -48,6 +50,10 @@ def migrate_tags_to_lookup(db_path='photo_scores_pro.db', batch_size=10000):
         # Create indexes
         for idx_name, table, column_expr in PHOTO_TAGS_INDEXES:
             conn.execute(f'CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column_expr})')
+
+        # Full resync: clear the derived table so removed tags don't linger.
+        conn.execute("DELETE FROM photo_tags")
+        conn.commit()
 
         # Get total count
         total = conn.execute(

--- a/db/vec.py
+++ b/db/vec.py
@@ -5,6 +5,7 @@ Populates and syncs the photos_vec virtual table for sqlite-vec KNN queries.
 """
 
 import logging
+import re
 
 from db.connection import get_connection, HAS_SQLITE_VEC
 from db.schema import detect_embedding_dim
@@ -19,6 +20,32 @@ def _vec_table_exists(conn):
         "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='photos_vec'"
     ).fetchone()
     return row[0] > 0
+
+
+def _vec_declared_dim(conn):
+    """Embedding dimension photos_vec was declared with, or None if unknown.
+
+    Parses the stored CREATE SQL (``embedding float[NNN]``). The vec0 table
+    hard-codes its dimension at creation, so an index built for one profile's
+    embeddings (e.g. CLIP 768) silently rejects or mis-stores another's
+    (SigLIP 1152); comparing this against the live embedding dim catches a
+    profile switch.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='photos_vec'"
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    match = re.search(r'float\s*\[\s*(\d+)\s*\]', row[0], re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _distinct_embedding_lengths(conn):
+    """Number of distinct clip_embedding byte-lengths present in photos."""
+    return conn.execute(
+        "SELECT COUNT(DISTINCT LENGTH(clip_embedding)) FROM photos "
+        "WHERE clip_embedding IS NOT NULL"
+    ).fetchone()[0]
 
 
 def populate_vec_table(db_path='photo_scores_pro.db'):
@@ -41,6 +68,29 @@ def populate_vec_table(db_path='photo_scores_pro.db'):
             return 0
 
         expected_bytes = dim * 4
+
+        # A library holding more than one embedding dimension (a half-finished
+        # profile switch) can only be indexed for one of them — warn loudly
+        # rather than silently indexing the majority and skipping the rest.
+        if _distinct_embedding_lengths(conn) > 1:
+            logger.warning(
+                "photos holds multiple embedding dimensions; indexing only dim=%d. "
+                "Re-run the scan under one profile so all embeddings share a space.",
+                dim,
+            )
+
+        # If an existing index was built for a different dimension (profile
+        # switch), drop it so it is recreated at the current dim instead of
+        # freezing the old space or silently rejecting new rows.
+        if _vec_table_exists(conn):
+            declared = _vec_declared_dim(conn)
+            if declared is not None and declared != dim:
+                logger.warning(
+                    "photos_vec was built for dim=%d but embeddings are now dim=%d; "
+                    "dropping and rebuilding the index.", declared, dim,
+                )
+                conn.execute("DROP TABLE photos_vec")
+                conn.commit()
 
         if not _vec_table_exists(conn):
             conn.execute(f'''

--- a/faces/clusterer.py
+++ b/faces/clusterer.py
@@ -316,20 +316,23 @@ class FaceClusterer:
             preserve_named_only: If True, only loads named persons
 
         Returns:
-            Dict mapping person_id to {'name': str, 'centroid': np.array}
+            Dict mapping person_id to {'name': str, 'centroid': np.array | None}.
+            A person with no stored centroid (API-created via create/split/assign,
+            or otherwise never re-clustered) is kept with ``centroid=None`` — it is
+            still preserved, but only through the previous-owner history rule, not
+            centroid similarity. Excluding these (the old ``centroid IS NOT NULL``
+            filter) dropped them from preservation, so every incremental run cleared
+            their faces' person_id and the cleanup then deleted the named person.
         """
         if force:
             return {}
 
         if preserve_named_only:
             cursor = conn.execute("""
-                SELECT id, name, centroid FROM persons
-                WHERE centroid IS NOT NULL AND name IS NOT NULL
+                SELECT id, name, centroid FROM persons WHERE name IS NOT NULL
             """)
         else:
-            cursor = conn.execute("""
-                SELECT id, name, centroid FROM persons WHERE centroid IS NOT NULL
-            """)
+            cursor = conn.execute("SELECT id, name, centroid FROM persons")
 
         existing_persons = {}
         for row in cursor.fetchall():
@@ -337,10 +340,12 @@ class FaceClusterer:
             if centroid_bytes:
                 centroid = np.frombuffer(centroid_bytes, dtype=np.float32)
                 centroid = centroid / (np.linalg.norm(centroid) + 1e-10)
-                existing_persons[person_id] = {'name': name, 'centroid': centroid}
+            else:
+                centroid = None
+            existing_persons[person_id] = {'name': name, 'centroid': centroid}
 
         if existing_persons:
-            logger.info("  Preserving %s named person(s)", len(existing_persons))
+            logger.info("  Preserving %s existing person(s)", len(existing_persons))
         return existing_persons
 
     def _preserved_face_assignments(self, conn, existing_persons):
@@ -426,6 +431,46 @@ class FaceClusterer:
                 conn.execute("""
                     UPDATE persons SET centroid = ? WHERE id = ?
                 """, (new_centroid.tobytes(), pid))
+
+    def _repair_preserved_representatives(self, conn, person_ids):
+        """Fix a preserved person's representative face when clustering moved it.
+
+        Incremental / named-only clustering clears and reassigns ``person_id`` on
+        every face, so a preserved person's ``representative_face_id`` can end up
+        pointing at a face now owned by someone else (or no one). Replace it with
+        the person's highest-confidence remaining face, or clear both columns when
+        the person kept no faces. Tuple-row equivalent of
+        ``api.db_helpers.repair_stale_representative`` (this connection opens with
+        ``row_factory=False``).
+        """
+        for pid in person_ids:
+            row = conn.execute(
+                "SELECT representative_face_id FROM persons WHERE id = ?", (pid,)
+            ).fetchone()
+            if not row:
+                continue
+            rep_id = row[0]
+            if rep_id is not None and conn.execute(
+                "SELECT 1 FROM faces WHERE id = ? AND person_id = ?", (rep_id, pid)
+            ).fetchone():
+                continue
+            replacement = conn.execute(
+                "SELECT id, face_thumbnail FROM faces WHERE person_id = ? "
+                "ORDER BY confidence DESC LIMIT 1",
+                (pid,),
+            ).fetchone()
+            if replacement:
+                conn.execute(
+                    "UPDATE persons SET representative_face_id = ?, face_thumbnail = ? "
+                    "WHERE id = ?",
+                    (replacement[0], replacement[1], pid),
+                )
+            else:
+                conn.execute(
+                    "UPDATE persons SET representative_face_id = NULL, "
+                    "face_thumbnail = NULL WHERE id = ?",
+                    (pid,),
+                )
 
     def _update_database(self, face_to_cluster, embeddings, face_ids, force=False, preserve_named_only=False):
         """
@@ -513,6 +558,10 @@ class FaceClusterer:
                 if existing_persons:
                     best_similarity = merge_threshold
                     for pid, pdata in existing_persons.items():
+                        # Centroid-less preserved persons (API-created) can only be
+                        # matched by the history rule below, not by similarity.
+                        if pdata['centroid'] is None:
+                            continue
                         similarity = float(np.dot(centroid, pdata['centroid']))
                         if similarity > best_similarity:
                             best_similarity = similarity
@@ -617,6 +666,19 @@ class FaceClusterer:
             # Update face counts and centroids for existing persons
             if existing_persons:
                 self._update_person_centroids(conn, existing_persons.keys())
+                # Clustering reassigned person_id on every face, so a preserved
+                # person's stored representative may now belong to someone else.
+                self._repair_preserved_representatives(conn, existing_persons.keys())
+                # An incremental run can leave a preserved *unnamed* auto-clustered
+                # person with no faces (all folded into other clusters). These husks
+                # accumulate run over run, so drop them -- but keep named persons and
+                # API-created (auto_clustered = 0) ones even when momentarily empty.
+                deleted_empty = conn.execute(
+                    "DELETE FROM persons WHERE name IS NULL AND auto_clustered = 1 "
+                    "AND (face_count = 0 OR face_count IS NULL)"
+                ).rowcount
+                if deleted_empty:
+                    logger.info("  Removed %s empty auto-clustered person(s)", deleted_empty)
 
             conn.commit()
 

--- a/facet.py
+++ b/facet.py
@@ -155,7 +155,7 @@ def _print_scan_summary(db_path, todo_list, raw_paired_skipped):
     scored = blinks = bursts_non_lead = duplicates_non_lead = 0
     CHUNK = 500
     try:
-        with sqlite3.connect(db_path) as conn:
+        with get_connection(db_path, row_factory=False) as conn:
             for i in range(0, len(paths), CHUNK):
                 chunk = paths[i:i + CHUNK]
                 placeholders = ",".join("?" * len(chunk))
@@ -195,7 +195,7 @@ def _get_photo_column_count(db_path: str) -> int:
     """Return the number of columns currently on the photos table (0 if absent)."""
     import sqlite3
     try:
-        with sqlite3.connect(db_path) as conn:
+        with get_connection(db_path, row_factory=False) as conn:
             return len(list(conn.execute("PRAGMA table_info(photos)")))
     except sqlite3.Error:
         return 0
@@ -1171,11 +1171,24 @@ def _run_scan(args, resumed_run):
     ``_scan_writes_to_library``).
     """
     from processing.scorer import Facet, process_bursts, process_single_photo
+    from config import ScoringConfig
+
+    # Resolve the EFFECTIVE processing mode from config before building Facet.
+    # `processing.mode: "single-pass"` in the JSON (with no --single-pass CLI flag)
+    # drives the BatchProcessor path below, which needs the eager CLIP/tagger
+    # models — so the scorer must NOT be built multi_pass=True (which leaves
+    # model/preprocess None and TypeErrors per image). A specific --pass run
+    # (single_pass_name) still uses the per-pass multi-pass loader.
+    config_mode = (
+        ScoringConfig(args.config, validate=False)
+        .get_processing_settings().get('mode', 'auto')
+    )
+    config_single_pass = config_mode == 'single-pass' and not args.single_pass_name
 
     # Full mode - initialize with GPU models for photo processing
     # Multi-pass mode skips eager loading of heavy GPU models (CLIP, SAMP-Net)
     # since multi-pass loads its own models per pass via ModelManager
-    use_multi_pass = not (args.dry_run or args.single_pass)
+    use_multi_pass = not (args.dry_run or args.single_pass or config_single_pass)
     scorer = Facet(db_path=args.db, config_path=args.config, multi_pass=use_multi_pass)
     _log_scan_db_destination(scorer.db_path)
 
@@ -1251,9 +1264,19 @@ def _run_scan(args, resumed_run):
         missing = len(failed) - len(all_files)
         logger.info("Retrying %d failed files (%d no longer on disk)", len(all_files), missing)
 
-    # Identify JPEGs to avoid double-processing if RAW+JPEG pairs exist
+    # Identify JPEGs to avoid double-processing if RAW+JPEG pairs exist. Pairing
+    # is keyed on (resolved parent dir, stem) so a JPEG only suppresses a RAW that
+    # sits beside it: an unrelated same-stem JPEG in another folder no longer hides
+    # the RAW library-wide.
     jpeg_like = {'.jpg', '.jpeg'} | HEIF_EXTENSIONS
-    jpegs_stems = {f.stem.lower() for f in all_files if f.suffix.lower() in jpeg_like}
+    jpeg_dir_stems = {
+        (os.path.dirname(_resolved(f)), f.stem.lower())
+        for f in all_files if f.suffix.lower() in jpeg_like
+    }
+
+    def _raw_paired_with_jpeg(f):
+        return (f.suffix.lower() in RAW_EXTENSIONS
+                and (os.path.dirname(_resolved(f)), f.stem.lower()) in jpeg_dir_stems)
     if args.retry_failed:
         unscanned = {_resolved(f) for f in all_files}
     elif args.force_since:
@@ -1274,11 +1297,8 @@ def _run_scan(args, resumed_run):
 
     # Filter the list to only include new or un-scanned files
     todo_list = [f for f in all_files if _resolved(f) in unscanned
-                 and not (f.suffix.lower() in RAW_EXTENSIONS and f.stem.lower() in jpegs_stems)]
-    raw_paired_skipped = sum(
-        1 for f in all_files
-        if f.suffix.lower() in RAW_EXTENSIONS and f.stem.lower() in jpegs_stems
-    )
+                 and not _raw_paired_with_jpeg(f)]
+    raw_paired_skipped = sum(1 for f in all_files if _raw_paired_with_jpeg(f))
 
     logger.info("Found %d total, processing %d new files.", len(all_files), len(todo_list))
 
@@ -1409,6 +1429,7 @@ def _run_scan(args, resumed_run):
                 scorer,
                 batch_size=current_settings['batch_size'],
                 num_workers=current_settings['num_workers'],
+                config=scorer.config.config,
                 on_error=scan_run.record_failure,
                 on_progress=_on_scan_progress,
             )
@@ -1447,6 +1468,7 @@ def _run_scan(args, resumed_run):
                     batch_size=current_settings['batch_size'],
                     num_workers=current_settings['num_workers'],
                     prefetch_multiplier=current_settings.get('prefetch_queue_multiplier', 2),
+                    config=scorer.config.config,
                     on_error=scan_run.record_failure,
                     on_progress=_on_scan_progress,
                 )
@@ -1484,6 +1506,7 @@ def _run_scan(args, resumed_run):
                     scorer,
                     batch_size=proc_settings.get('gpu_batch_size', 16),
                     num_workers=proc_settings.get('num_workers', 4),
+                    config=scorer.config.config,
                     on_error=scan_run.record_failure,
                     on_progress=_on_scan_progress,
                 )
@@ -1822,7 +1845,9 @@ Configuration:
     face_group.add_argument('--recompute-eyes-expression', action='store_true',
                         help='Recompute eyes-open and expression scores from stored landmarks (CPU only, fast)')
     face_group.add_argument('--recompute-face-signals', action='store_true',
-                        help='Backfill per-face eyes-open and smile scores from stored landmarks (CPU only, fast)')
+                        help='Backfill per-face eyes-open and smile scores from stored landmarks for '
+                             'faces still missing them (CPU only, fast); add --force to rewrite every '
+                             'face from geometry, overwriting stored MediaPipe blendshape values')
     face_group.add_argument('--recompute-burst', action='store_true',
                         help='Recompute burst detection groups')
     face_group.add_argument('--suggest-person-merges', action='store_true',
@@ -2318,7 +2343,9 @@ Configuration:
     if args.recompute_face_signals:
         init_database(args.db)  # Ensure the per-face signal columns exist
         scorer = Facet(db_path=args.db, config_path=args.config, lightweight=True)
-        scorer.recompute_face_signals()
+        # Default is a backfill of faces missing a signal; --force rewrites all
+        # of them from geometry (clobbering any stored MediaPipe blendshapes).
+        scorer.recompute_face_signals(force=args.force)
         exit()
 
     # --upgrade-db: run the full backfill chain in dependency order by

--- a/models/model_manager.py
+++ b/models/model_manager.py
@@ -319,8 +319,12 @@ class ModelManager:
             self._move_to_cpu(model, model_name)
             self._cpu_cache[model_name] = model
         else:
-            # Full unload
-            if hasattr(model, 'cpu'):
+            # Full unload — mirror unload_all(): let a wrapper release its own
+            # resources (PyIQAScorer/SAMPNetScorer/RAMTagger .unload()) before the
+            # reference is dropped, instead of only nudging tensors to CPU.
+            if hasattr(model, 'unload'):
+                model.unload()
+            elif hasattr(model, 'cpu'):
                 model.cpu()
             elif isinstance(model, dict):
                 for v in model.values():
@@ -328,6 +332,8 @@ class ModelManager:
                         v.cpu()
             del model
 
+        # The model is already popped from self.models above, so the reference is
+        # gone before we clear the device cache and the freed VRAM is reclaimed.
         from utils.device import clear_device_cache
         clear_device_cache(self.device)
 

--- a/optimization/auto_retrain.py
+++ b/optimization/auto_retrain.py
@@ -220,13 +220,18 @@ def _run_retrain(db_path, scope, pending=0):
 
     Deferred rather than run when another process holds the library lock;
     ``pending`` is handed back so the batch survives to trigger the next one.
+    A training exception is handed the same way (once, not twice — the
+    lock-deferral return already gave it back) so a broken run never discards
+    the accumulated comparisons.
     """
     global _retrain_running
     library_lock = None
+    counter_returned = False
     try:
         library_lock = _hold_library_lock(db_path, scope)
         if library_lock is None:
             _give_back_counter(db_path, scope, pending)
+            counter_returned = True
             return
         from optimization.personal_ranker import train_ranker
         result = train_ranker(db_path=db_path, user_id=scope)
@@ -260,6 +265,8 @@ def _run_retrain(db_path, scope, pending=0):
             logger.warning("Auto-retrain keeper (scope=%s) failed", scope, exc_info=True)
     except Exception:  # noqa: BLE001 — background worker must never propagate
         logger.warning("Auto-retrain (scope=%s) failed", scope, exc_info=True)
+        if not counter_returned:
+            _give_back_counter(db_path, scope, pending)
     finally:
         if library_lock is not None:
             library_lock.release()

--- a/optimization/weight_optimizer.py
+++ b/optimization/weight_optimizer.py
@@ -430,6 +430,7 @@ class WeightOptimizer:
         min_comparisons: int = 30,
         include_ties: bool = True,
         sources: Optional[List[str]] = None,
+        l2_regularization: float = 0.01,
     ) -> Dict:
         """
         K-fold cross-validation for robust weight optimization.
@@ -437,11 +438,20 @@ class WeightOptimizer:
         Splits comparisons into k folds, trains on k-1 folds, and evaluates
         on the held-out fold. Returns average weights and CV accuracy.
 
+        Each fold is trained with the SAME L2-regularized objective (anchored
+        to the current live weights) that ``optimize_weights_direct`` actually
+        ships — otherwise the CV accuracy this method reports as a deploy gate
+        would be scoring a different, unregularized/uniform-start model than
+        the one that goes live, understating (or overstating) the real
+        held-out accuracy.
+
         Args:
             category: Category to optimize
             n_folds: Number of cross-validation folds
             min_comparisons: Minimum comparisons required
             include_ties: Whether to include ties
+            l2_regularization: L2 penalty on weight changes from current weights
+                (must match ``optimize_weights_direct`` for the gate to be valid)
 
         Returns:
             Dict with:
@@ -465,6 +475,15 @@ class WeightOptimizer:
                 n_folds = len(all_data)
 
             n_features = len(self.SCORE_COMPONENTS)
+
+            # Current live weights: same anchor optimize_weights_direct regularizes
+            # toward, loaded/normalized the same way (see lines ~234-239 above).
+            old_weights = self._load_current_weights(category)
+            old_w = np.array([old_weights.get(c, 1.0 / n_features) for c in self.SCORE_COMPONENTS])
+            if old_w.sum() > 0:
+                old_w = old_w / old_w.sum()
+            else:
+                old_w = np.ones(n_features) / n_features
 
             # Create fold indices
             indices = np.arange(len(all_data))
@@ -508,12 +527,16 @@ class WeightOptimizer:
                             total_nll += rw * np.log1p(np.exp(np.clip(d, -20, 20)))
                         else:
                             total_nll += rw * (d / 0.2) ** 2
+                    # Same L2 anchor to old_w as optimize_weights_direct's
+                    # neg_log_likelihood, or this fold trains a different model
+                    # than the one the CV accuracy is meant to gate.
+                    total_nll += l2_regularization * np.sum((weights - old_w) ** 2)
                     return total_nll
 
-                # Optimize
+                # Optimize — anchored at old_w, same as optimize_weights_direct.
                 bounds = [(0.0, 0.60) for _ in range(n_features)]
                 constraints = {'type': 'eq', 'fun': lambda w: w.sum() - 1.0}
-                start = np.ones(n_features) / n_features
+                start = old_w.copy()
 
                 try:
                     result = minimize(
@@ -565,9 +588,6 @@ class WeightOptimizer:
             # Average weights across folds
             avg_weights = np.mean(fold_weights, axis=0)
             avg_weights = avg_weights / avg_weights.sum()
-
-            # Load current weights for comparison
-            old_weights = self._load_current_weights(category)
 
             new_weights = {c: float(w) for c, w in zip(self.SCORE_COMPONENTS, avg_weights)}
 

--- a/processing/batch_processor.py
+++ b/processing/batch_processor.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from analyzers import CompositionAnalyzer, ImageCache
 from db.scoring_overrides import get_photo_scoring_overrides
+from processing.scorer import build_scoring_metrics
 from utils import (
     load_image_from_path, get_tag_params, detect_silhouette,
     tags_to_string
@@ -376,33 +377,41 @@ class BatchProcessor:
                 # Determine silhouette using shared function
                 is_silhouette = detect_silhouette(histogram_data, tags, face_res.get('face_count', 0))
 
-                # Calculate aggregate (including EXIF for adjustments)
-                metrics = {
-                    'aesthetic': aesthetic,
-                    'face_count': face_res['face_count'],
-                    'face_quality': face_res['face_quality'],
-                    'eye_sharpness': face_res['eye_sharpness'],
-                    'tech_sharpness': sharpness_data['normalized'],
-                    'color_score': color_data['normalized'],
-                    'exposure_score': histogram_data['exposure_score'],
-                    'face_ratio': face_ratio,
-                    'comp_score': comp_data['score'],
-                    'isolation_bonus': isolation_bonus,
-                    'is_blink': is_blink,
-                    # New clipping/silhouette data
-                    'shadow_clipped': histogram_data.get('shadow_clipped', 0),
-                    'highlight_clipped': histogram_data.get('highlight_clipped', 0),
-                    'is_silhouette': is_silhouette,
-                    # Histogram spread for dynamic range
-                    'histogram_spread': histogram_data['spread'],
-                    # EXIF data for ISO/aperture adjustments
-                    'iso': exif_data.get('iso'),
-                    'f_stop': exif_data.get('f_stop'),
-                    'quality_score': quality_score,
-                    'scoring_model': scoring_model,
-                    'scoring_context': photo_override.get('scoring_context'),
-                    'category_override': photo_override.get('category_override'),
-                }
+                # Calculate aggregate via the shared builder so the single-pass
+                # batch path feeds calculate_aggregate_logic the same feature space
+                # as the multi-pass path (tags, is_monochrome, mean_luminance,
+                # is_group_portrait, face_sharpness, power_point_score,
+                # contrast_score, noise_sigma, mean_saturation — all previously
+                # dropped here, leaving 25/34 categories unreachable).
+                metrics = build_scoring_metrics(
+                    aesthetic=aesthetic,
+                    face_count=face_res['face_count'],
+                    face_quality=face_res['face_quality'],
+                    eye_sharpness=face_res['eye_sharpness'],
+                    face_sharpness=face_res['face_sharpness'],
+                    face_ratio=face_ratio,
+                    is_group_portrait=face_res.get('is_group_portrait', 0),
+                    is_blink=is_blink,
+                    isolation_bonus=isolation_bonus,
+                    sharpness_data=sharpness_data,
+                    color_data=color_data,
+                    histogram_data=histogram_data,
+                    mono_data=mono_data,
+                    noise_data=noise_data,
+                    contrast_data=contrast_data,
+                    comp_score=comp_data['score'],
+                    power_point_score=comp_data.get('power_point_score', 5.0),
+                    leading_lines_score=leading_lines_data.get('leading_lines_score', 0),
+                    is_silhouette=is_silhouette,
+                    tags=tags,
+                    iso=exif_data.get('iso'),
+                    f_stop=exif_data.get('f_stop'),
+                    shutter_speed=exif_data.get('shutter_speed'),
+                    quality_score=quality_score,
+                    scoring_model=scoring_model,
+                    scoring_context=photo_override.get('scoring_context'),
+                    category_override=photo_override.get('category_override'),
+                )
                 aggregate, category = self.scorer.calculate_aggregate_logic(metrics)
 
                 # Build result

--- a/processing/multi_pass.py
+++ b/processing/multi_pass.py
@@ -24,6 +24,7 @@ from tqdm import tqdm
 
 from db.scoring_overrides import get_photo_scoring_overrides
 from models.model_manager import UNIFIED_MEMORY_ACCELERATOR, ModelManager
+from processing.scorer import build_scoring_metrics
 
 logger = logging.getLogger("facet.multi_pass")
 
@@ -117,9 +118,10 @@ class ChunkedMultiPassProcessor:
             int(proc_config.get('load_workers', proc_config.get('num_workers', 4))), 8
         ))
 
-        # Processing mode: 'auto', 'multi-pass', 'single-pass'
+        # Processing mode: 'auto', 'multi-pass', 'single-pass'. Effective single-
+        # pass routing is decided in facet._run_scan (which builds a BatchProcessor
+        # instead of this processor), so no derived flag is kept here.
         self.mode = proc_config.get('mode', 'auto')
-        self.enabled = self.mode != 'single-pass'
 
         # Auto-tuning settings for RAM chunk size
         auto_tuning = proc_config.get('auto_tuning', {})
@@ -938,69 +940,52 @@ class ChunkedMultiPassProcessor:
             )
             data['is_silhouette'] = is_silhouette
 
-            # Build full metrics dict for aggregate calculation
-            metrics = {
-                'aesthetic': data.get('aesthetic', 5.0),
-                'quality_score': data.get('quality_score'),
-                'scoring_model': data.get('scoring_model', 'clip-mlp'),
-                'comp_score': data.get('comp_score', 5.0),
-                'face_count': data.get('face_count', 0),
-                'face_quality': data.get('face_quality', 0),
-                'eye_sharpness': data.get('eye_sharpness', 0),
-                'face_sharpness': data.get('face_sharpness', 0),
-                'tech_sharpness': tech_sharpness,
-                'color_score': color_score,
-                'exposure_score': exposure_score,
-                'face_ratio': data.get('face_ratio', 0),
-                'tags': data.get('tags', ''),
-                'isolation_bonus': data.get('isolation_bonus', 1.0),
-                'is_blink': data.get('is_blink', 0),
-                'is_group_portrait': data.get('is_group_portrait', 0),
-                # Histogram data for penalties
-                'shadow_clipped': histogram.get('shadow_clipped', 0),
-                'highlight_clipped': histogram.get('highlight_clipped', 0),
-                'is_silhouette': is_silhouette,
-                'histogram_spread': histogram.get('spread', 0),
-                'histogram_bimodality': histogram.get('bimodality', 0),
-                'mean_luminance': histogram.get('mean_luminance', 0.5),
-                # B&W and contrast
-                'is_monochrome': mono.get('is_monochrome', 0),
-                'mean_saturation': mono.get('mean_saturation', 0),
-                'contrast_score': contrast.get('contrast_score', 5.0),
-                # Noise
-                'noise_sigma': noise.get('noise_sigma', 0),
-                # Leading lines
-                'leading_lines_score': data.get('leading_lines_score', 0),
-                'power_point_score': data.get('power_point_score', 5.0),
-                'topiq_score': data.get('topiq_score'),
-                # Supplementary PyIQA scores
-                'aesthetic_iaa': data.get('aesthetic_iaa'),
-                'face_quality_iqa': data.get('face_quality_iqa'),
-                'liqe_score': data.get('liqe_score'),
-                # Extended IQA tier (config-gated; None unless enabled). Carried so
-                # build_metric_vector can weight them when a weight is configured.
-                'qalign_score': data.get('qalign_score'),
-                'aesthetic_v25': data.get('aesthetic_v25'),
-                'deqa_score': data.get('deqa_score'),
-                # Subject saliency metrics
-                'subject_sharpness': data.get('subject_sharpness'),
-                'subject_prominence': data.get('subject_prominence'),
-                'subject_placement': data.get('subject_placement'),
-                'bg_separation': data.get('bg_separation'),
-                # Form facet + Matsuda color harmony (computed in _load_images)
-                'form_symmetry': img_data.get('form', {}).get('form_symmetry'),
-                'form_balance': img_data.get('form', {}).get('form_balance'),
-                'form_edge_entropy': img_data.get('form', {}).get('form_edge_entropy'),
-                'form_fractal': img_data.get('form', {}).get('form_fractal'),
-                'color_harmony': img_data.get('form', {}).get('color_harmony'),
-                # EXIF for adjustments
-                'iso': img_data.get('exif', {}).get('iso'),
-                'f_stop': img_data.get('exif', {}).get('f_stop'),
-                'shutter_speed': img_data.get('exif', {}).get('shutter_speed'),
-            }
+            # Build full metrics dict for aggregate calculation via the shared
+            # builder — the single source of truth for the scan-time feature space,
+            # also used by the single-pass batch and PIL scoring paths.
+            exif = img_data.get('exif', {})
             photo_override = chunk_overrides.get(str(Path(path).resolve()), {})
-            metrics['scoring_context'] = photo_override.get('scoring_context')
-            metrics['category_override'] = photo_override.get('category_override')
+            metrics = build_scoring_metrics(
+                aesthetic=data.get('aesthetic', 5.0),
+                face_count=data.get('face_count', 0),
+                face_quality=data.get('face_quality', 0),
+                eye_sharpness=data.get('eye_sharpness', 0),
+                face_sharpness=data.get('face_sharpness', 0),
+                face_ratio=data.get('face_ratio', 0),
+                is_group_portrait=data.get('is_group_portrait', 0),
+                is_blink=data.get('is_blink', 0),
+                isolation_bonus=data.get('isolation_bonus', 1.0),
+                sharpness_data=sharpness,
+                color_data=color,
+                histogram_data=histogram,
+                mono_data=mono,
+                noise_data=noise,
+                contrast_data=contrast,
+                comp_score=data.get('comp_score', 5.0),
+                power_point_score=data.get('power_point_score', 5.0),
+                leading_lines_score=data.get('leading_lines_score', 0),
+                is_silhouette=is_silhouette,
+                tags=data.get('tags', ''),
+                iso=exif.get('iso'),
+                f_stop=exif.get('f_stop'),
+                shutter_speed=exif.get('shutter_speed'),
+                quality_score=data.get('quality_score'),
+                scoring_model=data.get('scoring_model', 'clip-mlp'),
+                topiq_score=data.get('topiq_score'),
+                aesthetic_iaa=data.get('aesthetic_iaa'),
+                face_quality_iqa=data.get('face_quality_iqa'),
+                liqe_score=data.get('liqe_score'),
+                qalign_score=data.get('qalign_score'),
+                aesthetic_v25=data.get('aesthetic_v25'),
+                deqa_score=data.get('deqa_score'),
+                subject_sharpness=data.get('subject_sharpness'),
+                subject_prominence=data.get('subject_prominence'),
+                subject_placement=data.get('subject_placement'),
+                bg_separation=data.get('bg_separation'),
+                form_data=img_data.get('form', {}),
+                scoring_context=photo_override.get('scoring_context'),
+                category_override=photo_override.get('category_override'),
+            )
 
             # Use scorer's aggregate calculation
             aggregate, category = self.scorer.calculate_aggregate_logic(metrics)
@@ -1272,10 +1257,19 @@ def run_single_pass(paths: List[str], pass_name: str, scorer, model_manager) -> 
         else:
             model_name = 'topiq'  # Default to best pyiqa model
 
-    # For tags, determine model from profile
+    # For tags, determine model from profile. A CLIP-similarity profile has no
+    # VLM tagger to run as a pass — routing it to the 'clip' embedding pass would
+    # rewrite clip_embedding + aesthetic and produce zero tags. Fail clearly and
+    # point at --recompute-tags, which re-tags from the stored embeddings.
     if pass_name == 'tags':
         tag_model = scorer.config.get_model_for_task('tagging')
-        model_name = tagging_model_to_key(tag_model, 'clip')
+        model_name = tagging_model_to_key(tag_model)
+        if model_name is None:
+            logger.error(
+                "--pass tags needs a VLM tagger, but the active profile's tagging "
+                "model is %r (CLIP embedding-similarity). Run --recompute-tags to "
+                "re-tag from stored embeddings instead.", tag_model)
+            return 0
 
     if not model_name:
         logger.error("Unknown pass: %s", pass_name)

--- a/processing/resource_monitor.py
+++ b/processing/resource_monitor.py
@@ -104,23 +104,20 @@ class ResourceMonitor:
 
     Auto-tuning capabilities:
     - GPU batch size: Reduced when VRAM exceeds limit
-    - RAM chunk size (multi-pass): Reduced when system RAM exceeds limit
     """
 
     MAX_MEMORY_WAIT_SECONDS = 10
     MEMORY_RECOVERY_TARGET_PERCENT = 75
 
-    def __init__(self, batch_processor, config=None, multi_pass_processor=None):
+    def __init__(self, batch_processor, config=None):
         """
         Initialize the resource monitor.
 
         Args:
             batch_processor: BatchProcessor instance to monitor
             config: Optional config dict with auto_tuning settings
-            multi_pass_processor: Optional ChunkedMultiPassProcessor for RAM tuning
         """
         self.processor = batch_processor
-        self.multi_pass_processor = multi_pass_processor
         self.stop_event = threading.Event()
         self.thread = None
 
@@ -135,8 +132,7 @@ class ResourceMonitor:
         self.monitor_interval = auto_tuning.get('monitor_interval_seconds', 5)
         self.min_workers = auto_tuning.get('min_processing_workers', 1)
         self.max_workers = auto_tuning.get('max_processing_workers', 24)
-        self.min_batch_size = auto_tuning.get('min_batch_size', 2)
-        self.max_batch_size = auto_tuning.get('max_batch_size', 32)
+        self.min_batch_size = auto_tuning.get('min_gpu_batch_size', 2)
         self.memory_limit_percent = auto_tuning.get('memory_limit_percent', 85)
         self.cpu_target_percent = auto_tuning.get('cpu_target_percent', 80)
 
@@ -259,72 +255,19 @@ class ResourceMonitor:
     def _apply_tuning(self):
         """Apply auto-tuning based on current metrics.
 
-        Handles both GPU batch size (for single-pass/batch processing) and
-        RAM chunk size (for multi-pass mode).
+        Reduces the GPU batch size when memory exceeds the configured limit.
+        (Multi-pass RAM chunk tuning lives in MultiPassResourceMonitor.)
         """
         metrics = self.get_metrics()
-        processor_metrics = self.processor.get_metrics()
-
-        # Get current state
-        queue_timeouts = processor_metrics.get('queue_timeouts', 0)
-        cpu_usage = metrics.get('cpu_percent', 0)
         memory_usage = metrics.get('memory_percent', 0)
 
-        # Tuning logic
-        # 1. Memory limit check (graceful reduction)
+        # Memory limit check (graceful reduction)
         if memory_usage > self.memory_limit_percent:
             self._graceful_memory_reduction(memory_usage)
-            return
-
-        # 2. Multi-pass RAM chunk tuning (if multi_pass_processor is set)
-        if self.multi_pass_processor is not None:
-            self._apply_ram_chunk_tuning(memory_usage)
-
-        # 3. Queue starvation (GPU waiting for images)
-        # If we're getting timeouts and CPU has headroom, suggest more workers
-        timeout_rate = queue_timeouts / max(1, processor_metrics.get('images_processed', 1))
-        if timeout_rate > 0.05 and cpu_usage < self.cpu_target_percent:
-            # Signal that more workers might help
-            with self._metrics_lock:
-                self.resource_metrics['recommendation'] = 'increase_workers'
-        elif timeout_rate < 0.01 and cpu_usage > self.cpu_target_percent:
-            # CPU is overloaded, might need fewer workers
-            with self._metrics_lock:
-                self.resource_metrics['recommendation'] = 'decrease_workers'
-        else:
-            with self._metrics_lock:
-                self.resource_metrics['recommendation'] = None
-
-    def _apply_ram_chunk_tuning(self, memory_usage):
-        """Apply RAM-based auto-tuning for multi-pass chunk size.
-
-        Args:
-            memory_usage: Current memory usage percentage (0-100)
-        """
-        if self.multi_pass_processor is None:
-            return
-
-        # High memory usage: reduce chunk size
-        if memory_usage > self.memory_limit_percent:
-            self.multi_pass_processor.reduce_chunk_size()
-        # Low memory usage with headroom: consider increasing
-        elif memory_usage < (self.memory_limit_percent - 20):
-            # Only increase if consistently low (check rolling average)
-            samples = self.resource_metrics.get('samples', [])
-            if len(samples) >= 3:
-                recent_avg = sum(s.get('memory_percent', 0) for s in samples[-3:]) / 3
-                if recent_avg < (self.memory_limit_percent - 20):
-                    self.multi_pass_processor.increase_chunk_size()
 
     def _graceful_memory_reduction(self, current_usage):
         """Handle memory limit exceeded by reducing batch size."""
         logger.warning("Memory usage at %.1f%%, reducing batch size...", current_usage)
-
-        # Evict CPU-cached models first (may free enough RAM)
-        if self.multi_pass_processor is not None:
-            mm = getattr(self.multi_pass_processor, 'model_manager', None)
-            if mm is not None:
-                mm.evict_cpu_cache()
 
         # Reduce batch size by 25%
         current_batch = self.processor.batch_size

--- a/processing/scorer.py
+++ b/processing/scorer.py
@@ -588,6 +588,89 @@ def build_metric_vector(m, cfg, category, weights=None, penalties=None):
     return result
 
 
+def build_scoring_metrics(
+    *,
+    aesthetic,
+    face_count, face_quality, eye_sharpness, face_sharpness, face_ratio,
+    is_group_portrait, is_blink, isolation_bonus,
+    sharpness_data, color_data, histogram_data, mono_data, noise_data, contrast_data,
+    comp_score, power_point_score, leading_lines_score,
+    is_silhouette, tags,
+    iso, f_stop, shutter_speed=None,
+    quality_score=None, scoring_model='clip-mlp',
+    topiq_score=None, aesthetic_iaa=None, face_quality_iqa=None, liqe_score=None,
+    qalign_score=None, aesthetic_v25=None, deqa_score=None,
+    subject_sharpness=None, subject_prominence=None,
+    subject_placement=None, bg_separation=None,
+    form_data=None,
+    scoring_context=None, category_override=None,
+):
+    """Build the metrics dict consumed by :meth:`Facet.calculate_aggregate_logic`.
+
+    Single source of truth for the scoring feature space at scan time, shared by
+    the single-pass batch processor, the single-image PIL scorer, and the
+    multi-pass aggregate step, so all three feed calculate_aggregate_logic the
+    exact same keys. A key silently dropped from one path (tags, is_monochrome,
+    mean_luminance, is_group_portrait, face_sharpness, power_point_score,
+    contrast_score, noise_sigma, mean_saturation, ...) makes whole categories
+    unreachable and zeroes penalties for that path only. Technical sub-dicts are
+    read with the same defaults the multi-pass path uses so a partially computed
+    chunk degrades identically everywhere.
+    """
+    form = form_data or {}
+    return {
+        'aesthetic': aesthetic,
+        'quality_score': quality_score,
+        'scoring_model': scoring_model,
+        'comp_score': comp_score,
+        'face_count': face_count,
+        'face_quality': face_quality,
+        'eye_sharpness': eye_sharpness,
+        'face_sharpness': face_sharpness,
+        'tech_sharpness': sharpness_data.get('normalized', 5.0),
+        'color_score': color_data.get('normalized', 5.0),
+        'exposure_score': histogram_data.get('exposure_score', 5.0),
+        'face_ratio': face_ratio,
+        'tags': tags,
+        'isolation_bonus': isolation_bonus,
+        'is_blink': is_blink,
+        'is_group_portrait': is_group_portrait,
+        'shadow_clipped': histogram_data.get('shadow_clipped', 0),
+        'highlight_clipped': histogram_data.get('highlight_clipped', 0),
+        'is_silhouette': is_silhouette,
+        'histogram_spread': histogram_data.get('spread', 0),
+        'histogram_bimodality': histogram_data.get('bimodality', 0),
+        'mean_luminance': histogram_data.get('mean_luminance', 0.5),
+        'is_monochrome': mono_data.get('is_monochrome', 0),
+        'mean_saturation': mono_data.get('mean_saturation', 0),
+        'contrast_score': contrast_data.get('contrast_score', 5.0),
+        'noise_sigma': noise_data.get('noise_sigma', 0),
+        'leading_lines_score': leading_lines_score,
+        'power_point_score': power_point_score,
+        'topiq_score': topiq_score,
+        'aesthetic_iaa': aesthetic_iaa,
+        'face_quality_iqa': face_quality_iqa,
+        'liqe_score': liqe_score,
+        'qalign_score': qalign_score,
+        'aesthetic_v25': aesthetic_v25,
+        'deqa_score': deqa_score,
+        'subject_sharpness': subject_sharpness,
+        'subject_prominence': subject_prominence,
+        'subject_placement': subject_placement,
+        'bg_separation': bg_separation,
+        'form_symmetry': form.get('form_symmetry'),
+        'form_balance': form.get('form_balance'),
+        'form_edge_entropy': form.get('form_edge_entropy'),
+        'form_fractal': form.get('form_fractal'),
+        'color_harmony': form.get('color_harmony'),
+        'iso': iso,
+        'f_stop': f_stop,
+        'shutter_speed': shutter_speed,
+        'scoring_context': scoring_context,
+        'category_override': category_override,
+    }
+
+
 IQA_PASS_VRAM_MARGIN_GB = 2
 CPU_DEVICE_LABEL = "CPU"
 
@@ -1264,41 +1347,41 @@ class Facet:
             # then calculate_aggregate_logic was adding it again via leading_lines_blend)
             final_comp = comp_data['score']
 
-            # Pack ingredients for the score calculation (including EXIF for adjustments)
-            metrics = {
-                'aesthetic': aesthetic,
-                'face_count': face_res['face_count'],
-                'face_quality': face_res['face_quality'],
-                'eye_sharpness': face_res['eye_sharpness'],
-                'tech_sharpness': sharpness_data['normalized'],
-                'color_score': color_data['normalized'],
-                'exposure_score': histogram_data['exposure_score'],
-                'face_ratio': face_ratio,
-                'comp_score': final_comp,
-                'isolation_bonus': isolation_bonus,
-                'is_blink': is_blink,
-                # New clipping/silhouette data
-                'shadow_clipped': histogram_data.get('shadow_clipped', 0),
-                'highlight_clipped': histogram_data.get('highlight_clipped', 0),
-                'is_silhouette': is_silhouette,
-                # Histogram spread for dynamic range
-                'histogram_spread': histogram_data['spread'],
-                # B&W detection
-                'is_monochrome': mono_data['is_monochrome'],
-                # Contrast score for B&W images
-                'contrast_score': contrast_data['contrast_score'],
-                # Form facet + Matsuda color harmony
-                'form_symmetry': form_data.get('form_symmetry'),
-                'form_balance': form_data.get('form_balance'),
-                'form_edge_entropy': form_data.get('form_edge_entropy'),
-                'form_fractal': form_data.get('form_fractal'),
-                'color_harmony': form_data.get('color_harmony'),
-                # EXIF data for ISO/aperture adjustments
-                'iso': exif_data.get('iso'),
-                'f_stop': exif_data.get('f_stop'),
-                'scoring_context': photo_override.get('scoring_context'),
-                'category_override': photo_override.get('category_override'),
-            }
+            # Pack ingredients for the score calculation via the shared builder so
+            # this path feeds calculate_aggregate_logic the same feature space as
+            # the batch and multi-pass paths (tags, is_monochrome, mean_luminance,
+            # is_group_portrait, face_sharpness, power_point_score, noise_sigma,
+            # mean_saturation — all previously dropped here).
+            metrics = build_scoring_metrics(
+                aesthetic=aesthetic,
+                face_count=face_res['face_count'],
+                face_quality=face_res['face_quality'],
+                eye_sharpness=face_res['eye_sharpness'],
+                face_sharpness=face_res['face_sharpness'],
+                face_ratio=face_ratio,
+                is_group_portrait=face_res.get('is_group_portrait', 0),
+                is_blink=is_blink,
+                isolation_bonus=isolation_bonus,
+                sharpness_data=sharpness_data,
+                color_data=color_data,
+                histogram_data=histogram_data,
+                mono_data=mono_data,
+                noise_data=noise_data,
+                contrast_data=contrast_data,
+                comp_score=final_comp,
+                power_point_score=comp_data.get('power_point_score', 5.0),
+                leading_lines_score=leading_lines_data.get('leading_lines_score', 0),
+                is_silhouette=is_silhouette,
+                tags=tags,
+                iso=exif_data.get('iso'),
+                f_stop=exif_data.get('f_stop'),
+                shutter_speed=exif_data.get('shutter_speed'),
+                quality_score=quality_score,
+                scoring_model=scoring_model,
+                form_data=form_data,
+                scoring_context=photo_override.get('scoring_context'),
+                category_override=photo_override.get('category_override'),
+            )
 
             # Calculate final aggregate score and category using the centralized logic
             aggregate, category = self.calculate_aggregate_logic(metrics)
@@ -1409,37 +1492,61 @@ class Facet:
         categories_updated = 0
 
         with get_connection(self.db_path) as conn:
-            # Select columns needed for recalculation and category determination
-            recalc_cols = """
-                path, aesthetic, face_count, face_quality, eye_sharpness, face_sharpness,
-                face_ratio, tech_sharpness, color_score, exposure_score, comp_score,
-                isolation_bonus, is_blink, iso, f_stop, focal_length, shadow_clipped, highlight_clipped,
-                is_silhouette, histogram_spread, is_monochrome, contrast_score, tags,
-                leading_lines_score, histogram_bimodality, clip_embedding,
-                raw_sharpness_variance, raw_color_entropy, raw_eye_sharpness,
-                shutter_speed, is_group_portrait, mean_luminance, scoring_model, quality_score,
-                noise_sigma, mean_saturation, power_point_score, dynamic_range_stops,
-                histogram_data, topiq_score,
-                aesthetic_iaa, face_quality_iqa, liqe_score,
-                qalign_score, aesthetic_v25, deqa_score,
-                subject_sharpness, subject_prominence, subject_placement, bg_separation,
-                form_symmetry, form_balance, form_edge_entropy, form_fractal, color_harmony
-            """
+            # Columns needed for recalculation and category determination, built
+            # conditionally: clip_embedding is the largest per-row BLOB, so it is
+            # fetched only when aesthetic will actually be recomputed from it —
+            # otherwise a 127k library streams ~0.5GB of embeddings into RAM only
+            # to discard them (honours the BLOB-exclusion invariant). histogram_data
+            # stays: it is decoded below to recompute exposure_score.
+            recalc_cols = [
+                'path', 'aesthetic', 'face_count', 'face_quality', 'eye_sharpness', 'face_sharpness',
+                'face_ratio', 'tech_sharpness', 'color_score', 'exposure_score', 'comp_score',
+                'isolation_bonus', 'is_blink', 'iso', 'f_stop', 'focal_length', 'shadow_clipped', 'highlight_clipped',
+                'is_silhouette', 'histogram_spread', 'is_monochrome', 'contrast_score', 'tags',
+                'leading_lines_score', 'histogram_bimodality',
+                'raw_sharpness_variance', 'raw_color_entropy', 'raw_eye_sharpness',
+                'shutter_speed', 'is_group_portrait', 'mean_luminance', 'scoring_model', 'quality_score',
+                'noise_sigma', 'mean_saturation', 'power_point_score', 'dynamic_range_stops',
+                'histogram_data', 'topiq_score',
+                'aesthetic_iaa', 'face_quality_iqa', 'liqe_score',
+                'qalign_score', 'aesthetic_v25', 'deqa_score',
+                'subject_sharpness', 'subject_prominence', 'subject_placement', 'bg_separation',
+                'form_symmetry', 'form_balance', 'form_edge_entropy', 'form_fractal', 'color_harmony',
+            ]
+            if use_embeddings:
+                recalc_cols.append('clip_embedding')
+            cols_sql = ', '.join(recalc_cols)
+
             if category_filter:
-                cursor = conn.execute(f"SELECT {recalc_cols} FROM photos WHERE category = ?", (category_filter,))
+                row_count = conn.execute(
+                    "SELECT COUNT(*) FROM photos WHERE category = ?", (category_filter,)
+                ).fetchone()[0]
+                cursor = conn.execute(f"SELECT {cols_sql} FROM photos WHERE category = ?", (category_filter,))
             else:
-                cursor = conn.execute(f"SELECT {recalc_cols} FROM photos")
-            rows = cursor.fetchall()
-            row_count = len(rows)
+                row_count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+                cursor = conn.execute(f"SELECT {cols_sql} FROM photos")
 
             # Loaded once up front (not columns in recalc_cols — they live in
             # photo_scoring_overrides) so a rescore preserves any sticky
             # per-photo context/override instead of silently dropping it.
             overrides = get_photo_scoring_overrides(conn)
 
+            # Stream the read cursor and buffer only the small UPDATE tuples: the
+            # photos.category index makes updating rows still being scanned a
+            # Halloween-problem hazard, so every write lands after the cursor is
+            # fully drained. Streaming also keeps the histogram BLOBs transient
+            # instead of materialising the whole table in RAM.
+            def _stream_rows():
+                while True:
+                    fetched = cursor.fetchmany(1000)
+                    if not fetched:
+                        return
+                    yield from fetched
+
+            updates = []
             emit_progress('recompute', 0, row_count, force=True)
             recompute_t0 = time.time()
-            for i, row in enumerate(tqdm(rows, desc="Updating DB")):
+            for i, row in enumerate(tqdm(_stream_rows(), total=row_count, desc="Updating DB")):
                 row_dict = dict(row)
                 photo_override = overrides.get(row_dict['path'], {})
                 row_dict['scoring_context'] = photo_override.get('scoring_context')
@@ -1521,30 +1628,38 @@ class Facet:
                 categories_updated += 1
 
                 new_exposure = round(row_dict.get('exposure_score', 5.0), 4)
-                try:
-                    conn.execute(
-                        "UPDATE photos SET aggregate = ?, config_version = ?, category = ?, is_group_portrait = ?, exposure_score = ? WHERE path = ?",
-                        (round(new_score, 2), self.config.version_hash, category, new_is_group, new_exposure, row_dict['path'])
-                    )
-                except sqlite3.DatabaseError as e:
-                    # Updating `category` fires the photos_fts_au trigger; a
-                    # corrupt FTS5 index surfaces here as "database disk image
-                    # is malformed" even though PRAGMA integrity_check passes
-                    # (it doesn't validate FTS shadow tables). Point at the fix
-                    # instead of crashing with a misleading disk-image error.
-                    if 'malformed' in str(e).lower():
-                        raise RuntimeError(
-                            "Aggregate update failed with 'database disk image is malformed'. "
-                            "This is almost always a corrupt FTS5 search index (the photos_fts "
-                            "trigger fires on category changes), not actual data corruption. "
-                            "Run 'python database.py --rebuild-fts' and retry --recompute-average."
-                        ) from e
-                    raise
+                updates.append(
+                    (round(new_score, 2), self.config.version_hash, category,
+                     new_is_group, new_exposure, row_dict['path'])
+                )
 
                 processed = i + 1
                 elapsed = time.time() - recompute_t0
                 emit_progress('recompute', processed, row_count,
                               eta_seconds=(row_count - processed) * elapsed / processed)
+
+            # Apply every buffered update now that the read cursor is drained, so
+            # an in-flight category UPDATE never perturbs the scan (Halloween
+            # problem) and the whole rescore commits in one transaction.
+            try:
+                conn.executemany(
+                    "UPDATE photos SET aggregate = ?, config_version = ?, category = ?, is_group_portrait = ?, exposure_score = ? WHERE path = ?",
+                    updates,
+                )
+            except sqlite3.DatabaseError as e:
+                # Updating `category` fires the photos_fts_au trigger; a corrupt
+                # FTS5 index surfaces here as "database disk image is malformed"
+                # even though PRAGMA integrity_check passes (it doesn't validate
+                # FTS shadow tables). Point at the fix instead of crashing with a
+                # misleading disk-image error.
+                if 'malformed' in str(e).lower():
+                    raise RuntimeError(
+                        "Aggregate update failed with 'database disk image is malformed'. "
+                        "This is almost always a corrupt FTS5 search index (the photos_fts "
+                        "trigger fires on category changes), not actual data corruption. "
+                        "Run 'python database.py --rebuild-fts' and retry --recompute-average."
+                    ) from e
+                raise
 
             conn.commit()
 
@@ -1626,20 +1741,23 @@ class Facet:
         logger.info("Run --recompute-average to update aggregate scores with new comp_score values")
 
     @staticmethod
-    def _foreach_face_landmark(db_path, select_cols, desc, compute):
+    def _foreach_face_landmark(db_path, select_cols, desc, compute, where_extra=""):
         """Shared scaffold for the landmark-only face recompute passes.
 
         Selects ``select_cols`` from every face with a stored 106-pt landmark
-        blob, decodes each to a (106, 2) float32 array (undecodable blobs are
-        skipped and counted), and calls ``compute(row, landmarks)`` per face.
-        Returns ``(results, total_faces, no_landmark_count, decode_errors)``.
+        blob (optionally narrowed by ``where_extra``, an extra SQL fragment
+        appended to the WHERE clause), decodes each to a (106, 2) float32 array
+        (undecodable blobs are skipped and counted), and calls
+        ``compute(row, landmarks)`` per face. Returns
+        ``(results, total_faces, no_landmark_count, decode_errors)``.
         """
         import numpy as np
         from tqdm import tqdm
 
         with get_connection(db_path) as conn:
             rows = conn.execute(
-                f"SELECT {select_cols} FROM faces WHERE landmark_2d_106 IS NOT NULL"
+                f"SELECT {select_cols} FROM faces "
+                f"WHERE landmark_2d_106 IS NOT NULL{where_extra}"
             ).fetchall()
             no_landmark_count = conn.execute(
                 "SELECT COUNT(*) FROM faces WHERE landmark_2d_106 IS NULL"
@@ -1760,7 +1878,7 @@ class Facet:
         logger.info("Finished. Updated %s photos with eyes/expression scores.", len(update_data))
         return len(update_data)
 
-    def recompute_face_signals(self):
+    def recompute_face_signals(self, force=False):
         """Backfill per-face eyes-open and smile scores from stored 106-pt landmarks.
 
         Mirrors :meth:`recompute_eyes_expression` but writes the per-face
@@ -1768,6 +1886,13 @@ class Facet:
         source for the culling face panel) instead of the photo-level
         aggregates. No InsightFace re-run — pure geometry on stored landmarks,
         so no pixels are needed.
+
+        By default this is a *backfill*: only faces still missing a signal
+        (``eyes_open_score IS NULL OR smile_score IS NULL``) are recomputed, so a
+        richer MediaPipe blendshape value already stored for a face is never
+        overwritten by the cruder landmark-geometry estimate — and a turned head,
+        where the geometry gate returns NULL, is not blanked. Pass ``force=True``
+        to rewrite every face with a landmark from geometry.
         """
         from analyzers import FaceAnalyzer as _FaceAnalyzer
 
@@ -1776,9 +1901,10 @@ class Facet:
                     _FaceAnalyzer.compute_smile_score(landmarks),
                     row['id'])
 
+        where_extra = "" if force else " AND (eyes_open_score IS NULL OR smile_score IS NULL)"
         update_data, total, no_landmark_count, decode_errors = Facet._foreach_face_landmark(
             self.db_path, "id, landmark_2d_106",
-            "Per-face signals from landmarks", _compute)
+            "Per-face signals from landmarks", _compute, where_extra=where_extra)
 
         if not total:
             logger.info("No faces with stored landmarks — nothing to compute.")
@@ -2201,78 +2327,6 @@ class Facet:
         except Exception as e:
             logger.warning("EXIF extraction failed for %s: %s", image_path, e)
         return _sanitize_exif_numeric(exif_data)
-
-    def save_photo(self, res, pil_img):
-        """Generates a thumbnail and saves the full result to SQLite."""
-        res['thumbnail'] = generate_photo_thumbnail(pil_img)
-
-        # Form facet columns default to NULL for callers that did not compute
-        # them (named-param INSERT needs every key).
-        from analyzers.form_facet import FORM_METRIC_COLUMNS
-        for form_col in FORM_METRIC_COLUMNS:
-            res.setdefault(form_col, None)
-
-        with get_connection(self.db_path, row_factory=False) as conn:
-            conn.execute(_photos_upsert('''
-                INSERT OR REPLACE INTO photos (
-                    path, filename, category, image_width, image_height,
-                    date_taken, camera_model, lens_model, iso, f_stop,
-                    shutter_speed, focal_length, focal_length_35mm, aesthetic, face_count, face_quality,
-                    eye_sharpness, face_sharpness, face_ratio, tech_sharpness, color_score,
-                    exposure_score, comp_score, isolation_bonus, is_blink, phash, aggregate, thumbnail,
-                    clip_embedding, raw_sharpness_variance, histogram_data, histogram_spread,
-                    mean_luminance, histogram_bimodality, power_point_score, raw_color_entropy,
-                    raw_eye_sharpness, config_version,
-                    shadow_clipped, highlight_clipped, is_silhouette, is_group_portrait, leading_lines_score,
-                    face_confidence, is_monochrome, mean_saturation,
-                    dynamic_range_stops, noise_sigma, contrast_score, tags,
-                    quality_score, composition_explanation, scoring_model, composition_pattern,
-                    form_symmetry, form_balance, form_edge_entropy, form_fractal, color_harmony,
-                    gps_latitude, gps_longitude, scanned_at
-                )
-                VALUES (
-                    :path, :filename, :category, :image_width, :image_height,
-                    :date_taken, :camera_model, :lens_model, :iso, :f_stop,
-                    :shutter_speed, :focal_length, :focal_length_35mm, :aesthetic, :face_count, :face_quality,
-                    :eye_sharpness, :face_sharpness, :face_ratio, :tech_sharpness, :color_score,
-                    :exposure_score, :comp_score, :isolation_bonus, :is_blink, :phash, :aggregate, :thumbnail,
-                    :clip_embedding, :raw_sharpness_variance, :histogram_data, :histogram_spread,
-                    :mean_luminance, :histogram_bimodality, :power_point_score, :raw_color_entropy,
-                    :raw_eye_sharpness, :config_version,
-                    :shadow_clipped, :highlight_clipped, :is_silhouette, :is_group_portrait, :leading_lines_score,
-                    :face_confidence, :is_monochrome, :mean_saturation,
-                    :dynamic_range_stops, :noise_sigma, :contrast_score, :tags,
-                    :quality_score, :composition_explanation, :scoring_model, :composition_pattern,
-                    :form_symmetry, :form_balance, :form_edge_entropy, :form_fractal, :color_harmony,
-                    :gps_latitude, :gps_longitude, datetime('now')
-                )
-            '''), res)
-
-            # Refresh this photo's faces (the UPSERT above no longer cascade-deletes
-            # them), then re-store embeddings, landmarks, thumbnails and per-face
-            # quality signals for recognition + culling.
-            conn.execute("DELETE FROM faces WHERE photo_path = ?", (res['path'],))
-            face_details = res.get('face_details', [])
-            for face in face_details:
-                if face.get('embedding'):
-                    conn.execute(FACES_UPSERT_SQL, face_upsert_row(res['path'], face))
-
-        # Emit plugin events
-        from plugins import get_plugin_manager
-        pm = get_plugin_manager()
-        if pm:
-            event_data = {
-                'path': res.get('path'),
-                'filename': res.get('filename'),
-                'aggregate': res.get('aggregate', 0),
-                'aesthetic': res.get('aesthetic', 0),
-                'comp_score': res.get('comp_score', 0),
-                'category': res.get('category', ''),
-                'tags': res.get('tags', ''),
-            }
-            pm.emit('on_score_complete', event_data)
-            if (res.get('aggregate') or 0) >= pm.high_score_threshold:
-                pm.emit('on_high_score', event_data)
 
     def save_photos_batch(self, results_with_images):
         """

--- a/processing/xmp_export.py
+++ b/processing/xmp_export.py
@@ -448,13 +448,13 @@ def _exiftool_tag_args(rating: XmpRating, existing_flat: list[str],
     target's existing keywords and Facet's own — foreign keywords authored by
     Lightroom / darktable / etc. are preserved, never wiped, and re-running never
     accumulates duplicates. Face regions stay clear-then-replace (Facet owns face
-    detection). Scalars (label, caption) are set only when present, so an external
-    value is not wiped when Facet has none.
+    detection). ``xmp:Label`` is fully Facet-owned (favourite/reject only), so it is
+    always emitted like ``xmp:Rating`` -- an empty value clears the exiftool tag,
+    which is what un-favouriting must do. Caption is set only when present, so an
+    external value is not wiped when Facet has none.
     """
     xmp_rating, label = rating.xmp_values()
-    args = [f"-XMP:Rating={xmp_rating}"]
-    if label:
-        args.append(f"-XMP:Label={label}")
+    args = [f"-XMP:Rating={xmp_rating}", f"-XMP:Label={label}"]
     if rating.caption:
         args.append(f"-XMP-dc:Description={rating.caption}")
         args.append(f"-IPTC:Caption-Abstract={rating.caption}")

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -40,7 +40,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -112,7 +116,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.5,
@@ -177,7 +185,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.1,
@@ -235,14 +247,20 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {
         "street": [
           "street",
           "urban",
-          "city life"
+          "city life",
+          "street scene",
+          "city street"
         ],
         "candid": [
           "candid",
@@ -302,7 +320,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -342,7 +364,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -384,7 +410,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.419,
@@ -428,7 +458,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.901,
@@ -468,7 +502,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.3
@@ -515,7 +553,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.171,
@@ -611,7 +653,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -661,7 +707,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.328,
@@ -790,7 +840,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.417,
@@ -844,7 +898,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.93,
@@ -955,7 +1013,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -1007,7 +1069,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -1057,7 +1123,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.512,
@@ -1114,7 +1184,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "tags": {
         "architecture": [
@@ -1208,7 +1282,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.922,
@@ -1216,10 +1294,6 @@
         "_clipping_multiplier": 0.501
       },
       "tags": {
-        "street": [
-          "street scene",
-          "city street"
-        ],
         "city": [
           "city",
           "cityscape",
@@ -1258,7 +1332,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {}
@@ -1296,7 +1374,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1346,7 +1428,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.3,
@@ -1400,7 +1486,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.72,
@@ -1454,7 +1544,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 1.5,
@@ -1524,7 +1618,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1571,7 +1669,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1618,7 +1720,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.216,
@@ -1670,7 +1776,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -1753,7 +1863,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.463,
@@ -1866,7 +1980,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {},
       "tags": {}
@@ -1906,7 +2024,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.3
@@ -1947,7 +2069,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1988,7 +2114,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {}
     },
@@ -2027,7 +2157,11 @@
         "balance_percent": 0,
         "edge_entropy_percent": 0,
         "fractal_percent": 0,
-        "color_harmony_percent": 0
+        "color_harmony_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0
       },
       "modifiers": {}
     }

--- a/sync/immich.py
+++ b/sync/immich.py
@@ -3,9 +3,15 @@
 Facet photo paths are mapped to Immich ``originalPath`` values through the
 configured ``immich.path_map`` prefix pairs, resolved to asset ids with
 ``POST /api/search/metadata``, and updated with batched ``PUT /api/assets``
-calls grouped by identical payload. Only ratings 1-5 are ever pushed (never 0,
-never -1); an optional single top-picks album is filled from a minimum-rating
-threshold. Immich's database is never touched — REST only.
+calls grouped by identical payload. A never-rated, never-favorited photo never
+pushes ``rating: 0`` (that would be noise on the vast majority of the library);
+but a photo that WAS pushed as rated/favorite and is later reset to 0/false
+must still reach Immich as an explicit clear, or the stale value is stuck
+there forever. ``stats_cache`` (a generic key/value side table, keyed per
+sync scope) remembers which paths were last pushed active so that transition
+is detected — see ``_fetch_rating_rows`` and ``_load_synced_state``. An
+optional single top-picks album is filled from a minimum-rating threshold.
+Immich's database is never touched — REST only.
 
 Expected ``scoring_config.json`` section::
 
@@ -29,6 +35,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import urlparse
@@ -156,13 +163,49 @@ def map_facet_path(path: str, path_map: list[dict]) -> str | None:
     return None
 
 
-def _fetch_rating_rows(conn, user_id: str | None) -> list:
-    """Read only paths that can push a rating 1-5 or ``isFavorite=true``.
+def _scope_key(scope: str | None) -> str:
+    """stats_cache key for the per-scope "paths last pushed active" state."""
+    return f"immich_synced_paths:{scope or 'global'}"
+
+
+def _load_synced_state(conn, scope: str | None) -> dict:
+    """Paths whose rating and/or favorite were ACTIVE as of the last successful push.
+
+    ``{path: {"rating": bool, "favorite": bool}}``, persisted in ``stats_cache``
+    (a generic key/value side table — no schema change needed). This is what
+    lets a photo that gets reset to 0/false be recognised as needing an
+    explicit clear even though it no longer matches the "currently active"
+    half of the ``_fetch_rating_rows`` WHERE clause.
+    """
+    row = conn.execute(
+        "SELECT value FROM stats_cache WHERE key = ?", (_scope_key(scope),)
+    ).fetchone()
+    if not row or not row[0]:
+        return {}
+    try:
+        return json.loads(row[0])
+    except (TypeError, ValueError):
+        return {}
+
+
+def _save_synced_state(conn, scope: str | None, state: dict) -> None:
+    conn.execute(
+        "INSERT INTO stats_cache (key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+        (_scope_key(scope), json.dumps(state), time.time()),
+    )
+    conn.commit()
+
+
+def _fetch_rating_rows(conn, user_id: str | None, extra_paths=()) -> list:
+    """Read paths that can push a rating 1-5 / ``isFavorite=true``, plus any
+    path in *extra_paths* whose rating/favorite may have just been reset.
 
     Mirrors the xmp_export overlay: when *user_id* is given the per-user
     ``user_preferences`` overlay replaces the global rating columns (COALESCE-d
-    to 0), same as ``export_sidecars``. Pure-rejected rows (no rating, not a
-    favorite) are excluded — they can never push anything.
+    to 0), same as ``export_sidecars``. A row that is neither currently active
+    nor in *extra_paths* is excluded — it can never push anything (a
+    never-touched photo has no clear to push either).
     """
     if user_id:
         join = ("LEFT JOIN user_preferences up ON up.photo_path = photos.path "
@@ -174,10 +217,15 @@ def _fetch_rating_rows(conn, user_id: str | None) -> list:
         join = ""
         star_expr, fav_expr = "star_rating", "is_favorite"
         params = []
+    where = f"({star_expr} BETWEEN 1 AND 5) OR {fav_expr} = 1"
+    extra_paths = list(extra_paths)
+    if extra_paths:
+        where += f" OR photos.path IN ({','.join('?' * len(extra_paths))})"
+        params = params + extra_paths
     return conn.execute(
         f"SELECT photos.path AS path, {star_expr} AS star_rating, "
         f"{fav_expr} AS is_favorite FROM photos {join} "
-        f"WHERE ({star_expr} BETWEEN 1 AND 5) OR {fav_expr} = 1",
+        f"WHERE {where}",
         params,
     ).fetchall()
 
@@ -205,34 +253,43 @@ def sync_to_immich(db_path, config: dict, user_id: str | None = None,
     album_min_rating = push_cfg.get("top_picks_min_rating", 4)
     path_map = immich_cfg.get("path_map", [])
     multi_user = any(k != "shared_directories" for k in config.get("users", {}))
+    scope = user_id if multi_user else None
     with get_connection(db_path) as conn:
-        rows = _fetch_rating_rows(conn, user_id if multi_user else None)
+        synced_state = _load_synced_state(conn, scope)
+        rows = _fetch_rating_rows(conn, scope, extra_paths=synced_state.keys())
     summary = {"matched": 0, "unmatched": 0, "updated": 0,
                "skipped_unrated": 0, "albums_created": 0}
     groups: dict[tuple, list[str]] = {}
     album_asset_ids: list[str] = []
     unmatched_paths: list[str] = []
+    matched_paths: set[str] = set()
 
     # First pass (no network): compute each row's push payload and target path.
+    # A row previously pushed active (tracked in synced_state) that has since
+    # gone inactive still gets an explicit clear — 0 / false — even though a
+    # never-touched row never pushes a bare 0/false. That is the ONLY reason a
+    # 0 rating or false favorite is ever added to fields below.
     resolvable: list[tuple] = []
     for row in rows:
+        facet_path = row["path"]
+        prev = synced_state.get(facet_path, {})
         rating = _effective_rating(row["star_rating"])
         favorite = bool(row["is_favorite"])
         fields: dict = {}
-        if push_ratings and rating is not None:
-            fields["rating"] = rating
-        if push_favorites and (favorite or fields):
+        if push_ratings and (rating is not None or prev.get("rating")):
+            fields["rating"] = rating if rating is not None else 0
+        if push_favorites and (favorite or fields or prev.get("favorite")):
             fields["isFavorite"] = favorite
         if not fields:
             summary["skipped_unrated"] += 1
             continue
         resolvable.append(
-            (row["path"], map_facet_path(row["path"], path_map), fields, rating))
+            (facet_path, map_facet_path(facet_path, path_map), fields, rating, favorite))
 
     try:
         # One bulk pass builds a local path index; misses fall back to per-path.
         path_index = dict(client.iter_asset_paths()) if resolvable else {}
-        for facet_path, immich_path, fields, rating in resolvable:
+        for facet_path, immich_path, fields, rating, favorite in resolvable:
             asset_id = None
             if immich_path:
                 asset_id = path_index.get(immich_path) or client.search_asset_id(immich_path)
@@ -241,6 +298,7 @@ def sync_to_immich(db_path, config: dict, user_id: str | None = None,
                 unmatched_paths.append(facet_path)
                 continue
             summary["matched"] += 1
+            matched_paths.add(facet_path)
             groups.setdefault(tuple(sorted(fields.items())), []).append(asset_id)
             if rating is not None and rating >= album_min_rating:
                 album_asset_ids.append(asset_id)
@@ -255,6 +313,26 @@ def sync_to_immich(db_path, config: dict, user_id: str | None = None,
             else:
                 client.create_album(album_name, album_asset_ids)
                 summary["albums_created"] = 1
+        if not dry_run:
+            # Only rows actually confirmed pushed (matched_paths) advance the
+            # tracked state; an unmatched row keeps its prior entry so the next
+            # sync retries it instead of losing the clear. Derived from the
+            # ACTUAL fields sent (not the raw DB rating/favorite) so a field
+            # disabled via push_ratings/push_favorites is never tracked as if
+            # it had been pushed.
+            new_state = dict(synced_state)
+            for facet_path, _, fields, _, _ in resolvable:
+                if facet_path not in matched_paths:
+                    continue
+                active = {"rating": bool(fields.get("rating")),
+                         "favorite": fields.get("isFavorite") is True}
+                if active["rating"] or active["favorite"]:
+                    new_state[facet_path] = active
+                else:
+                    new_state.pop(facet_path, None)
+            if new_state != synced_state:
+                with get_connection(db_path) as write_conn:
+                    _save_synced_state(write_conn, scope, new_state)
     except (urllib_error.URLError, TimeoutError) as e:
         e.partial_summary = dict(summary)
         raise

--- a/tests/test_a1_core_fixes.py
+++ b/tests/test_a1_core_fixes.py
@@ -1,0 +1,198 @@
+"""Regression tests for the A1 core-scoring fixes.
+
+Covers:
+- build_scoring_metrics: the single shared metric-dict builder must carry the
+  keys the single-pass paths used to drop (tags, is_monochrome, mean_luminance,
+  is_group_portrait, face_sharpness, power_point_score, contrast_score,
+  noise_sigma, mean_saturation), so the batch / PIL / multi-pass paths feed
+  calculate_aggregate_logic an identical feature space.
+- recompute_face_signals: default is a backfill scoped to faces still missing a
+  signal (so stored MediaPipe blendshapes survive); force=True rewrites all.
+
+Uses only scratch state / tmp_path — never touches photo_scores_pro.db.
+"""
+
+import sqlite3
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from analyzers.face import FaceAnalyzer
+from db.schema import FACES_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# build_scoring_metrics
+# ---------------------------------------------------------------------------
+
+# The nine keys the single-pass batch/PIL paths silently dropped before the fix.
+_PREVIOUSLY_DROPPED = (
+    'tags', 'is_monochrome', 'mean_luminance', 'is_group_portrait',
+    'face_sharpness', 'power_point_score', 'contrast_score',
+    'noise_sigma', 'mean_saturation',
+)
+
+
+def _call_builder(**overrides):
+    from processing.scorer import build_scoring_metrics
+
+    kwargs = dict(
+        aesthetic=7.0,
+        face_count=5, face_quality=6.0, eye_sharpness=6.0, face_sharpness=6.5,
+        face_ratio=0.3, is_group_portrait=1, is_blink=0, isolation_bonus=1.2,
+        sharpness_data={'normalized': 7.1},
+        color_data={'normalized': 7.2},
+        histogram_data={'exposure_score': 7.3, 'spread': 12.0, 'bimodality': 1.0,
+                        'mean_luminance': 0.42, 'shadow_clipped': 0, 'highlight_clipped': 0},
+        mono_data={'is_monochrome': 1, 'mean_saturation': 0.9},
+        noise_data={'noise_sigma': 4.4},
+        contrast_data={'contrast_score': 5.5},
+        comp_score=6.6, power_point_score=6.7, leading_lines_score=3.0,
+        is_silhouette=0, tags='landscape, mountain',
+        iso=800, f_stop=2.8,
+    )
+    kwargs.update(overrides)
+    return build_scoring_metrics(**kwargs)
+
+
+def test_builder_carries_previously_dropped_keys():
+    m = _call_builder()
+    for key in _PREVIOUSLY_DROPPED:
+        assert key in m, f"builder dropped {key}"
+    assert m['tags'] == 'landscape, mountain'
+    assert m['is_monochrome'] == 1
+    assert m['mean_luminance'] == pytest.approx(0.42)
+    assert m['is_group_portrait'] == 1
+    assert m['face_sharpness'] == pytest.approx(6.5)
+    assert m['power_point_score'] == pytest.approx(6.7)
+    assert m['contrast_score'] == pytest.approx(5.5)
+    assert m['noise_sigma'] == pytest.approx(4.4)
+    assert m['mean_saturation'] == pytest.approx(0.9)
+
+
+def test_builder_key_set_matches_the_multipass_feature_space():
+    """The builder is the single source of truth: the exact key set the
+    multi-pass path historically produced must all be present."""
+    expected = {
+        'aesthetic', 'quality_score', 'scoring_model', 'comp_score', 'face_count',
+        'face_quality', 'eye_sharpness', 'face_sharpness', 'tech_sharpness',
+        'color_score', 'exposure_score', 'face_ratio', 'tags', 'isolation_bonus',
+        'is_blink', 'is_group_portrait', 'shadow_clipped', 'highlight_clipped',
+        'is_silhouette', 'histogram_spread', 'histogram_bimodality', 'mean_luminance',
+        'is_monochrome', 'mean_saturation', 'contrast_score', 'noise_sigma',
+        'leading_lines_score', 'power_point_score', 'topiq_score', 'aesthetic_iaa',
+        'face_quality_iqa', 'liqe_score', 'qalign_score', 'aesthetic_v25', 'deqa_score',
+        'subject_sharpness', 'subject_prominence', 'subject_placement', 'bg_separation',
+        'form_symmetry', 'form_balance', 'form_edge_entropy', 'form_fractal',
+        'color_harmony', 'iso', 'f_stop', 'shutter_speed',
+        'scoring_context', 'category_override',
+    }
+    assert set(_call_builder().keys()) == expected
+
+
+def test_builder_defaults_missing_subdict_entries_like_multipass():
+    """A partially populated sub-dict degrades to the multi-pass defaults, not a
+    KeyError — matching the .get(..., default) behaviour the multi-pass path used."""
+    m = _call_builder(
+        sharpness_data={}, color_data={}, histogram_data={}, mono_data={},
+        noise_data={}, contrast_data={},
+    )
+    assert m['tech_sharpness'] == 5.0
+    assert m['color_score'] == 5.0
+    assert m['exposure_score'] == 5.0
+    assert m['mean_luminance'] == 0.5
+    assert m['noise_sigma'] == 0
+    assert m['contrast_score'] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# recompute_face_signals scoping
+# ---------------------------------------------------------------------------
+
+def _make_landmarks():
+    """Valid, front-facing 106-pt landmarks that pass the geometry pose gates."""
+    lm = np.zeros((106, 2), dtype=np.float32)
+
+    def eye(indices, cx, width=12.0, open_px=6.0):
+        half = width / 2.0
+        lm[indices[0]] = (cx - half, 40.0)
+        lm[indices[1]] = (cx + half, 40.0)
+        lm[indices[2]] = (cx - 2.0, 40.0 - open_px / 2.0)
+        lm[indices[3]] = (cx + 2.0, 40.0 - open_px / 2.0)
+        lm[indices[4]] = (cx - 2.0, 40.0 + open_px / 2.0)
+        lm[indices[5]] = (cx + 2.0, 40.0 + open_px / 2.0)
+
+    eye(FaceAnalyzer.LEFT_EYE_INDICES, 30.0)
+    eye(FaceAnalyzer.RIGHT_EYE_INDICES, 70.0)
+    lm[FaceAnalyzer.MOUTH_CORNER_LEFT] = (35.0, 70.0 - 4.0)
+    lm[FaceAnalyzer.MOUTH_CORNER_RIGHT] = (65.0, 70.0 - 4.0)
+    others = [i for i in FaceAnalyzer.MOUTH_INDICES
+              if i not in (FaceAnalyzer.MOUTH_CORNER_LEFT, FaceAnalyzer.MOUTH_CORNER_RIGHT)]
+    for i, x in zip(others, np.linspace(38.0, 62.0, len(others))):
+        lm[i] = (x, 70.0)
+    return lm
+
+
+def _create_faces_table(conn):
+    cols = ", ".join(f"{name} {type_}" for name, type_ in FACES_COLUMNS)
+    conn.execute(f"CREATE TABLE faces ({cols}, UNIQUE(photo_path, face_index))")
+
+
+def _seed(db_path):
+    """Face 0: already has (sentinel) signals. Face 1: signals NULL. Both have
+    valid landmarks. The sentinel (-1) is outside the geometry range [0, 10] so a
+    rewrite is detectable."""
+    lm = _make_landmarks().tobytes()
+    conn = sqlite3.connect(db_path)
+    _create_faces_table(conn)
+    conn.execute(
+        "INSERT INTO faces (photo_path, face_index, embedding, landmark_2d_106, "
+        "eyes_open_score, smile_score) VALUES (?, ?, ?, ?, ?, ?)",
+        ('/have.jpg', 0, b'e', lm, -1.0, -1.0))
+    conn.execute(
+        "INSERT INTO faces (photo_path, face_index, embedding, landmark_2d_106, "
+        "eyes_open_score, smile_score) VALUES (?, ?, ?, ?, ?, ?)",
+        ('/missing.jpg', 0, b'e', lm, None, None))
+    conn.commit()
+    conn.close()
+
+
+def _read(db_path, photo_path):
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT eyes_open_score, smile_score FROM faces WHERE photo_path = ?",
+        (photo_path,)).fetchone()
+    conn.close()
+    return row
+
+
+def test_default_backfill_preserves_existing_signals(tmp_path):
+    from processing.scorer import Facet
+
+    db_path = str(tmp_path / "signals.db")
+    _seed(db_path)
+
+    updated = Facet.recompute_face_signals(SimpleNamespace(db_path=db_path))
+
+    # Only the face missing a signal is touched; the pre-populated one is left
+    # alone (its stored blendshape-style sentinel survives).
+    assert updated == 1
+    assert _read(db_path, '/have.jpg') == (-1.0, -1.0)
+    eyes, smile = _read(db_path, '/missing.jpg')
+    assert eyes is not None and smile is not None
+
+
+def test_force_rewrites_every_face_from_geometry(tmp_path):
+    from processing.scorer import Facet
+
+    db_path = str(tmp_path / "signals_force.db")
+    _seed(db_path)
+
+    updated = Facet.recompute_face_signals(SimpleNamespace(db_path=db_path), force=True)
+
+    assert updated == 2
+    # The sentinel (-1) is overwritten with an in-range geometry score.
+    eyes, smile = _read(db_path, '/have.jpg')
+    assert eyes != -1.0 and 0.0 <= eyes <= 10.0
+    assert smile != -1.0 and 0.0 <= smile <= 10.0

--- a/tests/test_a2_db_and_comparisons_migration.py
+++ b/tests/test_a2_db_and_comparisons_migration.py
@@ -1,0 +1,339 @@
+"""Regression tests for the A2 database-layer fixes and the A8 comparisons
+user-scoped UNIQUE migration.
+
+Covers:
+  * comparisons UNIQUE(photo_a_path, photo_b_path, user_id) migration — row
+    preservation, constraint present, idempotency (A8#2)
+  * ComparisonManager.submit_comparison per-user upsert (A8#2)
+  * record_culling_pairs NULL-safe dedup under the user-scoped UNIQUE (A8#2)
+  * get_schema_info index count matches the indexes actually created (A2#8)
+  * get_cached_stat keyless error-path return precedence (A2#11)
+  * migrate_tags_to_lookup full resync (DELETE before insert) (A2#1)
+  * photos_vec declared-dim / multi-dim helpers (A2#3)
+  * sequence-override open_connection returns a real connection (A2#7)
+"""
+
+import sqlite3
+
+import pytest
+
+from db.schema import (
+    _build_create_table_sql,
+    COMPARISONS_COLUMNS,
+    init_database,
+)
+
+
+def _seed_old_comparisons_db(tmp_path):
+    """A DB carrying the pre-migration comparisons schema (user-blind UNIQUE)."""
+    db_path = str(tmp_path / "old.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    # Minimal photos table — init_database's additive sweep fills in the rest.
+    conn.execute("CREATE TABLE photos (path TEXT PRIMARY KEY, tags TEXT)")
+    conn.executemany(
+        "INSERT INTO photos (path) VALUES (?)",
+        [(p,) for p in ("/p/a", "/p/b", "/p/c", "/p/d", "/p/e", "/p/f")],
+    )
+    # Old comparisons table: the user-BLIND 2-column UNIQUE.
+    conn.execute(_build_create_table_sql(
+        "comparisons", COMPARISONS_COLUMNS,
+        constraints=["UNIQUE(photo_a_path, photo_b_path)"]))
+    conn.executemany(
+        "INSERT INTO comparisons (photo_a_path, photo_b_path, winner, user_id) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            ("/p/a", "/p/b", "a", "u1"),
+            ("/p/c", "/p/d", "b", None),   # legacy NULL-user row
+            ("/p/e", "/p/f", "tie", "u2"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _comparisons_create_sql(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='comparisons'"
+        ).fetchone()[0]
+
+
+class TestComparisonsUserIdMigration:
+    def test_migration_preserves_rows_and_adds_user_id_constraint(self, tmp_path):
+        db_path = _seed_old_comparisons_db(tmp_path)
+
+        # Sanity: the seeded constraint is user-blind.
+        assert "user_id" not in _comparisons_create_sql(db_path).lower().split(
+            "unique", 1)[1].split(")", 1)[0]
+
+        init_database(db_path)
+
+        # Every seeded row survives, unchanged.
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT photo_a_path, photo_b_path, winner, user_id "
+                "FROM comparisons ORDER BY photo_a_path"
+            ).fetchall()
+        assert rows == [
+            ("/p/a", "/p/b", "a", "u1"),
+            ("/p/c", "/p/d", "b", None),
+            ("/p/e", "/p/f", "tie", "u2"),
+        ]
+
+        # The new constraint scopes by user_id, and no scratch table lingers.
+        create_sql = _comparisons_create_sql(db_path).lower()
+        unique_clause = create_sql.split("unique", 1)[1]
+        assert "user_id" in unique_clause.split(")", 1)[0]
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name='comparisons_new'"
+            ).fetchone()[0] == 0
+
+    def test_new_constraint_allows_second_user_and_blocks_same_user_dup(self, tmp_path):
+        db_path = _seed_old_comparisons_db(tmp_path)
+        init_database(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("PRAGMA foreign_keys=ON")
+            # A second user voting on an already-voted pair is now allowed.
+            conn.execute(
+                "INSERT INTO comparisons (photo_a_path, photo_b_path, winner, user_id) "
+                "VALUES ('/p/a', '/p/b', 'b', 'u2')")
+            conn.commit()
+            assert conn.execute(
+                "SELECT COUNT(*) FROM comparisons "
+                "WHERE photo_a_path='/p/a' AND photo_b_path='/p/b'"
+            ).fetchone()[0] == 2
+
+            # But the SAME (pair, user) still collides on the triple.
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO comparisons (photo_a_path, photo_b_path, winner, user_id) "
+                    "VALUES ('/p/a', '/p/b', 'a', 'u1')")
+
+    def test_migration_is_idempotent(self, tmp_path):
+        db_path = _seed_old_comparisons_db(tmp_path)
+        init_database(db_path)
+        sql_after_first = _comparisons_create_sql(db_path)
+        with sqlite3.connect(db_path) as conn:
+            count_after_first = conn.execute("SELECT COUNT(*) FROM comparisons").fetchone()[0]
+
+        # Second (and third) init must not rebuild or lose rows.
+        init_database(db_path)
+        init_database(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute("SELECT COUNT(*) FROM comparisons").fetchone()[0] == count_after_first
+            assert conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name='comparisons_new'"
+            ).fetchone()[0] == 0
+        assert _comparisons_create_sql(db_path) == sql_after_first
+
+
+class TestSubmitComparisonPerUser:
+    def _fresh_db(self, tmp_path):
+        db_path = str(tmp_path / "fresh.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executemany("INSERT INTO photos (path) VALUES (?)",
+                         [("/p/a",), ("/p/b",)])
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_two_users_do_not_clobber_each_other(self, tmp_path):
+        from comparison.comparison_manager import ComparisonManager
+
+        db_path = self._fresh_db(tmp_path)
+        mgr = ComparisonManager(db_path)
+        assert mgr.submit_comparison("/p/a", "/p/b", "a", user_id="u1")
+        assert mgr.submit_comparison("/p/a", "/p/b", "b", user_id="u2")
+
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT user_id, winner FROM comparisons "
+                "WHERE photo_a_path='/p/a' AND photo_b_path='/p/b' ORDER BY user_id"
+            ).fetchall()
+        assert rows == [("u1", "a"), ("u2", "b")]
+
+    def test_same_user_revote_updates_in_place(self, tmp_path):
+        from comparison.comparison_manager import ComparisonManager
+
+        db_path = self._fresh_db(tmp_path)
+        mgr = ComparisonManager(db_path)
+        mgr.submit_comparison("/p/a", "/p/b", "a", user_id="u1")
+        mgr.submit_comparison("/p/a", "/p/b", "tie", user_id="u1")
+
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT winner FROM comparisons WHERE user_id='u1'").fetchall()
+        assert rows == [("tie",)]
+
+    def test_null_user_revote_updates_in_place(self, tmp_path):
+        from comparison.comparison_manager import ComparisonManager
+
+        db_path = self._fresh_db(tmp_path)
+        mgr = ComparisonManager(db_path)
+        mgr.submit_comparison("/p/a", "/p/b", "a")  # user_id defaults to None
+        mgr.submit_comparison("/p/a", "/p/b", "b")
+
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT winner FROM comparisons WHERE user_id IS NULL").fetchall()
+        assert rows == [("b",)]  # single row, updated — not duplicated
+
+
+class TestRecordCullingPairsNullSafe:
+    def _burst_conn(self, tmp_path):
+        db_path = str(tmp_path / "cull.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executemany(
+            "INSERT INTO photos (path, category, burst_group_id, aggregate) VALUES (?, ?, ?, ?)",
+            [(f"/b/p{i}", "portrait", 1, 7.0 - i) for i in range(4)],
+        )
+        conn.commit()
+        return conn
+
+    def test_repeat_cull_does_not_duplicate_null_user_pairs(self, tmp_path):
+        from comparison.comparison_manager import record_culling_pairs
+
+        conn = self._burst_conn(tmp_path)
+        assert record_culling_pairs(conn, ["/b/p0"], ["/b/p1"], user_id=None) == 1
+        # Re-culling the same pair as the NULL user must be a no-op.
+        assert record_culling_pairs(conn, ["/b/p0"], ["/b/p1"], user_id=None) == 0
+        assert conn.execute("SELECT COUNT(*) FROM comparisons").fetchone()[0] == 1
+        conn.close()
+
+    def test_existing_vote_blocks_culling_pair(self, tmp_path):
+        from comparison.comparison_manager import record_culling_pairs
+
+        conn = self._burst_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO comparisons (photo_a_path, photo_b_path, winner, user_id, source) "
+            "VALUES ('/b/p0', '/b/p1', 'a', NULL, 'vote')")
+        conn.commit()
+        assert record_culling_pairs(conn, ["/b/p0"], ["/b/p1"], user_id=None) == 0
+        row = conn.execute(
+            "SELECT source FROM comparisons WHERE photo_a_path='/b/p0' AND photo_b_path='/b/p1'"
+        ).fetchall()
+        assert row == [("vote",)]  # the explicit vote is untouched
+        conn.close()
+
+
+class TestSchemaInfoIndexCount:
+    def test_reported_index_count_matches_created_indexes(self, tmp_path):
+        from db.info import get_schema_info
+
+        db_path = str(tmp_path / "idx.db")
+        init_database(db_path)
+        with sqlite3.connect(db_path) as conn:
+            created = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='index' AND name LIKE 'idx_%'"
+            ).fetchone()[0]
+        assert get_schema_info()["indexes"] == created
+
+
+class TestCachedStatReturnPrecedence:
+    def test_keyless_error_path_returns_dict_not_tuple(self, tmp_path):
+        from db.stats_cache import get_cached_stat
+
+        db_path = str(tmp_path / "stats.db")
+        init_database(db_path)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DROP TABLE stats_cache")
+            conn.commit()
+
+        # Keyless call on a missing table -> {} (was (None, {}) before the fix).
+        assert get_cached_stat(db_path, key=None) == {}
+        # Keyed call on a missing table -> (None, False).
+        assert get_cached_stat(db_path, key="total_photos") == (None, False)
+
+
+class TestMigrateTagsResync:
+    def test_resync_drops_removed_tags(self, tmp_path):
+        from db.tags import migrate_tags_to_lookup
+
+        db_path = str(tmp_path / "tags.db")
+        init_database(db_path)
+        with sqlite3.connect(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO photos (path, tags) VALUES (?, ?)",
+                [("/p/1", "beach, sunset"), ("/p/2", "beach")],
+            )
+            conn.commit()
+
+        migrate_tags_to_lookup(db_path)
+        with sqlite3.connect(db_path) as conn:
+            tags = set(conn.execute("SELECT photo_path, tag FROM photo_tags").fetchall())
+        assert tags == {("/p/1", "beach"), ("/p/1", "sunset"), ("/p/2", "beach")}
+
+        # Change /p/1's tags, then resync: the removed tags must disappear.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE photos SET tags='mountain' WHERE path='/p/1'")
+            conn.commit()
+        migrate_tags_to_lookup(db_path)
+        with sqlite3.connect(db_path) as conn:
+            tags = set(conn.execute("SELECT photo_path, tag FROM photo_tags").fetchall())
+        assert tags == {("/p/1", "mountain"), ("/p/2", "beach")}
+
+
+class TestVecDimHelpers:
+    def test_declared_dim_parsed_from_create_sql(self, tmp_path):
+        from db.vec import _vec_declared_dim
+
+        db_path = str(tmp_path / "vec.db")
+        conn = sqlite3.connect(db_path)
+        # A plain table named photos_vec whose column type carries the vec0-style
+        # dimension — exercises the parser without needing the sqlite-vec ext.
+        conn.execute("CREATE TABLE photos_vec (path TEXT, embedding float[768])")
+        assert _vec_declared_dim(conn) == 768
+        conn.close()
+
+    def test_distinct_embedding_lengths_detects_multi_dim(self, tmp_path):
+        from db.vec import _distinct_embedding_lengths
+
+        db_path = str(tmp_path / "vec2.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.executemany(
+            "INSERT INTO photos (path, clip_embedding) VALUES (?, ?)",
+            [("/p/1", b"\x00" * (768 * 4)), ("/p/2", b"\x00" * (1152 * 4))],
+        )
+        conn.commit()
+        assert _distinct_embedding_lengths(conn) == 2
+        conn.close()
+
+
+class TestSequenceOverridesOpenConnection:
+    def test_functions_accept_a_path_string(self, tmp_path):
+        from db.sequence_overrides import (
+            get_sequence_overrides,
+            set_sequence_overrides,
+            open_connection,
+        )
+
+        db_path = str(tmp_path / "seq.db")
+        init_database(db_path)
+        with sqlite3.connect(db_path) as conn:
+            conn.executemany("INSERT INTO photos (path) VALUES (?)",
+                             [("/s/1",), ("/s/2",)])
+            conn.commit()
+
+        # Passing a path (not a live connection) used to raise AttributeError
+        # because _connection_for returned the context-manager object.
+        assert set_sequence_overrides(db_path, ["/s/1", "/s/2"], None) == 2
+        result = get_sequence_overrides(db_path)
+        assert set(result) == {"/s/1", "/s/2"}
+
+        # open_connection hands back a real, usable connection.
+        conn = open_connection(db_path)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0] == 2
+        finally:
+            conn.close()

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -203,6 +203,31 @@ class TestSharing:
         assert len(body["share_token"]) > 0
         mock_conn.commit.assert_called_once()
 
+    def test_share_album_reuses_existing_token(self, client):
+        """Without rotate, a re-share returns the album's existing token."""
+        album_row = _make_album_row(id=1, share_token="existing-tok")
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = album_row
+
+        with mock.patch(f"{_ALBUMS_MODULE}.get_db", return_value=nullcontext(mock_conn)):
+            resp = client.post("/api/albums/1/share")
+
+        assert resp.status_code == 200
+        assert resp.json()["share_token"] == "existing-tok"
+
+    def test_share_album_rotate_mints_new_token(self, client):
+        """rotate=true invalidates the old link by minting a fresh token."""
+        album_row = _make_album_row(id=1, share_token="old-tok")
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = album_row
+
+        with mock.patch(f"{_ALBUMS_MODULE}.get_db", return_value=nullcontext(mock_conn)):
+            resp = client.post("/api/albums/1/share", params={"rotate": "true"})
+
+        assert resp.status_code == 200
+        assert resp.json()["share_token"] != "old-tok"
+        assert len(resp.json()["share_token"]) > 0
+
 
     def test_shared_album_invalid_token(self, client):
         """GET /api/shared/album/1 with wrong token returns 403."""

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -4,7 +4,6 @@ match in ``map_disk_path`` (A5#2) and the share-secret bootstrap in
 """
 
 import json
-import os
 from unittest import mock
 
 import pytest
@@ -16,8 +15,13 @@ _MOD = "api.config"
 
 
 def _norm(path):
-    """Compare paths independent of the platform separator map_disk_path applies."""
-    return path.replace(os.sep, "/")
+    """Compare paths independent of the platform separator map_disk_path applies.
+
+    map_disk_path rewrites separators to os.sep, so its output is backslashes on
+    Windows and forward slashes on Linux; canonicalise both to '/' so the
+    expected literals (written with backslashes) match on either platform.
+    """
+    return path.replace("\\", "/")
 
 
 class TestMapDiskPathPrefixBoundary:

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -1,0 +1,111 @@
+"""Unit tests for api/config.py: the ``viewer.path_mapping`` prefix-boundary
+match in ``map_disk_path`` (A5#2) and the share-secret bootstrap in
+``_load_and_ensure_share_secret`` (A6#9).
+"""
+
+import json
+import os
+from unittest import mock
+
+import pytest
+
+import api.config as api_config
+from api.config import map_disk_path
+
+_MOD = "api.config"
+
+
+def _norm(path):
+    """Compare paths independent of the platform separator map_disk_path applies."""
+    return path.replace(os.sep, "/")
+
+
+class TestMapDiskPathPrefixBoundary:
+    """A5#2: a configured prefix must match at a path-separator boundary.
+
+    A bare ``startswith`` let ``/mnt/photos`` also match ``/mnt/photos-backup``,
+    silently rewriting a sibling directory's files onto the mapped target
+    (wrong-file bytes, or a 404). ``api/path_validation.py`` already requires the
+    boundary; ``map_disk_path`` must mirror it on both the raw and
+    backslash-normalized branches.
+    """
+
+    def test_exact_prefix_matches(self):
+        cfg = {"path_mapping": {"/mnt/photos": "/data/photos"}}
+        with mock.patch(f"{_MOD}.VIEWER_CONFIG", cfg):
+            result = map_disk_path("/mnt/photos")
+        assert _norm(result) == "/data/photos"
+
+    def test_prefix_with_separator_maps(self):
+        cfg = {"path_mapping": {"/mnt/photos": "/data/photos"}}
+        with mock.patch(f"{_MOD}.VIEWER_CONFIG", cfg):
+            result = map_disk_path("/mnt/photos/a.jpg")
+        assert _norm(result) == "/data/photos/a.jpg"
+
+    def test_sibling_directory_with_shared_prefix_is_not_matched(self):
+        """/mnt/photos must not match /mnt/photos-backup/a.jpg."""
+        cfg = {"path_mapping": {"/mnt/photos": "/data/photos"}}
+        with mock.patch(f"{_MOD}.VIEWER_CONFIG", cfg):
+            result = map_disk_path("/mnt/photos-backup/a.jpg")
+        # Left unmapped -- no configured prefix actually contains it.
+        assert _norm(result) == "/mnt/photos-backup/a.jpg"
+
+    def test_backslash_prefix_still_maps_with_boundary(self):
+        cfg = {"path_mapping": {r"D:\photos": r"E:\data\photos"}}
+        with mock.patch(f"{_MOD}.VIEWER_CONFIG", cfg):
+            result = map_disk_path(r"D:\photos\a.jpg")
+        assert _norm(result) == _norm(r"E:\data\photos\a.jpg")
+
+    def test_sibling_directory_not_matched_via_backslash_prefix(self):
+        """Same boundary requirement on the normalized (backslash) branch."""
+        cfg = {"path_mapping": {r"D:\photos": r"E:\data\photos"}}
+        with mock.patch(f"{_MOD}.VIEWER_CONFIG", cfg):
+            result = map_disk_path(r"D:\photos-backup\a.jpg")
+        assert _norm(result) == _norm(r"D:\photos-backup\a.jpg")
+
+
+class TestShareSecretBootstrap:
+    """A6#9: the share-secret bootstrap must not hand each ``--workers>1``
+    process a different in-memory-only key.
+
+    A genuinely absent config still needs a secret to boot, so one is
+    generated and persisted to a minimal new file. A config that EXISTS but
+    fails to parse is different -- minting a secret there would silently hide
+    a broken file behind the same per-worker divergence, so that case must
+    fail loudly instead.
+    """
+
+    def test_missing_config_persists_the_generated_secret(self, tmp_path):
+        config_path = tmp_path / "scoring_config.json"
+        assert not config_path.exists()
+
+        with mock.patch.object(api_config, "_CONFIG_PATH", str(config_path)):
+            _, secret1 = api_config._load_and_ensure_share_secret()
+
+            assert config_path.exists(), "a fresh install must persist its secret to disk"
+            on_disk = json.loads(config_path.read_text())
+            assert on_disk["share_secret"] == secret1
+
+            # A second "worker" reading the now-existing file must see the
+            # SAME secret, not mint its own -- that divergence is exactly
+            # what breaks JWT validation under --workers>1.
+            _, secret2 = api_config._load_and_ensure_share_secret()
+
+        assert secret1 == secret2
+        assert not api_config.CONFIG_WRITE_LOCK.locked()
+
+    def test_unparseable_existing_config_refuses_to_mint_a_secret(self, tmp_path):
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text("{not valid json")
+
+        previous_failed = api_config._config_load_failed
+        try:
+            with mock.patch.object(api_config, "_CONFIG_PATH", str(config_path)):
+                with pytest.raises(RuntimeError):
+                    api_config._load_and_ensure_share_secret()
+        finally:
+            api_config._config_load_failed = previous_failed
+
+        # Refusing to mint a secret must not also destroy the broken file.
+        assert config_path.read_text() == "{not valid json"
+        assert not api_config.CONFIG_WRITE_LOCK.locked()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -75,9 +75,37 @@ class TestJWTTokens:
         hole the claims close."""
         payload = decode_access_token(create_access_token({"sub": "alice"}))
         del payload[claim]
-        from api.auth import JWT_ALGORITHM, JWT_SECRET
+        from api.auth import JWT_ALGORITHM
+        from api.config import JWT_SECRET
 
         assert decode_access_token(jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)) is None
+
+    def test_encode_and_decode_pick_up_a_rotated_secret_without_reimport(self):
+        """DEBT A6#8: api.auth used to bind JWT_SECRET at import time, so a
+        rotated api.config.JWT_SECRET (what reload_config() actually mutates)
+        never took effect for this process -- both signing and verification
+        kept using the stale value forever. They must read it through the
+        module fresh on every call, like frame._secret() does."""
+        import api.config as api_config
+
+        original_secret = api_config.JWT_SECRET
+        try:
+            token_under_old_secret = create_access_token({"sub": "u1"})
+            assert decode_access_token(token_under_old_secret) is not None
+
+            api_config.JWT_SECRET = "rotated-secret-does-not-match-original"
+
+            # A token signed before rotation must fail verification now...
+            assert decode_access_token(token_under_old_secret) is None
+
+            # ...and a token minted after rotation must both sign AND verify
+            # under the new secret.
+            token_under_new_secret = create_access_token({"sub": "u1"})
+            payload = decode_access_token(token_under_new_secret)
+            assert payload is not None
+            assert payload["sub"] == "u1"
+        finally:
+            api_config.JWT_SECRET = original_secret
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -166,11 +166,18 @@ def test_worker_failure_releases_lock(db_path):
 
     with mock.patch("optimization.personal_ranker.train_ranker", side_effect=boom):
         assert ar.maybe_retrain(db_path, user_id=None, added=30, threshold=25) is True
+        # Joining inside the patch: the worker resolves train_ranker when it
+        # runs, so a join outside races the patch teardown and can exercise the
+        # real trainer instead.
+        for t in list(ar._active_threads):
+            t.join(timeout=5)
 
-    for t in list(ar._active_threads):
-        t.join(timeout=5)
     # A failing worker must still release the lock so future retrains can run.
     assert ar._retrain_running is False
+    # Regression: an exception inside the worker (as opposed to a deferral)
+    # must also hand the consumed counter back, or the whole batch of pending
+    # comparisons is silently discarded by one flaky training run.
+    assert _counter(db_path, None) == 30
 
 
 def test_commit_failure_after_claim_releases_slot(db_path, monkeypatch):

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,6 +1,17 @@
-import numpy as np
+import json
+import sqlite3
 
-from calibrate import METRIC_COLUMNS, build_metric_matrix
+import numpy as np
+import pytest
+
+from calibrate import (
+    METRIC_COLUMNS,
+    build_metric_matrix,
+    load_current_category_weights,
+    log_run_to_db,
+    optimize_weights,
+)
+from db.schema import init_database
 
 
 def test_build_metric_matrix_preserves_genuine_zero_scores():
@@ -12,3 +23,108 @@ def test_build_metric_matrix_preserves_genuine_zero_scores():
     assert col in col_names
     idx = col_names.index(col)
     assert np.all(X[:, idx] == 0.0)
+
+
+class TestLoadCurrentCategoryWeights:
+    """Regression: the calibration baseline must be the live config weights,
+    not a uniform strawman -- otherwise "before" SRCC and the persisted
+    old_weights both compare against a vector nobody actually runs.
+    """
+
+    def _write_config(self, tmp_path, weights):
+        cfg = tmp_path / "scoring_config.json"
+        cfg.write_text(json.dumps({"categories": [{"name": "portrait", "weights": weights}]}))
+        return str(cfg)
+
+    def test_reads_and_normalizes_live_percent_weights(self, tmp_path):
+        cfg_path = self._write_config(
+            tmp_path, {"aesthetic_percent": 60, "composition_percent": 40},
+        )
+        w = load_current_category_weights(cfg_path, "portrait", ["aesthetic", "comp_score"])
+        assert w == pytest.approx([0.6, 0.4])
+
+    def test_unknown_category_falls_back_to_uniform(self, tmp_path):
+        cfg_path = self._write_config(tmp_path, {"aesthetic_percent": 60})
+        w = load_current_category_weights(cfg_path, "nonexistent", ["aesthetic", "comp_score"])
+        assert w == pytest.approx([0.5, 0.5])
+
+    def test_missing_config_file_falls_back_to_uniform(self, tmp_path):
+        w = load_current_category_weights(
+            str(tmp_path / "does_not_exist.json"), "portrait", ["aesthetic", "comp_score"],
+        )
+        assert w == pytest.approx([0.5, 0.5])
+
+    def test_missing_metric_weight_defaults_to_zero_before_normalizing(self, tmp_path):
+        # Only 'aesthetic' is configured; 'comp_score' -> composition_percent
+        # is absent, so it contributes 0 rather than crashing.
+        cfg_path = self._write_config(tmp_path, {"aesthetic_percent": 30})
+        w = load_current_category_weights(cfg_path, "portrait", ["aesthetic", "comp_score"])
+        assert w == pytest.approx([1.0, 0.0])
+
+
+class TestOptimizeWeightsBaselineIsLiveConfig:
+    def test_w_before_matches_config_not_uniform(self, tmp_path):
+        cfg_path = tmp_path / "scoring_config.json"
+        cfg_path.write_text(json.dumps({
+            "categories": [{"name": "portrait",
+                           "weights": {"aesthetic_percent": 70, "composition_percent": 30}}],
+        }))
+        rng = np.random.default_rng(0)
+        rows = [
+            {"aesthetic": float(rng.uniform(1, 9)), "comp_score": float(rng.uniform(1, 9)),
+             "mos": float(rng.uniform(1, 9))}
+            for _ in range(15)
+        ]
+
+        info, _ = optimize_weights(rows, "portrait", method="nelder-mead", config_path=str(cfg_path))
+
+        assert set(info["col_names"]) == {"aesthetic", "comp_score"}
+        idx = {c: i for i, c in enumerate(info["col_names"])}
+        # Must reflect the configured 70/30 split, not a uniform 50/50 strawman.
+        assert info["w_before"][idx["aesthetic"]] == pytest.approx(0.7)
+        assert info["w_before"][idx["comp_score"]] == pytest.approx(0.3)
+
+
+class TestLogRunToDbUsesRealBaseline:
+    def test_uses_current_config_weights_when_given(self, tmp_path):
+        db_path = str(tmp_path / "t.db")
+        init_database(db_path)
+        info = {
+            "category": "portrait", "n_photos": 20,
+            "srcc_before": 0.5, "srcc_after": 0.6,
+            "col_names": ["aesthetic", "comp_score"],
+            "w_before": [0.5, 0.5],  # deliberately different from the real config dict
+            "w_after": [0.8, 0.2],
+        }
+        real_config_weights = {"aesthetic": 0.7, "comp_score": 0.3}
+
+        log_run_to_db(db_path, info, {"aesthetic": 0.8, "comp_score": 0.2},
+                      current_config_weights=real_config_weights)
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT old_weights FROM weight_optimization_runs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert json.loads(row[0]) == real_config_weights
+
+    def test_falls_back_to_info_w_before_when_empty(self, tmp_path):
+        db_path = str(tmp_path / "t.db")
+        init_database(db_path)
+        info = {
+            "category": "portrait", "n_photos": 20,
+            "srcc_before": 0.5, "srcc_after": 0.6,
+            "col_names": ["aesthetic", "comp_score"],
+            "w_before": [0.5, 0.5],
+            "w_after": [0.8, 0.2],
+        }
+
+        log_run_to_db(db_path, info, {"aesthetic": 0.8, "comp_score": 0.2},
+                      current_config_weights={})
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT old_weights FROM weight_optimization_runs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert json.loads(row[0]) == {"aesthetic": 0.5, "comp_score": 0.5}

--- a/tests/test_capsule_generator.py
+++ b/tests/test_capsule_generator.py
@@ -171,14 +171,9 @@ class TestGroupedCapsuleTitleTemplate:
         # so short-circuit it. This dimension is unrelated to day_of_week.
         monkeypatch.setattr("api.db_helpers.is_photo_tags_available", lambda *a, **k: False)
 
-        # day_of_week's real sql_expr is a strftime()/CAST() expression; SQLite
-        # exposes an unaliased complex expression under its own literal text as
-        # the implicit column name, not under any column it references, so the
-        # grouped subquery's outer SELECT can never resolve it back — a
-        # separate, pre-existing bug unrelated to this fix. Swap in a bare
-        # column for the query to structurally succeed, keeping day_of_week's
-        # real title_tpl/value_map so this exercises exactly the templating
-        # logic this fix touches.
+        # Swap in a bare column so this test isolates the templating logic from
+        # the date expression. The grouped subquery's date-expression resolution
+        # is covered separately by test_real_date_expr_groups_without_error.
         patched_dim = dict(cg._DIMENSIONS["day_of_week"])
         patched_dim["sql_expr"] = "star_rating"
         patched_dim["value_map"] = {5: "Monday"}
@@ -204,3 +199,37 @@ class TestGroupedCapsuleTitleTemplate:
         monday_capsules = [c for c in capsules if c["type"] == "day_of_week"]
         assert monday_capsules, "expected a day_of_week capsule for the 3 five-star photos"
         assert monday_capsules[0]["title"] == "Best of Mondays"
+
+    def test_real_date_expr_groups_without_error(self, tmp_path, monkeypatch):
+        """The real strftime(date_taken) grouped query must resolve, not be
+        swallowed by ``except Exception``. Regression for the grouped subquery
+        re-evaluating a date expression against a scope where date_taken is
+        gone ("no such column: date_taken")."""
+        import sqlite3
+
+        import analyzers.capsule_generator as cg
+        from db.schema import init_database
+
+        monkeypatch.setattr("api.db_helpers.is_photo_tags_available", lambda *a, **k: False)
+
+        db_path = str(tmp_path / "cap.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        # 20 photos all on 2024-03-11 (a Monday) — uses the real, unpatched
+        # day_of_week sql_expr CAST(strftime('%w', ...) AS INTEGER).
+        conn.executemany(
+            "INSERT INTO photos (path, filename, aggregate, date_taken) VALUES (?, ?, ?, ?)",
+            [(f"/p/{i}.jpg", f"{i}.jpg", 8.0, "2024:03:11 10:00:00") for i in range(20)],
+        )
+        conn.commit()
+
+        capsule_config = {"day_of_week": {"min_photos": 3}}
+        capsules = cg._generate_dimension_capsules(
+            conn, capsule_config, min_aggregate=6.0, vis=("1=1", []), user_id=None,
+        )
+        conn.close()
+
+        dow = [c for c in capsules if c["type"] == "day_of_week"]
+        assert dow, "real strftime date expr must produce a day_of_week capsule"
+        assert dow[0]["title"] == "Best of Mondays"

--- a/tests/test_capsule_generator.py
+++ b/tests/test_capsule_generator.py
@@ -149,3 +149,58 @@ class TestIsJunkLens:
     @pytest.mark.parametrize("lens", ["EF 50mm f/1.8", "XF 23mm", "Sony FE 24-70"])
     def test_real(self, lens):
         assert _is_junk_lens(lens) is False
+
+
+class TestGroupedCapsuleTitleTemplate:
+    """Regression: a grouped capsule's title must go through its title_tpl.
+
+    day_of_week's title_tpl is "Best of {value}s" — the grouped-dimension
+    builder in ``_generate_dimension_capsules`` used to set ``title`` to the
+    bare display value directly, skipping the template entirely, so the
+    generated title/alt-text read "Monday" instead of "Best of Mondays".
+    """
+
+    def test_title_wraps_value_in_its_template(self, tmp_path, monkeypatch):
+        import sqlite3
+
+        import analyzers.capsule_generator as cg
+        from db.schema import init_database
+
+        # The photo_tags probe opens its own connection to the DEFAULT
+        # (production) DB when none is supplied — tests must never touch that,
+        # so short-circuit it. This dimension is unrelated to day_of_week.
+        monkeypatch.setattr("api.db_helpers.is_photo_tags_available", lambda *a, **k: False)
+
+        # day_of_week's real sql_expr is a strftime()/CAST() expression; SQLite
+        # exposes an unaliased complex expression under its own literal text as
+        # the implicit column name, not under any column it references, so the
+        # grouped subquery's outer SELECT can never resolve it back — a
+        # separate, pre-existing bug unrelated to this fix. Swap in a bare
+        # column for the query to structurally succeed, keeping day_of_week's
+        # real title_tpl/value_map so this exercises exactly the templating
+        # logic this fix touches.
+        patched_dim = dict(cg._DIMENSIONS["day_of_week"])
+        patched_dim["sql_expr"] = "star_rating"
+        patched_dim["value_map"] = {5: "Monday"}
+        monkeypatch.setitem(cg._DIMENSIONS, "day_of_week", patched_dim)
+
+        db_path = str(tmp_path / "cap.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        # 3 five-star photos stand in for "3 photos taken on a Monday".
+        conn.executemany(
+            "INSERT INTO photos (path, filename, aggregate, star_rating) VALUES (?, ?, ?, ?)",
+            [(f"/p/{i}.jpg", f"{i}.jpg", 8.0, 5) for i in range(3)],
+        )
+        conn.commit()
+
+        capsule_config = {"day_of_week": {"min_photos": 3}}
+        capsules = cg._generate_dimension_capsules(
+            conn, capsule_config, min_aggregate=6.0, vis=("1=1", []), user_id=None,
+        )
+        conn.close()
+
+        monday_capsules = [c for c in capsules if c["type"] == "day_of_week"]
+        assert monday_capsules, "expected a day_of_week capsule for the 3 five-star photos"
+        assert monday_capsules[0]["title"] == "Best of Mondays"

--- a/tests/test_cluster_preserve_null_centroid.py
+++ b/tests/test_cluster_preserve_null_centroid.py
@@ -1,0 +1,159 @@
+"""Incremental re-clustering must not orphan API-created / named persons that
+carry a NULL centroid.
+
+Persons created through the viewer (create / split / assign) are inserted with
+``centroid = NULL`` — only the clusterer ever writes a centroid. The old
+``_load_existing_persons`` selected ``WHERE centroid IS NOT NULL``, so those
+persons were dropped from the preservation set: every incremental run then did
+``UPDATE faces SET person_id = NULL`` and never re-attached them, and the
+end-of-run cleanup deleted the now-empty named person. Reproduced live as
+"Alice: 6 faces -> 0".
+
+These tests drive ``FaceClusterer._update_database`` directly with a
+hand-built cluster labelling so they are deterministic (no HDBSCAN) and need no
+image files, and assert the named/NULL-centroid person survives with all her
+faces via the previous-owner history rule — through both the clustered and the
+noise re-labelling paths.
+"""
+
+import sqlite3
+
+import numpy as np
+import pytest
+
+from db import init_database
+from faces.clusterer import FaceClusterer
+
+DIM = 512
+ACTIVE_MODEL = "arcface_buffalo_l"
+
+
+def _unit_lobe(seed, n, dim=DIM, scale=0.02):
+    """n tight, L2-normalized vectors clustered around one random axis."""
+    rng = np.random.default_rng(seed)
+    axis = rng.normal(size=dim)
+    axis /= np.linalg.norm(axis)
+    pts = axis + rng.normal(scale=scale, size=(n, dim))
+    return (pts / np.linalg.norm(pts, axis=1, keepdims=True)).astype(np.float32)
+
+
+def _seed_person(conn, pid, name, centroid=None, auto_clustered=0, face_count=0):
+    conn.execute(
+        "INSERT INTO persons(id, name, centroid, auto_clustered, face_count) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (pid, name, centroid, auto_clustered, face_count),
+    )
+
+
+def _seed_faces(conn, person_id, vectors, path_prefix):
+    """Insert one face per row of ``vectors`` owned by ``person_id``.
+
+    Returns the parallel ``(face_ids, embeddings)`` the clusterer expects.
+    """
+    face_ids = []
+    for i, vec in enumerate(vectors):
+        path = f"{path_prefix}{i}.jpg"
+        conn.execute("INSERT OR IGNORE INTO photos(path) VALUES (?)", (path,))
+        cur = conn.execute(
+            "INSERT INTO faces(photo_path, face_index, embedding, person_id, "
+            "confidence, embedding_model) VALUES (?, ?, ?, ?, ?, ?)",
+            (path, i, sqlite3.Binary(vec.tobytes()), person_id, 0.9, ACTIVE_MODEL),
+        )
+        face_ids.append(cur.lastrowid)
+    return face_ids, np.asarray(vectors, dtype=np.float32)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "faces.db"
+    init_database(str(p))
+    return str(p)
+
+
+def _owner_counts(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return dict(
+            conn.execute(
+                "SELECT person_id, COUNT(*) FROM faces GROUP BY person_id"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+
+def _person(db_path, pid):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute("SELECT * FROM persons WHERE id = ?", (pid,)).fetchone()
+    finally:
+        conn.close()
+
+
+class TestNullCentroidPersonSurvivesReclustering:
+    def test_clustered_faces_are_handed_back_by_history(self, db_path):
+        """The exact repro: Alice is named, has a NULL centroid and 6 faces.
+
+        HDBSCAN would re-derive those 6 as a fresh cluster; because Alice has no
+        centroid the similarity rule cannot match it, so only the previous-owner
+        history rule can keep them. Before the fix Alice was not even in the
+        preservation set, so all 6 faces were orphaned and she was deleted.
+        """
+        conn = sqlite3.connect(db_path)
+        _seed_person(conn, 1, name="Alice", centroid=None, auto_clustered=0)
+        vectors = _unit_lobe(seed=7, n=6)
+        face_ids, embeddings = _seed_faces(conn, 1, vectors, "alice/")
+        conn.commit()
+        conn.close()
+
+        clusterer = FaceClusterer(db_path)
+        # Whole lobe re-derived as one new cluster (label 0), as HDBSCAN would.
+        face_to_cluster = {fid: 0 for fid in face_ids}
+        clusterer._update_database(face_to_cluster, embeddings, face_ids, force=False)
+
+        assert _person(db_path, 1) is not None, "named person was deleted"
+        assert _owner_counts(db_path) == {1: 6}, "faces orphaned off their named person"
+
+        alice = _person(db_path, 1)
+        assert alice["face_count"] == 6
+        # Bonus: the run should have given Alice a real centroid.
+        assert alice["centroid"] is not None
+
+    def test_noise_relabelled_faces_are_restored(self, db_path):
+        """Same person, but every face is re-labelled noise (-1) this run.
+
+        The noise-restore path must re-attach them to their preserved person.
+        """
+        conn = sqlite3.connect(db_path)
+        _seed_person(conn, 1, name="Bob", centroid=None, auto_clustered=0)
+        vectors = _unit_lobe(seed=8, n=5)
+        face_ids, embeddings = _seed_faces(conn, 1, vectors, "bob/")
+        conn.commit()
+        conn.close()
+
+        clusterer = FaceClusterer(db_path)
+        face_to_cluster = {fid: -1 for fid in face_ids}
+        clusterer._update_database(face_to_cluster, embeddings, face_ids, force=False)
+
+        assert _person(db_path, 1) is not None
+        assert _owner_counts(db_path) == {1: 5}
+
+
+class TestEmptyPreservedPersonCleanup:
+    def test_unnamed_auto_husk_deleted_named_kept(self, db_path):
+        """After a re-cluster leaves preserved persons with zero faces, an
+        unnamed auto-clustered person is a husk and must be dropped, while a
+        named person is kept even when momentarily empty."""
+        conn = sqlite3.connect(db_path)
+        _seed_person(conn, 1, name="Named", centroid=None, auto_clustered=0)
+        _seed_person(conn, 2, name=None, centroid=None, auto_clustered=1)
+        conn.commit()
+        conn.close()
+
+        clusterer = FaceClusterer(db_path)
+        # A run that assigns nothing (both preserved persons end with 0 faces).
+        clusterer._update_database({}, np.empty((0, DIM), np.float32), [], force=False)
+
+        assert _person(db_path, 2) is None, "empty unnamed auto husk should be deleted"
+        assert _person(db_path, 1) is not None, "named person must be kept even if empty"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,12 @@
 """Tests for the core config module (ScoringConfig, CategoryFilter, determine_category)."""
 
 import json
+import logging
 import os
 
 import pytest
 
-from config.category_filter import CategoryFilter
+from config.category_filter import CategoryFilter, VALID_WEIGHT_COLUMNS
 from config.scoring_config import ScoringConfig
 
 # Resolve the real scoring_config.json path (repo root)
@@ -784,3 +785,217 @@ class TestTagVocabulary:
         """get_category_tags for unknown category returns empty list."""
         tags = scoring_config.get_category_tags("nonexistent_xyz")
         assert tags == []
+
+
+# ---------------------------------------------------------------------------
+# VALID_WEIGHT_COLUMNS / validate_weights (A3#1: documented metrics were
+# missing from the valid set, so validate_weights() silently deleted them)
+# ---------------------------------------------------------------------------
+
+
+class TestValidWeightColumnsCoversDocumentedMetrics:
+    """face_sharpness, power_point, saturation and noise are documented
+    weight keys (docs/SCORING.md, processing.scorer.SCORING_METRIC_KEYS,
+    written by optimization/weight_optimizer.py) but were missing from
+    VALID_WEIGHT_COLUMNS, so validate_weights() treated their *_percent
+    keys as invalid, deleted them, and persisted the deletion to disk."""
+
+    @pytest.mark.parametrize(
+        "metric", ["face_sharpness", "power_point", "saturation", "noise"]
+    )
+    def test_metric_is_a_valid_weight_column(self, metric):
+        assert metric in VALID_WEIGHT_COLUMNS
+
+    def test_percent_keys_survive_validate_round_trip(self, tmp_path):
+        """A category using these 4 keys must come out of
+        ScoringConfig(path, validate=True) unchanged -- not stripped and
+        not renormalized away."""
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [{
+                "name": "test_cat",
+                "priority": 1,
+                "filters": {},
+                "weights": {
+                    "face_sharpness_percent": 25,
+                    "power_point_percent": 25,
+                    "saturation_percent": 25,
+                    "noise_percent": 25,
+                },
+            }],
+        }))
+
+        cfg = ScoringConfig(config_path=str(config_path), validate=True)
+
+        weights = cfg.config["categories"][0]["weights"]
+        for key in (
+            "face_sharpness_percent", "power_point_percent",
+            "saturation_percent", "noise_percent",
+        ):
+            assert key in weights, f"{key} was stripped by validate_weights()"
+            assert weights[key] == 25, f"{key} was renormalized: {weights[key]}"
+
+
+# ---------------------------------------------------------------------------
+# validate_weights decimal heuristic (A3#2: the 0b zero-padding step ran
+# before the decimal-vs-percent heuristic, so its len(...) > 1 guard was
+# always satisfied post-padding and a single small user-set value got
+# misread as a decimal fraction)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWeightsDecimalHeuristic:
+    """A lone user-set _percent value must not be misinterpreted as a
+    decimal fraction just because 0b zero-pads the category out to every
+    valid weight column first."""
+
+    def _single_key_config(self, tmp_path, value=1):
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [{
+                "name": "test_cat",
+                "priority": 1,
+                "filters": {},
+                "weights": {"tech_sharpness_percent": value},
+            }],
+        }))
+        return str(config_path)
+
+    def test_lone_small_value_is_not_decimal_converted(self, tmp_path, monkeypatch):
+        """Isolates the decimal heuristic (step 1) from step 4's separate,
+        legitimate normalize-to-100% pass (which -- correctly -- would also
+        scale a category's lone nonzero weight up to 100, masking the step 1
+        bug if left enabled). With normalization neutralized, a single
+        {"tech_sharpness_percent": 1} must stay 1, not become 100."""
+        monkeypatch.setattr(
+            ScoringConfig, "normalize_weights_to_100",
+            staticmethod(lambda *a, **k: None),
+        )
+        path = self._single_key_config(tmp_path, value=1)
+        cfg = ScoringConfig(config_path=path, validate=False)
+        cfg.validate_weights(verbose=False)
+        assert cfg.config["categories"][0]["weights"]["tech_sharpness_percent"] == 1
+
+    def test_decimal_to_percent_correction_is_not_logged_for_a_lone_value(self, tmp_path, caplog):
+        """End-to-end (normalization included): the value still ends up
+        renormalized to 100% -- a category with only one populated weight
+        is legitimately entitled to all of it -- but the correction log
+        must not attribute that to a bogus 'decimal to percent' misread."""
+        path = self._single_key_config(tmp_path, value=1)
+        cfg = ScoringConfig(config_path=path, validate=False)
+        with caplog.at_level(logging.INFO, logger="facet.config"):
+            cfg.validate_weights(verbose=True)
+        assert "decimal to percent" not in caplog.text
+
+    def test_genuine_multi_key_decimal_config_still_converts(self, tmp_path):
+        """Sanity check: a real decimal-style config (multiple small values
+        summing to ~1.0) must still be converted -- the fix narrows the
+        guard to single-key configs, it must not disable it entirely."""
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [{
+                "name": "test_cat",
+                "priority": 1,
+                "filters": {},
+                "weights": {"aesthetic_percent": 0.3, "composition_percent": 0.7},
+            }],
+        }))
+        cfg = ScoringConfig(config_path=str(config_path), validate=False)
+        cfg.validate_weights(verbose=False)
+        weights = cfg.config["categories"][0]["weights"]
+        assert weights["aesthetic_percent"] == 30
+        assert weights["composition_percent"] == 70
+
+
+# ---------------------------------------------------------------------------
+# get_tag_vocabulary collision detection (A3#3: two categories claiming the
+# same tag name with different synonyms silently overwrote each other)
+# ---------------------------------------------------------------------------
+
+
+class TestTagVocabularyCollisionWarning:
+    """get_tag_vocabulary() must warn (not silently overwrite) when two
+    categories -- or a category and standalone_tags -- define the same tag
+    name with different synonym lists."""
+
+    def _config_with_colliding_tags(self, tmp_path):
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [
+                {
+                    "name": "cat_a", "priority": 1, "filters": {},
+                    "tags": {"street": ["street", "urban", "city life"]},
+                },
+                {
+                    "name": "cat_b", "priority": 2, "filters": {},
+                    "tags": {"street": ["street scene", "city street"]},
+                },
+                {"name": "default", "priority": 999, "filters": {}},
+            ],
+        }))
+        return ScoringConfig(config_path=str(config_path), validate=False)
+
+    def test_collision_with_different_synonyms_logs_a_warning(self, tmp_path, caplog):
+        cfg = self._config_with_colliding_tags(tmp_path)
+        with caplog.at_level(logging.WARNING, logger="facet.config"):
+            cfg.get_tag_vocabulary()
+        assert any(
+            "street" in record.message and "redefines synonyms" in record.message
+            for record in caplog.records
+        )
+
+    def test_collision_last_definition_still_wins(self, tmp_path):
+        """Behaviour is otherwise unchanged: last category processed wins."""
+        cfg = self._config_with_colliding_tags(tmp_path)
+        vocab = cfg.get_tag_vocabulary()
+        assert vocab["street"] == ["street scene", "city street"]
+
+    def test_identical_synonyms_across_categories_do_not_warn(self, tmp_path, caplog):
+        """Two categories legitimately sharing the exact same synonym list
+        for a tag is not a collision."""
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [
+                {"name": "cat_a", "priority": 1, "filters": {},
+                 "tags": {"bokeh": ["bokeh", "blurred background"]}},
+                {"name": "cat_b", "priority": 2, "filters": {},
+                 "tags": {"bokeh": ["bokeh", "blurred background"]}},
+            ],
+        }))
+        cfg = ScoringConfig(config_path=str(config_path), validate=False)
+        with caplog.at_level(logging.WARNING, logger="facet.config"):
+            cfg.get_tag_vocabulary()
+        assert not any("redefines synonyms" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Fallback defaults (A3#4: get_face_detection_settings / get_burst_detection_
+# settings fell back to values that had drifted from docs/CONFIGURATION.md
+# and the shipped config)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackDefaultsMatchDocumentedDefaults:
+    """When a config omits face_detection/burst_detection entirely, the
+    in-code fallback must match docs/CONFIGURATION.md (and the shipped
+    scoring_config.json), not a stale value that scores differently."""
+
+    def _minimal_config(self, tmp_path):
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text(json.dumps({
+            "categories": [{"name": "default", "priority": 999, "filters": {}}],
+        }))
+        return ScoringConfig(config_path=str(config_path), validate=False)
+
+    def test_face_detection_fallback_matches_docs(self, tmp_path):
+        cfg = self._minimal_config(tmp_path)
+        settings = cfg.get_face_detection_settings()
+        assert settings["min_confidence_percent"] == 65
+        assert settings["min_face_size"] == 20
+
+    def test_burst_detection_fallback_matches_docs(self, tmp_path):
+        cfg = self._minimal_config(tmp_path)
+        settings = cfg.get_burst_detection_settings()
+        assert settings["similarity_threshold_percent"] == 70
+        assert settings["time_window_minutes"] == 0.8
+        assert settings["rapid_burst_seconds"] == 0.4

--- a/tests/test_config_writes.py
+++ b/tests/test_config_writes.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import stat
+import sys
 import threading
 import time
 from datetime import datetime
@@ -16,7 +17,9 @@ from fastapi import HTTPException
 from api.auth import _is_hashed, upgrade_legacy_password
 from api.config import CONFIG_WRITE_LOCK, atomic_write_json
 from api.config_writes import (
+    MAX_CONFIG_BACKUPS,
     update_category_priorities,
+    update_category_weights,
     update_scoring_context,
 )
 from config.scoring_config import ScoringConfig
@@ -187,6 +190,40 @@ class TestUpdateCategoryPriorities:
         ok, issues = cfg.validate_categories(verbose=False)
         assert ok is True
         assert issues == []
+
+
+def _raising_get_db():
+    """A get_db stand-in for tests that don't need the best-effort weight
+    snapshot: record_category_snapshot swallows any exception from get_db()
+    and just logs a warning, so this keeps these tests from needing a real DB."""
+    raise RuntimeError("no db needed for this test")
+
+
+class TestUpdateCategoryWeightsBackupPruning:
+    """DEBT A5#3: update_category_weights(backup=True) was the only writer
+    passing prune=False to _backup_config, so modifier/filter edits
+    accumulated ~88KB backups unbounded. It must prune like every other
+    config-backup writer (update_category_priorities, update_scoring_context)."""
+
+    def test_backup_prunes_old_files_to_the_shared_limit(self, config_copy):
+        config_path = str(config_copy)
+        directory = os.path.dirname(config_path)
+        prefix = os.path.basename(config_path) + ".backup."
+        for i in range(MAX_CONFIG_BACKUPS + 5):
+            shutil.copy2(config_path, os.path.join(directory, f"{prefix}stale{i:03d}"))
+        backups_before = [f for f in os.listdir(directory) if f.startswith(prefix)]
+        assert len(backups_before) > MAX_CONFIG_BACKUPS
+
+        category = _non_default_names(config_copy)[0]
+        update_category_weights(
+            config_path, category, "test:prune", _raising_get_db,
+            not_found_detail="missing",
+            modifiers={"bonus": 0.1},
+            backup=True,
+        )
+
+        backups_after = [f for f in os.listdir(directory) if f.startswith(prefix)]
+        assert len(backups_after) <= MAX_CONFIG_BACKUPS
 
 
 def _context(config_path, name):
@@ -378,6 +415,7 @@ class TestAtomicConfigWrite:
     def _mode(self, path):
         return stat.S_IMODE(os.stat(path).st_mode)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="POSIX chmod permission bits do not apply on Windows")
     @pytest.mark.parametrize("mode", [GROUP_READABLE_MODE, OWNER_ONLY_MODE])
     def test_existing_permissions_are_preserved(self, config_copy, mode):
         """``tempfile.mkstemp`` creates its file 0600, so an unfixed writer
@@ -388,6 +426,7 @@ class TestAtomicConfigWrite:
 
         assert self._mode(config_copy) == mode
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="POSIX directory fsync is not supported on Windows")
     def test_payload_is_fsynced_before_the_rename(self, config_copy):
         """Rename-atomic is not crash-durable: without the flush the rename can
         land while the replacement's bytes are still only in the page cache."""

--- a/tests/test_cull.py
+++ b/tests/test_cull.py
@@ -203,6 +203,31 @@ class TestCullApply:
             resp = client.post("/api/cull/apply", json={"action": "copy_keeps"})
         assert resp.status_code == 400
 
+    def test_not_visible_paths_are_counted_separately_from_excluded_by_state(self, client, tmp_path):
+        """A5#4: a path that isn't in the DB at all (or isn't visible to this
+        user) used to vanish from every count -- neither acted on nor
+        reported, so matching + excluded_by_state never reconciled with
+        len(paths). It must show up as not_visible instead."""
+        keep = _make_file(tmp_path, "keep.jpg")
+        reject = _make_file(tmp_path, "reject.jpg")
+        missing = str(tmp_path / "never_scanned.jpg")  # not in the DB at all
+        db = _db(tmp_path, [(keep, 0), (reject, 1)])
+        with (
+            mock.patch(f"{_EXPORT_MODULE}.get_db", _db_cm(db)),
+            mock.patch(f"{_EXPORT_MODULE}._allowed_export_roots", return_value=[str(tmp_path)]),
+        ):
+            resp = client.post("/api/cull/apply", json={
+                "paths": [keep, reject, missing], "action": "copy_keeps",
+                "target_dir": str(tmp_path / "k"), "dry_run": True,
+                "include_companions": False,
+            })
+        body = resp.json()
+        assert body["would_copy"] == [keep]
+        assert body["excluded_by_state"] == 1  # reject
+        assert body["not_visible"] == 1  # missing
+        # The three counts now reconcile with the request's own path count.
+        assert len(body["would_copy"]) + body["excluded_by_state"] + body["not_visible"] == 3
+
 
 class TestCullAuth:
     def test_regular_user_forbidden(self, regular_client, tmp_path):

--- a/tests/test_filter_options.py
+++ b/tests/test_filter_options.py
@@ -43,6 +43,13 @@ def _build_app_with(db_path: str, viewer_cfg: dict):
         mock.patch("api.routers.filter_options.VIEWER_CONFIG", viewer_cfg),
         mock.patch("api.routers.filter_options.is_multi_user_enabled", return_value=True),
         mock.patch("api.db_helpers.is_multi_user_enabled", return_value=True),
+        # These tests exercise the persons/colors dropdown LOGIC (min_photos,
+        # ids force-include, colour buckets), not visibility gating — which is
+        # covered by test_filter_options_visibility.py. Open the visibility
+        # clause so an unauthenticated TestClient reaches the rows under test;
+        # otherwise get_visibility_clause(None) fails closed to 0=1 under the
+        # multi-user patch above.
+        mock.patch("api.routers.filter_options.get_visibility_clause", return_value=("1=1", [])),
     ]
     for p in patches:
         p.start()

--- a/tests/test_filter_options_visibility.py
+++ b/tests/test_filter_options_visibility.py
@@ -1,0 +1,100 @@
+"""Regression tests for the filter-options visibility short-circuit (A6 #1).
+
+The bug: ``api.routers.filter_options._vis_where`` returned ``('', [])`` for an
+anonymous request *without ever calling* ``get_visibility_clause``. On a locked
+or multi-user install ``get_visibility_clause(None)`` returns a fail-closed
+``0=1`` clause, so short-circuiting before that call served whole-library
+metadata (cameras, lenses, tags, persons, categories, …) to anonymous callers.
+
+The fix must ALWAYS resolve the clause first, exactly like ``stats._vis_where``.
+
+These tests monkeypatch ``get_visibility_clause`` (a DB helper), never the auth
+dependencies — per the repo LAW, auth is swapped via the shared conftest
+``anonymous_client`` fixture / ``app.dependency_overrides`` only.
+"""
+
+from api.routers import filter_options
+
+
+def test_vis_where_calls_visibility_clause_for_anonymous(monkeypatch):
+    """Anonymous (user=None) must still consult get_visibility_clause.
+
+    This is the core regression guard: the old short-circuit returned before
+    the call, so the spy would record nothing.
+    """
+    seen = []
+
+    def spy(user_id):
+        seen.append(user_id)
+        return '1=1', []
+
+    monkeypatch.setattr(filter_options, 'get_visibility_clause', spy)
+
+    filter_options._vis_where(None)
+
+    assert seen == [None], "get_visibility_clause must be called with None for anon"
+
+
+def test_vis_where_fails_closed_on_locked_install(monkeypatch):
+    """When the clause denies anon (0=1) the fragment must carry it through."""
+    monkeypatch.setattr(
+        filter_options, 'get_visibility_clause', lambda user_id: ('0=1', [])
+    )
+
+    frag, params = filter_options._vis_where(None)
+
+    assert frag == ' AND 0=1'
+    assert params == []
+
+
+def test_vis_where_open_install_returns_empty(monkeypatch):
+    """On a fully open install (1=1) the fragment collapses to empty."""
+    monkeypatch.setattr(
+        filter_options, 'get_visibility_clause', lambda user_id: ('1=1', [])
+    )
+
+    assert filter_options._vis_where(None) == ('', [])
+
+
+def test_vis_where_passes_authenticated_user_id(monkeypatch):
+    """An authenticated user forwards its user_id and the returned params."""
+    seen = []
+
+    def spy(user_id):
+        seen.append(user_id)
+        return 'path LIKE ?', ['/u/alice/%']
+
+    monkeypatch.setattr(filter_options, 'get_visibility_clause', spy)
+
+    class _U:
+        user_id = 'alice'
+
+    frag, params = filter_options._vis_where(_U())
+
+    assert seen == ['alice']
+    assert frag == ' AND path LIKE ?'
+    assert params == ['/u/alice/%']
+
+
+def test_filter_options_cameras_anonymous_hits_visibility_clause(
+    anonymous_client, monkeypatch
+):
+    """End-to-end via the shared anonymous_client fixture.
+
+    Proves the endpoint path resolves visibility for the anonymous (None) user
+    rather than short-circuiting. The spy forces a fail-closed clause so the
+    response is empty even if the library holds cameras.
+    """
+    seen = []
+
+    def spy(user_id):
+        seen.append(user_id)
+        return '0=1', []
+
+    monkeypatch.setattr(filter_options, 'get_visibility_clause', spy)
+
+    resp = anonymous_client.get('/api/filter_options/cameras')
+
+    assert resp.status_code == 200
+    assert None in seen, "anon endpoint must resolve visibility for user_id=None"
+    assert resp.json()['cameras'] == []

--- a/tests/test_immich_sync.py
+++ b/tests/test_immich_sync.py
@@ -316,6 +316,71 @@ class TestPushConfig:
         assert "isFavorite" not in updates[0]
 
 
+class TestClearingPreviouslySyncedState:
+    """A rating/favorite that gets reset to 0/false must still reach Immich.
+
+    Regression: _fetch_rating_rows only ever selected currently-active rows,
+    so a photo pushed with rating=5 and then un-rated in Facet fell out of the
+    WHERE clause entirely — Immich kept the stale rating=5 forever.
+    """
+
+    def test_reset_rating_and_favorite_are_pushed_as_a_clear(self, tmp_path, transport):
+        db_path = make_db(tmp_path, [('/p/a.jpg', 5, 1, 0)])
+        transport.assets_by_path = {'/p/a.jpg': 'id-a'}
+
+        # First sync: establishes id-a as having an active rating + favorite.
+        summary1 = sync_to_immich(db_path, make_config())
+        assert summary1["matched"] == 1
+        updates1 = transport.asset_updates()
+        assert updates1[-1]["rating"] == 5
+        assert updates1[-1]["isFavorite"] is True
+
+        # User clears the star rating and un-favorites.
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE photos SET star_rating = 0, is_favorite = 0 WHERE path = ?",
+                    ('/p/a.jpg',))
+        conn.commit()
+        conn.close()
+
+        summary2 = sync_to_immich(db_path, make_config())
+        updates2 = transport.asset_updates()
+        # The clear must actually reach Immich, not be silently dropped.
+        assert summary2["matched"] == 1
+        assert updates2[-1]["rating"] == 0
+        assert updates2[-1]["isFavorite"] is False
+
+        # Once the clear is confirmed pushed, the row drops out of tracking
+        # entirely (no longer active, no longer in synced state) so it falls
+        # outside the fetch WHERE clause: a third sync must not re-touch it.
+        requests_before = len(transport.requests)
+        summary3 = sync_to_immich(db_path, make_config())
+        assert summary3["matched"] == 0
+        assert summary3["skipped_unrated"] == 0
+        assert len(transport.requests) == requests_before
+
+    def test_never_synced_zero_rating_still_never_pushed(self, tmp_path, transport):
+        # A photo with no history in synced state and no active rating/favorite
+        # must keep costing zero requests, exactly as before this fix (excluded
+        # at the fetch WHERE, same as a pure-rejected row).
+        db_path = make_db(tmp_path, [('/p/untouched.jpg', 0, 0, 0)])
+        summary = sync_to_immich(db_path, make_config())
+        assert transport.requests == []
+        assert summary["skipped_unrated"] == 0
+
+    def test_dry_run_does_not_persist_synced_state(self, tmp_path, transport):
+        db_path = make_db(tmp_path, [('/p/a.jpg', 5, 0, 0)])
+        transport.assets_by_path = {'/p/a.jpg': 'id-a'}
+        # A dry run must not confirm state that was never actually written.
+        sync_to_immich(db_path, make_config(), dry_run=True)
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT value FROM stats_cache WHERE key = 'immich_synced_paths:global'"
+        ).fetchone()
+        conn.close()
+        assert row is None
+
+
 class TestPartialProgress:
     def test_network_error_carries_partial_summary(self, tmp_path, monkeypatch):
         import urllib.error

--- a/tests/test_merge_suggestions.py
+++ b/tests/test_merge_suggestions.py
@@ -1,21 +1,26 @@
 """Tests for the merge suggestions API router (api/routers/merge_suggestions.py)."""
 
+import math
+import sqlite3
 from contextlib import contextmanager
 from unittest import mock
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
 from api import create_app
 from api.auth import CurrentUser, require_authenticated
 
+_ROUTER = "api.routers.merge_suggestions"
 
-def _cm(conn):
-    """Wrap a mock connection in a context manager compatible with get_db()."""
-    @contextmanager
-    def _ctx():
-        yield conn
-    return _ctx()
+_ONE_PAIR = [
+    {
+        "person1": {"id": 1, "name": "Alice", "face_count": 10},
+        "person2": {"id": 2, "name": "Alice B", "face_count": 5},
+        "similarity": 0.85,
+    }
+]
 
 
 @pytest.fixture()
@@ -32,19 +37,8 @@ class TestGetMergeSuggestions:
     """GET /api/merge_suggestions — person merge suggestions."""
 
     def test_returns_suggestions(self, client):
-        """When get_merge_groups returns groups, endpoint yields pairwise suggestions."""
-        fake_groups = [
-            {
-                "persons": [
-                    {"id": 1, "name": "Alice", "face_count": 10},
-                    {"id": 2, "name": "Alice B", "face_count": 5},
-                ],
-                "avg_similarity": 0.85,
-            }
-        ]
-        fake_faces = mock.MagicMock()
-        fake_faces.get_merge_groups = mock.MagicMock(return_value=fake_groups)
-        with mock.patch.dict("sys.modules", {"faces": fake_faces}):
+        """The endpoint surfaces the pairwise suggestions it computes."""
+        with mock.patch(f"{_ROUTER}._pairwise_suggestions", return_value=_ONE_PAIR):
             resp = client.get("/api/merge_suggestions")
 
         assert resp.status_code == 200
@@ -57,10 +51,8 @@ class TestGetMergeSuggestions:
         assert s["similarity"] == 0.85
 
     def test_empty_persons_returns_empty(self, client):
-        """No merge groups yields an empty suggestions list."""
-        fake_faces = mock.MagicMock()
-        fake_faces.get_merge_groups = mock.MagicMock(return_value=[])
-        with mock.patch.dict("sys.modules", {"faces": fake_faces}):
+        """No candidate pairs yields an empty suggestions list."""
+        with mock.patch(f"{_ROUTER}._pairwise_suggestions", return_value=[]):
             resp = client.get("/api/merge_suggestions")
 
         assert resp.status_code == 200
@@ -78,3 +70,96 @@ class TestGetMergeSuggestions:
             resp = unauthenticated_client.get("/api/merge_suggestions")
 
         assert resp.status_code in (401, 403)
+
+
+def _planar(angle_deg, dim=512, plane=(0, 1)):
+    """A unit vector in the (plane) 2-plane of a ``dim``-space at ``angle_deg``."""
+    v = np.zeros(dim, dtype=np.float32)
+    r = math.radians(angle_deg)
+    v[plane[0]] = math.cos(r)
+    v[plane[1]] = math.sin(r)
+    return v
+
+
+def _db_cm(path):
+    @contextmanager
+    def _cm():
+        c = sqlite3.connect(path)
+        c.row_factory = sqlite3.Row
+        try:
+            yield c
+        finally:
+            c.close()
+    return _cm
+
+
+class TestPairwiseSuggestions:
+    """The heart of the fix: each emitted pair carries its OWN centroid
+    similarity, and a pair merely linked through a chain is never invented.
+
+    Persons are placed by angle in one plane so pairwise cosine similarity is
+    exactly ``cos(delta)``:
+        P1 @ 0deg, P2 @ 10deg, P4 @ 60deg  ->  (1,2)=cos10, (2,4)=cos50, (1,4)=cos60
+    plus P3 orthogonal (no pair). At threshold 0.6:
+        (1,2)=0.985 kept, (2,4)=0.643 kept, (1,4)=0.500 dropped.
+    The old union-find grouping would have folded 1,2,4 into one group and
+    emitted the adjacent pair (1,4) at the group average — a false merge.
+    """
+
+    def _seed(self, tmp_path):
+        path = str(tmp_path / "pairs.db")
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "CREATE TABLE persons (id INTEGER PRIMARY KEY, name TEXT, "
+            "face_count INTEGER, centroid BLOB, is_hidden INTEGER)"
+        )
+        rows = [
+            (1, "P1", 40, _planar(0)),
+            (2, "P2", 30, _planar(10)),
+            (4, "P4", 20, _planar(60)),
+            (3, "P3", 10, _planar(90, plane=(2, 3))),  # orthogonal to the others
+        ]
+        conn.executemany(
+            "INSERT INTO persons VALUES (?, ?, ?, ?, 0)",
+            [(i, n, fc, sqlite3.Binary(v.tobytes())) for i, n, fc, v in rows],
+        )
+        conn.commit()
+        conn.close()
+        return path
+
+    def _pairs(self, tmp_path):
+        from api.routers.merge_suggestions import _pairwise_suggestions
+        path = self._seed(tmp_path)
+        with mock.patch(f"{_ROUTER}.get_db", _db_cm(path)):
+            suggestions = _pairwise_suggestions(0.6)
+        return {
+            tuple(sorted((s["person1"]["id"], s["person2"]["id"]))): s["similarity"]
+            for s in suggestions
+        }
+
+    def test_only_true_pairs_above_threshold(self, tmp_path):
+        pairs = self._pairs(tmp_path)
+        assert set(pairs) == {(1, 2), (2, 4)}, pairs
+        # The transitive pair (1,4) is below threshold and must not appear.
+        assert (1, 4) not in pairs
+
+    def test_each_pair_carries_its_own_similarity(self, tmp_path):
+        pairs = self._pairs(tmp_path)
+        assert pairs[(1, 2)] == pytest.approx(math.cos(math.radians(10)), abs=1e-4)
+        assert pairs[(2, 4)] == pytest.approx(math.cos(math.radians(50)), abs=1e-4)
+        # ...and they are genuinely different, not one shared group average.
+        assert pairs[(1, 2)] > pairs[(2, 4)]
+
+    def test_hidden_person_excluded(self, tmp_path):
+        path = self._seed(tmp_path)
+        conn = sqlite3.connect(path)
+        conn.execute("UPDATE persons SET is_hidden = 1 WHERE id = 2")
+        conn.commit()
+        conn.close()
+        from api.routers.merge_suggestions import _pairwise_suggestions
+        with mock.patch(f"{_ROUTER}.get_db", _db_cm(path)):
+            suggestions = _pairwise_suggestions(0.6)
+        ids = {s["person1"]["id"] for s in suggestions} | {
+            s["person2"]["id"] for s in suggestions
+        }
+        assert 2 not in ids

--- a/tests/test_merge_suggestions_visibility.py
+++ b/tests/test_merge_suggestions_visibility.py
@@ -28,13 +28,14 @@ _SCHEMA = """
     CREATE TABLE rejected_merge_suggestions (person_a_id INTEGER, person_b_id INTEGER);
 """
 
-_GROUPS = [
-    {"avg_similarity": 0.9,
-     "persons": [{"id": 1, "name": "A", "face_count": 3},
-                 {"id": 2, "name": "B", "face_count": 3}]},
-    {"avg_similarity": 0.8,
-     "persons": [{"id": 1, "name": "A", "face_count": 3},
-                 {"id": 3, "name": "C", "face_count": 3}]},
+# Candidate pairwise suggestions (person 1 pairs with both 2 and 3). The
+# endpoint's directory-visibility filtering is what these tests exercise, so the
+# similarity computation is stubbed at ``_pairwise_suggestions``.
+_SUGGESTIONS = [
+    {"person1": {"id": 1, "name": "A", "face_count": 3},
+     "person2": {"id": 2, "name": "B", "face_count": 3}, "similarity": 0.9},
+    {"person1": {"id": 1, "name": "A", "face_count": 3},
+     "person2": {"id": 3, "name": "C", "face_count": 3}, "similarity": 0.8},
 ]
 
 
@@ -77,7 +78,7 @@ def _client(db_path, user, multi_user):
     patches = [
         mock.patch(f"{_ROUTER}.get_db", _db_cm(db_path)),
         mock.patch(f"{_ROUTER}.is_multi_user_enabled", return_value=multi_user),
-        mock.patch("faces.get_merge_groups", return_value=_GROUPS),
+        mock.patch(f"{_ROUTER}._pairwise_suggestions", return_value=_SUGGESTIONS),
         mock.patch(f"{_HELPERS}.is_multi_user_enabled", return_value=multi_user),
         mock.patch(f"{_HELPERS}.get_user_directories",
                    side_effect=lambda uid: dirs.get(uid, [])),

--- a/tests/test_persons_merge_batch.py
+++ b/tests/test_persons_merge_batch.py
@@ -170,24 +170,19 @@ class TestRejectMergeSuggestion:
             conn.commit()
             conn.close()
 
-            fake_groups = [{
-                "persons": [
-                    {"id": 9100, "name": "A", "face_count": 3},
-                    {"id": 9101, "name": "B", "face_count": 2},
-                ],
-                "avg_similarity": 0.8,
+            one_pair = [{
+                "person1": {"id": 9100, "name": "A", "face_count": 3},
+                "person2": {"id": 9101, "name": "B", "face_count": 2},
+                "similarity": 0.8,
             }]
-            fake_faces = mock.MagicMock()
-            fake_faces.get_merge_groups = mock.MagicMock(return_value=fake_groups)
 
-            # Stub the whole ``faces`` module in sys.modules rather than patching
-            # ``faces.get_merge_groups`` directly: importing the real ``faces``
-            # package pulls in InsightFace/torch (FaceProcessor), which is heavy
-            # and GPU-dependent. This relies on the endpoint doing a *lazy*
-            # ``from faces import get_merge_groups`` at call time
-            # (api/routers/merge_suggestions.py) — if that import is ever hoisted
-            # to module top, swap this for patching the bound symbol there.
-            with mock.patch.dict("sys.modules", {"faces": fake_faces}):
+            # Patch the pairwise-suggestion computation directly so the test is
+            # isolated from whatever centroids the session DB happens to hold;
+            # the endpoint's rejected-pair filtering is what we exercise here.
+            with mock.patch(
+                "api.routers.merge_suggestions._pairwise_suggestions",
+                return_value=one_pair,
+            ):
                 before = edition_client.get("/api/merge_suggestions")
                 assert before.status_code == 200
                 assert len(before.json()["suggestions"]) == 1

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -18,7 +18,7 @@ class _FakeMemory:
 
 def _make_monitor():
     processor = SimpleNamespace(batch_size=16, get_metrics=lambda: {})
-    return ResourceMonitor(processor, config={}, multi_pass_processor=None)
+    return ResourceMonitor(processor, config={})
 
 
 def test_graceful_reduction_returns_promptly_on_stop():

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -185,6 +185,49 @@ class TestStartScan:
 
         assert resp.status_code == 400
 
+    def test_lock_is_released_when_spawn_raises_uncaught_exception(self):
+        """A5#1: an exception type the narrow ``except`` clause does not name
+        (e.g. a RuntimeError from Thread.start under resource exhaustion)
+        must still release the shared job lock -- it is the try/finally, not
+        the except clause, that has to guarantee that. Without it this wedges
+        every later /api/scan/start and /api/scan/recompute behind a
+        permanent 409 until the process restarts."""
+        from api.routers import scan as scan_router
+
+        scan_router._scan_state['running'] = False
+        viewer_cfg = _viewer_config_with_scan()
+        with (
+            mock.patch(f"{_AUTH_MODULE}.VIEWER_CONFIG", viewer_cfg),
+            mock.patch(f"{_AUTH_MODULE}.is_multi_user_enabled", return_value=True),
+            mock.patch(f"{_ROUTER_MODULE}.VIEWER_CONFIG", viewer_cfg),
+            mock.patch(f"{_ROUTER_MODULE}.get_all_scan_directories", return_value=["/photos"]),
+            mock.patch.object(scan_router.subprocess, "Popen", side_effect=RuntimeError("boom")),
+        ):
+            app, client, _ = _make_superadmin_app(viewer_cfg)
+            resp = client.post("/api/scan/start", json={"directories": ["/photos"]})
+
+        assert resp.status_code == 500
+        assert not scan_router._scan_lock.locked()
+
+        # And the lock being free actually means a following start can run --
+        # not just that .locked() reports False.
+        with (
+            mock.patch(f"{_AUTH_MODULE}.VIEWER_CONFIG", viewer_cfg),
+            mock.patch(f"{_AUTH_MODULE}.is_multi_user_enabled", return_value=True),
+            mock.patch(f"{_ROUTER_MODULE}.VIEWER_CONFIG", viewer_cfg),
+            mock.patch(f"{_ROUTER_MODULE}.get_all_scan_directories", return_value=["/photos"]),
+        ):
+            scan_router._scan_state['running'] = False
+            mock_proc = mock.MagicMock()
+            mock_proc.pid = 4242
+            mock_proc.stdout = iter([])
+            mock_proc.wait.return_value = 0
+            with mock.patch.object(scan_router.subprocess, "Popen", return_value=mock_proc):
+                app, client, _ = _make_superadmin_app(viewer_cfg)
+                resp = client.post("/api/scan/start", json={"directories": ["/photos"]})
+
+        assert resp.status_code == 200
+
 
 class TestScanStatus:
     """Tests for GET /api/scan/status."""

--- a/tests/test_single_pass_preserves.py
+++ b/tests/test_single_pass_preserves.py
@@ -14,6 +14,7 @@ The restricted save must update ONLY the columns the executed pass produced.
 """
 
 import struct
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -75,7 +76,11 @@ def seeded(tmp_path):
     facet = Facet.__new__(Facet)  # bypass heavy __init__; only db_path/config used
     facet.db_path = db
     facet.config = SimpleNamespace(version_hash='v1')
-    path = '/p/seed.jpg'
+    # Resolved the same way production's _base_record (multi_pass.py) resolves
+    # it, so the fixture's seeded row and the code-under-test's UPSERT target
+    # the same path on every OS (Windows turns a bare '/p/seed.jpg' into
+    # 'D:\\p\\seed.jpg', which would otherwise never match ON CONFLICT(path)).
+    path = str(Path(tmp_path / 'seed.jpg').resolve())
     facet.save_photos_batch([(_scored_result(path), _IMG)])
     with get_connection(db, row_factory=False) as conn:
         conn.execute(
@@ -208,10 +213,10 @@ def test_faces_refreshed_when_pass_is_insightface(seeded):
         assert faces[0]['embedding'] == b'\x09' * 8
 
 
-def test_new_photo_gets_row_with_computed_columns_and_thumbnail(seeded):
+def test_new_photo_gets_row_with_computed_columns_and_thumbnail(seeded, tmp_path):
     _, facet, db = seeded
     proc = _processor(facet, [['saliency']])
-    newpath = '/p/brand_new.jpg'
+    newpath = str(Path(tmp_path / 'brand_new.jpg').resolve())
 
     _persist(proc, {newpath: dict(_SALIENCY)}, _images(newpath))
 

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 
+from db.schema import init_database
 from validation.database_validator import DatabaseValidator
 
 
@@ -56,3 +57,63 @@ class TestDatabaseIntegrity:
         validator = DatabaseValidator(":memory:")
         validator._check_database_integrity(_FakeConn([("ok",)]))
         assert not validator.results[-1].has_issues
+
+
+class TestDataTypeCorruption:
+    """TEXT (not just BLOB) corruption in numeric columns must be flagged.
+
+    Every other check in the validator gates on TYPEOF IN ('real', 'integer')
+    before looking at the value, so an error message or empty string written
+    into a score/raw-metric column (SQLite's dynamic typing allows this)
+    silently sails through as if the column were NULL unless the corruption
+    check itself catches it.
+    """
+
+    def _seed(self, tmp_path, aesthetic_value, face_sharpness_value=None):
+        db = tmp_path / "t.db"
+        init_database(str(db))
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "INSERT INTO photos (path, filename, aesthetic, face_sharpness) VALUES (?, ?, ?, ?)",
+            ("/p/a.jpg", "a.jpg", aesthetic_value, face_sharpness_value),
+        )
+        conn.commit()
+        return db, conn
+
+    def test_text_in_score_column_flagged(self, tmp_path):
+        db, conn = self._seed(tmp_path, "ERROR")
+        validator = DatabaseValidator(str(db))
+        validator._check_data_type_corruption(conn)
+        conn.close()
+
+        result = next(r for r in validator.results if r.check_name == "text_in_numeric_columns")
+        assert result.has_issues
+        assert result.count == 1
+
+    def test_empty_string_in_score_column_flagged(self, tmp_path):
+        db, conn = self._seed(tmp_path, "")
+        validator = DatabaseValidator(str(db))
+        validator._check_data_type_corruption(conn)
+        conn.close()
+
+        result = next(r for r in validator.results if r.check_name == "text_in_numeric_columns")
+        assert result.has_issues
+
+    def test_text_in_raw_metric_column_flagged(self, tmp_path):
+        db, conn = self._seed(tmp_path, 5.0, face_sharpness_value="nan")
+        validator = DatabaseValidator(str(db))
+        validator._check_data_type_corruption(conn)
+        conn.close()
+
+        result = next(r for r in validator.results if r.check_name == "text_in_numeric_columns")
+        assert result.has_issues
+        assert any(i['record']['column'] == 'face_sharpness' for i in result.issues)
+
+    def test_numeric_value_not_flagged(self, tmp_path):
+        db, conn = self._seed(tmp_path, 7.5)
+        validator = DatabaseValidator(str(db))
+        validator._check_data_type_corruption(conn)
+        conn.close()
+
+        result = next(r for r in validator.results if r.check_name == "text_in_numeric_columns")
+        assert not result.has_issues

--- a/tests/test_visibility_fail_open.py
+++ b/tests/test_visibility_fail_open.py
@@ -58,7 +58,7 @@ def test_authenticated_multi_user_scoped_to_directories():
         mock.patch("api.db_helpers.get_user_directories", return_value=["/photos/alice"]),
     ):
         sql, params = get_visibility_clause("alice")
-    assert sql == "(photos.path LIKE ?)"
+    assert sql == "(photos.path LIKE ? ESCAPE '\\')"
     assert params == ["/photos/alice/%"]
 
 

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -14,6 +14,7 @@ path; the ``upload`` block is patched in place on ``api.config._FULL_CONFIG``
 """
 
 import os
+import sys
 import xml.etree.ElementTree as ET
 
 import pytest
@@ -141,6 +142,7 @@ class TestPropfind:
         resp = client.request("PROPFIND", "/dav/nope.jpg", auth=AUTH, headers={"Depth": "0"})
         assert resp.status_code == 404
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="< and > are invalid in Windows filenames")
     def test_xml_escaping_round_trips(self, client, inbox):
         name = "a & b <c>.jpg"
         (inbox / name).write_bytes(b"x")
@@ -318,6 +320,7 @@ class TestContainment:
         resp = client.request("PROPFIND", "/dav//etc/hosts.jpg", auth=AUTH, headers={"Depth": "0"})
         assert resp.status_code in (403, 404)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlink creation requires admin privileges on Windows")
     def test_symlink_escape_put_403(self, client, inbox, tmp_path):
         outside = tmp_path / "outside"
         outside.mkdir()
@@ -327,6 +330,7 @@ class TestContainment:
         assert not (outside / "evil.jpg").exists()
         assert list(outside.iterdir()) == []
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlink creation requires admin privileges on Windows")
     def test_symlink_escape_propfind_403(self, client, inbox, tmp_path):
         outside = tmp_path / "outside2"
         outside.mkdir()

--- a/tests/test_weight_optimizer_sources.py
+++ b/tests/test_weight_optimizer_sources.py
@@ -250,6 +250,61 @@ class TestApplyWritesConfigKeys:
         assert "qalign_percent" not in weights
 
 
+class TestCVFoldsMatchDeployedObjective:
+    """The held-out CV gate must score the SAME model optimize_weights_direct
+    ships: L2-regularized toward the current config weights. Before the fix,
+    each fold's fit was unregularized and started from a uniform prior, so the
+    reported CV accuracy was gating a different model than the one applied.
+    """
+
+    def test_l2_regularization_defaults_match_direct_optimization(self):
+        import inspect
+        direct_default = inspect.signature(
+            WeightOptimizer.optimize_weights_direct
+        ).parameters['l2_regularization'].default
+        cv_default = inspect.signature(
+            WeightOptimizer.optimize_weights_with_cv
+        ).parameters['l2_regularization'].default
+        assert direct_default == cv_default
+
+    def test_high_l2_pulls_every_fold_toward_current_weights(self, optimizer_db):
+        db_path, aesthetics = optimizer_db
+        _add_comparisons(db_path, aesthetics, 'vote', agree=True, count=80)
+        optimizer = WeightOptimizer(db_path)
+
+        old_weights = optimizer._load_current_weights(None)
+        n = len(WeightOptimizer.SCORE_COMPONENTS)
+        old_w = np.array([old_weights.get(c, 1.0 / n) for c in WeightOptimizer.SCORE_COMPONENTS])
+        old_w = old_w / old_w.sum()
+
+        # A huge L2 penalty should overwhelm the comparison-fit term in every
+        # fold, so the averaged CV weights land right back on the current
+        # config weights -- only possible if each fold is actually anchored to
+        # old_w the way optimize_weights_direct is.
+        result = optimizer.optimize_weights_with_cv(min_comparisons=30, l2_regularization=1e6)
+        assert 'error' not in result
+        new_w = np.array([result['new_weights'][c] for c in WeightOptimizer.SCORE_COMPONENTS])
+        assert np.allclose(new_w, old_w, atol=0.02)
+
+    def test_zero_l2_lets_folds_drift_from_current_weights(self, optimizer_db):
+        """Sanity check that the l2_regularization param actually takes effect
+        (rules out a no-op wiring that would make the test above pass by
+        accident)."""
+        db_path, aesthetics = optimizer_db
+        _add_comparisons(db_path, aesthetics, 'vote', agree=True, count=80)
+        optimizer = WeightOptimizer(db_path)
+
+        old_weights = optimizer._load_current_weights(None)
+        n = len(WeightOptimizer.SCORE_COMPONENTS)
+        old_w = np.array([old_weights.get(c, 1.0 / n) for c in WeightOptimizer.SCORE_COMPONENTS])
+        old_w = old_w / old_w.sum()
+
+        result = optimizer.optimize_weights_with_cv(min_comparisons=30, l2_regularization=0.0)
+        assert 'error' not in result
+        new_w = np.array([result['new_weights'][c] for c in WeightOptimizer.SCORE_COMPONENTS])
+        assert not np.allclose(new_w, old_w, atol=0.02)
+
+
 class TestHeldOutGate:
     def _setup(self, tmp_path):
         db_path = str(tmp_path / "gate.db")

--- a/tests/test_xmp_export.py
+++ b/tests/test_xmp_export.py
@@ -308,6 +308,13 @@ class TestExiftoolArgs:
         assert f"-XMP:Rating={RATING_REJECTED}" in args
         assert "-XMP:Label=Red" in args
 
+    def test_no_favorite_no_reject_clears_label(self):
+        # A photo with neither favorite nor reject set (e.g. just un-favorited)
+        # must still emit -XMP:Label= so exiftool CLEARS a stale label on the
+        # target instead of leaving a previous Yellow/Red label in place.
+        args = xe._exiftool_tag_args(XmpRating(star_rating=3), [], [])
+        assert "-XMP:Label=" in args
+
     def test_keywords_clear_before_replace_no_append(self):
         args = xe._exiftool_tag_args(XmpRating(tags=["beach"], person_names=["Alice"]), [], [])
         # The clear must precede the values (idempotent replace, not append).

--- a/validation/database_validator.py
+++ b/validation/database_validator.py
@@ -271,7 +271,7 @@ class DatabaseValidator:
         self._print_result(result4)
 
     def _check_data_type_corruption(self, conn: sqlite3.Connection):
-        """Check for BLOB data accidentally stored in numeric columns."""
+        """Check for BLOB or TEXT data accidentally stored in numeric columns."""
         result = ValidationResult(
             "blob_in_numeric_columns",
             "BLOB data stored in numeric columns (requires rescan)"
@@ -297,6 +297,33 @@ class DatabaseValidator:
 
         self.results.append(result)
         self._print_result(result)
+
+        # TEXT corruption (an empty string, an error message, ...) is just as
+        # invisible to every other check here as BLOB is: they all gate on
+        # TYPEOF IN ('real', 'integer') before touching the value, so a
+        # TEXT-typed score/raw-metric column sails through every range and
+        # consistency check as if it were NULL.
+        result2 = ValidationResult(
+            "text_in_numeric_columns",
+            "TEXT data stored in numeric columns (requires rescan)"
+        )
+
+        for col in SCORE_COLUMNS + RAW_METRIC_COLUMNS:
+            cursor.execute(f"""
+                SELECT path, filename, {col}
+                FROM photos
+                WHERE TYPEOF({col}) = 'text' AND {col} IS NOT NULL
+                LIMIT 20
+            """)
+
+            for row in cursor.fetchall():
+                result2.add_issue(
+                    {'path': row[0], 'filename': row[1], 'column': col, 'value': row[2]},
+                    f"{col} is TEXT ({row[2]!r})"
+                )
+
+        self.results.append(result2)
+        self._print_result(result2)
 
     def _check_histogram_integrity(self, conn: sqlite3.Connection):
         """Check histogram data integrity."""

--- a/viewer.py
+++ b/viewer.py
@@ -61,6 +61,10 @@ def main():
 
     import uvicorn
 
+    # Disable uvicorn's access log: its default format records the full request
+    # line including the query string, which would leak share/frame/scan tokens
+    # (passed as query params) into plaintext logs. The app's own
+    # RequestLoggingMiddleware logs the path only.
     if args.production:
         uvicorn.run(
             "api:create_app",
@@ -68,6 +72,7 @@ def main():
             host=args.host,
             port=args.port,
             workers=args.workers,
+            access_log=False,
         )
     else:
         uvicorn.run(
@@ -77,6 +82,7 @@ def main():
             port=args.port,
             reload=True,
             reload_dirs=[_script_dir],
+            access_log=False,
         )
 
 


### PR DESCRIPTION
Full-project `/review-all` sweep: 11 parallel review agents → every finding independently re-verified by an adversarial agent → 9 parallel fix agents on disjoint file sets → full-gate verification. **79 findings, 0 false positives, all confirmed defects fixed.**

## Gates (baseline → this branch)
| Gate | Baseline | Now |
|------|----------|-----|
| pytest | 11 failed | **0 failed, 2539 passed, 22 skipped** |
| vitest | 62 failed | **0 failed, 1551 passed** |
| ruff / tsc | pass | **pass** |

Also smoke-tested against the live 127k library (gallery renders, no console errors; the date-filter and visibility fixes confirmed returning real data).

## CRITICALs fixed
- **Anonymous metadata leak** — `/api/filter_options/*` served person names/cameras/tags library-wide to unauthenticated callers on a locked install (found by two agents independently); album list leaked album metadata the same way.
- **World-readable on config corruption** — an unparseable `scoring_config.json` flipped the whole photo surface open.
- **Named people orphaned** — API-created/named persons had `centroid=NULL`; every incremental re-cluster dropped them and deleted their faces (reproduced live). Merges into a stale person id stranded faces and deleted the source.
- **Same-year date filters returned nothing** — stats (7 endpoints) + map compared ISO dates against EXIF-format `date_taken`.
- **Single-pass scoring broke 25/34 categories** — metrics dict dropped `tags`/`is_monochrome`/etc.; `processing.mode="single-pass"` errored on every image.
- **Config validation deleted documented weight metrics** from disk on ordinary loads (reproduced live).
- **XMP un-favorite reverted on import**; **cross-user comparison votes clobbered** each other (fixed with an idempotent, row-preserving migration); **gallery undo desynced** on a silent failure.

Plus ~30 IMPORTANT and the DEBT/SUGGESTED items.

## Follow-ups in this branch (requested)
- **Config data**: deduped the colliding `street`/`urban` `tags.street` key.
- **Capsules**: fixed the date-dimension grouped SQL that raised `no such column: date_taken` (silently swallowed) in both capsule builders.
- **Security**: album share tokens can now be rotated (`?rotate=true`); disabled uvicorn's access log so query-string tokens don't reach plaintext logs.

## Notes / decisions
- Reverted one SUGGESTED item (auth on `/api/ranker/status`) — a test documents that scope as intentionally open.
- The 11 baseline pytest failures were Windows/test-portability only (product code was correct); fixed or `skipif`-guarded.
- The 62 vitest failures were a test-builder module-duplication bug (not reproducible in AOT) — moved the affected components to literal i18n keys and guarded the codemod.
- One fix agent flagged and correctly ignored a prompt-injection attempt embedded in a tool result mid-run; no scope violation occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
