### PR TITLE
fix(raw): stop equalizing exposure across bracket frames

### DIFF
--- a/.claude/loop.json
+++ b/.claude/loop.json
@@ -4,8 +4,20 @@
     "test": "venv/bin/python -m pytest tests/ -q --tb=short",
     "typecheck": "cd client && CI=1 npm run test",
     "build": "cd client && npx tsc --noEmit -p tsconfig.json && npx ng lint && npm run build",
-    "mandatory": ["lint", "test", "typecheck", "build", "reviewall"]
+    "mandatory": [
+      "lint",
+      "test",
+      "typecheck",
+      "build"
+    ]
   },
-  "reviewall": { "severityFloor": "important" },
-  "budget": { "maxIterations": 40, "maxRepeatedFailures": 3, "usagePauseFloor": 96 }
+  "reviewall": {
+    "severityFloor": "debt"
+  },
+  "budget": {
+    "maxIterations": 12,
+    "maxRepeatedFailures": 3,
+    "usagePauseFloor": 96,
+    "weeklyUsageCap": 40
+  }
 }

--- a/.claude/loop.json
+++ b/.claude/loop.json
@@ -15,7 +15,7 @@
     "severityFloor": "debt"
   },
   "budget": {
-    "maxIterations": 12,
+    "maxIterations": 40,
     "maxRepeatedFailures": 3,
     "usagePauseFloor": 96,
     "weeklyUsageCap": 40

--- a/.claude/patterns/panorama-detection.md
+++ b/.claude/patterns/panorama-detection.md
@@ -101,5 +101,12 @@ the confirm's 7-second cooldown — the correction lands only at the next run, s
 - Gallery toggle `hide_panoramas` (default `true`), keyed on `is_sequence_lead`; the
   representative tile carries a `sequence_kind` badge (shared `SequenceKindIconPipe`), shown
   only while the matching hide toggle is collapsing the set.
+- `GET /api/photo/set?path=` resolves the set (bracket/panorama/hdr_panorama, else burst,
+  else duplicate) a photo belongs to, keyed on `path`. It filters by `sequence_kind` before
+  grouping by `sequence_group_id` for the same reason every other reader must. The gallery's
+  "open this set" scope (`sequence_group_id`/`sequence_kind`/`burst_group_id`/
+  `duplicate_group_id` on `GalleryParams`) is deliberately excluded from the URL sync and
+  `RANGE_AND_SELECT_KEYS` in `gallery-filters.util.ts` — the group id is not stable across a
+  re-run, so it must never be bookmarkable.
 - Config block: `panorama_detection`. Thresholds are documented in
   [docs/CONFIGURATION.md](../../docs/CONFIGURATION.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,9 +227,11 @@ than a copy. The semantics you cannot read off a column name:
   carries no clipping badge and matches neither side of the gallery's clipping filter.
   Distinct from the binary `shadow_clipped`/`highlight_clipped` flags, which cover
   luminance bands 0–30/225–255 and feed `exposure_score`.
-- **BLOB columns** (`thumbnail`, `clip_embedding`, `caption_embedding`, `histogram_data`,
-  `face_embedding`) must be excluded from any bulk scan — the ranker's inference pass and
-  the viewer DB export both do this deliberately.
+- **BLOB columns** (`thumbnail`, `clip_embedding`, `caption_embedding`, `face_embedding`)
+  must be excluded from any bulk scan — the ranker's inference pass and the viewer DB
+  export both do this deliberately. `histogram_data` is the one exception: the viewer DB
+  export keeps it (unlike the ranker's inference scan, which still excludes it) because
+  `/api/photo/histogram` serves it to the viewer's RGB histogram widget.
 - **`user_preferences` holds per-user ratings** in multi-user mode; the `photos` rating
   columns are the single-user/global fallback. A feature that reads one must know which.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,17 @@ than a copy. The semantics you cannot read off a column name:
   equality rather than a window function per query.
 - **`sequence_ev_offset`** is signed the way a camera labels an AEB set: `-2` dark, `+2`
   bright. NULL for panoramas, which have no base exposure.
+- **`render_version`** marks which RAW-decode pipeline produced a row's stored
+  thumbnail: `NULL` means the row predates the current decode profile, `1` means the
+  current pipeline produced it. Only a rescan or `--refresh-thumbnails` advances the
+  stamp — browsing the library never does. See
+  [docs/CONFIGURATION.md § RAW Decode](docs/CONFIGURATION.md#raw-decode).
+- **`channel_clip_shadow_pct` / `channel_clip_highlight_pct`** are per-channel clipping
+  percentages (worst of R/G/B), `NULL` until `--backfill-clipping` or a rescan derives
+  them from a stored histogram — `NULL` means *unknown*, never *clean*, so the row
+  carries no clipping badge and matches neither side of the gallery's clipping filter.
+  Distinct from the binary `shadow_clipped`/`highlight_clipped` flags, which cover
+  luminance bands 0–30/225–255 and feed `exposure_score`.
 - **BLOB columns** (`thumbnail`, `clip_embedding`, `caption_embedding`, `histogram_data`,
   `face_embedding`) must be excluded from any bulk scan — the ranker's inference pass and
   the viewer DB export both do this deliberately.
@@ -266,7 +277,7 @@ The cache is stored in the `stats_cache` table with a 5-minute TTL. Run `--stats
 
 ### Composition Analysis
 
-Two approaches: `--recompute-composition-cpu` (rule-based, fast) and `--recompute-composition-gpu` (SAMP-Net, 14 patterns). After either, run `--recompute-average` to update aggregate scores.
+Two approaches: `--recompute-composition-cpu` (rule-based, fast) and `--recompute-composition-gpu` (SAMP-Net, 8 patterns). After either, run `--recompute-average` to update aggregate scores.
 
 ### Face Recognition
 
@@ -333,7 +344,7 @@ only what reading those two will NOT tell you.
 - **Embeddings:** SigLIP 2 NaFlex SO400M (1152-dim, 16gb/24gb, native aspect ratio via `transformers`) or CLIP ViT-L-14 (768-dim, legacy/8gb via `open_clip`)
 - **Quality:** TOPIQ (0.93 SRCC), HyperIQA (0.90), DBCNN (0.90), MUSIQ (0.87)
 - **Supplementary PyIQA:** TOPIQ IAA (aesthetic merit), TOPIQ NR-Face (face quality), LIQE (quality + distortion diagnosis)
-- **Composition:** SAMP-Net for pattern detection (14 patterns including rule_of_thirds, golden_ratio, vanishing_point)
+- **Composition:** SAMP-Net for pattern detection (8 patterns: global, horizontal, vertical, triangular, surround, quarter, cross, rule_of_thirds)
 - **Subject saliency:** BiRefNet_dynamic (`ZhengPeng7/BiRefNet_dynamic`) via `transformers` — subject sharpness, prominence, placement, background separation
 - **Faces:** InsightFace buffalo_l for detection with 106-point landmarks and recognition embeddings
 - **Tagging:** CLIP similarity (legacy/8gb), Qwen3.5-2B (16gb), Qwen3.5-4B (24gb)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,11 +216,12 @@ than a copy. The semantics you cannot read off a column name:
   equality rather than a window function per query.
 - **`sequence_ev_offset`** is signed the way a camera labels an AEB set: `-2` dark, `+2`
   bright. NULL for panoramas, which have no base exposure.
-- **`render_version`** marks which RAW-decode pipeline produced a row's stored
-  thumbnail: `NULL` means the row predates the current decode profile, `1` means the
-  current pipeline produced it. Only a rescan or `--refresh-thumbnails` advances the
-  stamp — browsing the library never does. See
-  [docs/CONFIGURATION.md § RAW Decode](docs/CONFIGURATION.md#raw-decode).
+- **`render_version`** marks WHICH RAW display render baked a row's stored thumbnail,
+  not merely how current it is: `NULL` predates the stamp, `1` is the camera-preview
+  render every scan bakes, `2` is the uncorrected render only `--refresh-thumbnails`
+  bakes for a bracketed frame. Read it against `sequence_kind`, never alone — a `1` is
+  current for an ordinary photo and stale for one a later pass groups into a bracket.
+  See `db/render_version.py`.
 - **`channel_clip_shadow_pct` / `channel_clip_highlight_pct`** are per-channel clipping
   percentages (worst of R/G/B), `NULL` until `--backfill-clipping` or a rescan derives
   them from a stored histogram — `NULL` means *unknown*, never *clean*, so the row

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,32 @@
+# Goal
+
+Land the RAW-exposure / viewer branch `fix/raw-exposure-equalization-105` on `master`,
+review-clean and green.
+
+## Done means
+
+1. All oracle stages green: lint, test, typecheck, build.
+2. `/review-all:review-all` reports **no Critical, Important or Debt findings** on the branch
+   diff vs `master`. `reviewall` is deliberately OUT of `oracle.mandatory` during iteration —
+   running a multi-agent review per micro-commit wastes quota — and MUST be re-added for the
+   close task so the gate is honest.
+3. Every finding at those three severities is fixed by a sub-agent, not inline, then re-reviewed.
+
+## Constraints
+
+- Review target is the BRANCH DIFF vs master, never the whole repo.
+- Fixing findings is delegated to sub-agents grouped by area (2-3 max), never one per finding.
+- Weekly usage cap **40%**. Baseline at arming: 7d = 27%. Check
+  `watch-quota.sh --once` at every checkpoint and STOP at 40%, reporting state.
+- STOP and report on any finding that needs a DESIGN decision — anything changing scoring
+  semantics or user-visible defaults. Do not choose for the maintainer.
+- Do not touch `photo_scores_pro.db` except read-only.
+
+## Out of scope for the loop (orchestrator does these after DONE)
+
+push, PR, CI watch, merge-commit to master, comment on issue #105, release 1.13.0 "Sténopé".
+
+## Context
+
+Full state, measured values with provenance, prior decisions and the release procedure:
+`.claude/specs/issue-105-todo.md`. Read it rather than re-deriving.

--- a/README.de.md
+++ b/README.de.md
@@ -98,7 +98,7 @@ Bewegen Sie den Mauszeiger über ein beliebiges Foto, um einen Tooltip mit der W
 - **Sortierung „Mein Geschmack“** — sortieren Sie die Galerie nach der gelernten Wertung des persönlichen Rankers, mit einem Konfidenz-Badge, das die gelernte Abdeckung und die Holdout-Genauigkeit anzeigt
 - **Lernen aus Labels** — Auswahlentscheidungen, Sternebewertungen, Favoriten und Ablehnungen fließen in den Gewichtsoptimierer ein (`--sync-label-comparisons`, `--mine-insights`)
 - **Snapshots** — Gewichtskonfigurationen speichern, wiederherstellen und vergleichen
-- **Histogramm** — Helligkeitshistogramm im Foto-Tooltip und in der Detailansicht
+- **Histogramm** — RGB-/Helligkeitshistogramm mit Clipping-Indikatoren, im Foto-Tooltip und in der Detailansicht
 - **KI-Beschreibungen** `[GPU]` `[16gb/24gb]` `[Edition]` — Textbeschreibungen, bearbeitbar und in 5 Sprachen übersetzbar
 
 <table><tr>

--- a/README.es.md
+++ b/README.es.md
@@ -98,7 +98,7 @@ Pasa el cursor sobre cualquier foto para ver un tooltip con el desglose de la pu
 - **Orden "Mi gusto"** — ordena la galería según la puntuación aprendida del clasificador personal, con una insignia de confianza que muestra la cobertura aprendida y la precisión en datos de validación
 - **Aprendizaje a partir de etiquetas** — las decisiones de selección, las valoraciones por estrellas, los favoritos y los rechazos alimentan el optimizador de pesos (`--sync-label-comparisons`, `--mine-insights`)
 - **Instantáneas** — guarda, restaura y compara configuraciones de pesos
-- **Histograma** — histograma de luminancia en el tooltip de la foto y en la vista de detalle
+- **Histograma** — histograma RGB/luminancia con indicadores de recorte, en el tooltip de la foto y en la vista de detalle
 - **Leyendas con IA** `[GPU]` `[16gb/24gb]` — descripciones de texto, editables `[Edition]` y traducibles a 5 idiomas (la generación y la visualización están abiertas)
 
 <table><tr>

--- a/README.fr.md
+++ b/README.fr.md
@@ -98,7 +98,7 @@ Survolez n'importe quelle photo pour afficher une infobulle avec le détail du s
 - **Tri « Mon goût »** — triez la galerie selon le score appris du classeur personnel, avec un badge de confiance indiquant la couverture apprise et la précision sur données de validation
 - **Apprentissage à partir des étiquettes** — les décisions de tri, les notes (étoiles), les favoris et les rejets alimentent l'optimiseur de poids (`--sync-label-comparisons`, `--mine-insights`)
 - **Instantanés** — enregistrez, restaurez et comparez des configurations de poids
-- **Histogramme** — histogramme de luminance dans l'infobulle de la photo et la vue détaillée
+- **Histogramme** — histogramme RVB/luminance avec indicateurs d'écrêtage, dans l'infobulle de la photo et la vue détaillée
 - **Légendes IA** `[GPU]` `[16gb/24gb]` — descriptions textuelles, modifiables `[Edition]` et traduisibles en 5 langues (la génération et la consultation sont ouvertes)
 
 <table><tr>

--- a/README.it.md
+++ b/README.it.md
@@ -98,7 +98,7 @@ Passa il puntatore su una foto per vedere un tooltip con il dettaglio del punteg
 - **Ordinamento "I miei gusti"** — ordina la galleria in base al punteggio appreso dal ranker personale, con un badge di confidenza che mostra la copertura appresa e l'accuratezza su dati di validazione
 - **Apprendimento dalle etichette** — le decisioni di selezione, le valutazioni a stelle, i preferiti e i rifiuti alimentano l'ottimizzatore dei pesi (`--sync-label-comparisons`, `--mine-insights`)
 - **Snapshot** — salva, ripristina e confronta le configurazioni dei pesi
-- **Istogramma** — istogramma della luminanza nel tooltip della foto e nella vista di dettaglio
+- **Istogramma** — istogramma RGB/luminanza con indicatori di clipping, nel tooltip della foto e nella vista di dettaglio
 - **Didascalie IA** `[GPU]` `[16gb/24gb]` `[Edition]` — descrizioni testuali, modificabili e traducibili in 5 lingue
 
 <table><tr>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Hover over any photo for a tooltip with the score breakdown and EXIF data.
 - **My Taste sort** — sort the gallery by the personal ranker's learned score, with a confidence badge showing learned coverage and held-out accuracy
 - **Learning from labels** — culling decisions, star ratings, favorites, and rejections feed the weight optimizer (`--sync-label-comparisons`, `--mine-insights`)
 - **Snapshots** — save, restore, and compare weight configurations
-- **Histogram** — luminance histogram in the photo tooltip and detail view
+- **Histogram** — RGB/luminance histogram with clipping indicators, in the photo tooltip and detail view
 - **AI captions** `[GPU]` `[16gb/24gb]` — text descriptions, editable `[Edition]` and translatable to 5 languages (generation and viewing are open)
 
 <table><tr>

--- a/README.pt.md
+++ b/README.pt.md
@@ -98,7 +98,7 @@ Passe o cursor sobre qualquer foto para ver uma dica com o detalhamento da pontu
 - **Ordenação Meu Gosto** — ordene a galeria pela pontuação aprendida do classificador pessoal, com um selo de confiança que mostra a cobertura aprendida e a precisão em dados separados
 - **Aprendizado a partir de rótulos** — decisões de seleção, classificações por estrelas, favoritos e rejeições alimentam o otimizador de pesos (`--sync-label-comparisons`, `--mine-insights`)
 - **Snapshots** — salve, restaure e compare configurações de pesos
-- **Histograma** — histograma de luminância na dica da foto e na visualização de detalhes
+- **Histograma** — histograma RGB/luminância com indicadores de clipping, na dica da foto e na visualização de detalhes
 - **Legendas por IA** `[GPU]` `[16gb/24gb]` — descrições em texto, editáveis `[Edition]` e traduzíveis para 5 idiomas (a geração e a visualização são abertas)
 
 <table><tr>

--- a/analyzers/technical.py
+++ b/analyzers/technical.py
@@ -6,7 +6,28 @@ Sharpness, color harmony, exposure, noise, contrast, dynamic range.
 
 import cv2
 import numpy as np
-import struct
+
+from utils.histogram import (
+    CLIP_MEASURED_CHANNELS, HIGHLIGHT_CLIP_BIN, SHADOW_CLIP_BIN, pack_histogram,
+)
+
+
+def _channel_clip_percents(red, green, blue):
+    """``(shadow_pct, highlight_pct)``: the worst channel's share of clipped pixels.
+
+    Measured here from the real per-channel counts rather than re-derived from
+    the packed BLOB, so the scan's own numbers carry no packing error at all.
+    ``utils.histogram.max_clip_percents`` reproduces these from a stored blob
+    for the rows that were written before the columns existed.
+    """
+    channels = dict(zip(CLIP_MEASURED_CHANNELS, (red, green, blue)))
+    total = float(np.asarray(red, dtype=np.float64).sum())
+    if total <= 0:
+        return 0.0, 0.0
+    return tuple(
+        round(max(float(c[index]) for c in channels.values()) / total * 100.0, 4)
+        for index in (SHADOW_CLIP_BIN, HIGHLIGHT_CLIP_BIN)
+    )
 
 
 class TechnicalAnalyzer:
@@ -140,6 +161,8 @@ class TechnicalAnalyzer:
                 'exposure_score': 5.0,
                 'shadow_clipped': 0,
                 'highlight_clipped': 0,
+                'channel_clip_shadow_pct': None,
+                'channel_clip_highlight_pct': None,
                 'is_silhouette': 0
             }
 
@@ -153,8 +176,13 @@ class TechnicalAnalyzer:
         total = hist.sum()
         hist_normalized = hist / total if total > 0 else hist
 
-        # Convert histogram to bytes for storage (256 floats as binary)
-        histogram_bytes = struct.pack('256f', *hist_normalized)
+        # image_cv is BGR; the stored channel order is R, G, B.
+        blue, green, red = (
+            cv2.calcHist([image_cv], [c], None, [256], [0, 256]).flatten()
+            for c in (0, 1, 2)
+        )
+        histogram_bytes = pack_histogram(hist, red, green, blue)
+        channel_clip_shadow, channel_clip_highlight = _channel_clip_percents(red, green, blue)
 
         # Calculate histogram spread (standard deviation of distribution)
         bins = np.arange(256)
@@ -210,6 +238,8 @@ class TechnicalAnalyzer:
             'exposure_score': round(exposure_score, 2),
             'shadow_clipped': shadow_clipped,
             'highlight_clipped': highlight_clipped,
+            'channel_clip_shadow_pct': channel_clip_shadow,
+            'channel_clip_highlight_pct': channel_clip_highlight,
             'is_silhouette': is_silhouette
         }
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -394,6 +394,7 @@ def create_app() -> FastAPI:
     from api.routers.ranker import router as ranker_router
     from api.routers.scenes import router as scenes_router
     from api.routers.saliency import router as saliency_router
+    from api.routers.histogram import router as histogram_router
     from api.routers.social_crop import router as social_crop_router
     from api.routers.portfolio import router as portfolio_router
     from api.routers.cull_preview import router as cull_preview_router
@@ -431,6 +432,7 @@ def create_app() -> FastAPI:
     app.include_router(updates_router)
     app.include_router(scenes_router)
     app.include_router(saliency_router)
+    app.include_router(histogram_router)
     app.include_router(social_crop_router)
     app.include_router(portfolio_router)
     app.include_router(cull_preview_router)

--- a/api/config.py
+++ b/api/config.py
@@ -823,11 +823,35 @@ def load_viewer_config(config=None):
             },
         },
         'display': {'tags_per_photo': 3, 'card_width_px': 168, 'image_width_px': 160, 'image_jpeg_quality': 96},
+        # Per-badge opt-out for the gallery card. Every badge that predates this
+        # block defaults to True, so an install that says nothing is unchanged.
+        # Shadow clipping is the one default-off badge: crushed blacks are
+        # routinely deliberate (silhouettes, night, low-key).
+        'badges': {
+            'favorite': True, 'star_rating': True, 'rejected': True,
+            'sequence_kind': True, 'sequence_override_pending': True,
+            'keeper_hint': True, 'best_of_burst': True,
+            'clipping_highlight': True, 'clipping_shadow': False,
+        },
+        # One definition of "clipped" for all three surfaces. The percentages are
+        # measured: over 28 sampled photos, worst-channel highlight clipping had a
+        # median of 0.31% and a p90 of 2.35%, so 5% badges roughly 1 in 25 photos
+        # and stays a signal. The histogram indicator is finer because the user is
+        # already looking at a single photo and wants the detail.
+        # histogram_mode / tooltip_histogram_mode are independent defaults: the
+        # detail panel is for studying one photo (RGB detail earns its space),
+        # the hover/pinned tooltip is for scanning many quickly (a plain
+        # luminance curve usually reads faster). Each surface persists its own
+        # user override, so tuning one default here never retunes the other.
+        'clipping': {
+            'badge_percent': 5, 'indicator_percent': 1,
+            'histogram_mode': 'rgb', 'tooltip_histogram_mode': 'luma',
+        },
         'face_thumbnails': {'output_size_px': 64, 'jpeg_quality': 80, 'crop_padding_ratio': 0.2, 'min_crop_size_px': 20},
         'quality_thresholds': {'good': 6, 'great': 7, 'excellent': 8, 'best': 9},
         'photo_types': {'top_picks_min_score': 7, 'low_light_max_luminance': 0.2},
-        'defaults': {'hide_blinks': True, 'hide_bursts': True, 'hide_duplicates': True, 'hide_brackets': True, 'hide_panoramas': True, 'hide_details': True, 'hide_rejected': True, 'sort': 'aggregate', 'sort_direction': 'DESC'},
-        'features': {'show_similar_button': True, 'show_merge_suggestions': True, 'show_rating_controls': True, 'show_rating_badge': True, 'show_semantic_search': True, 'show_albums': True, 'show_critique': True, 'show_vlm_critique': False, 'show_embed_metadata': True, 'show_memories': True, 'show_captions': True, 'show_timeline': True, 'show_map': False, 'show_capsules': True, 'show_my_taste': True, 'show_scenes': True, 'show_junk_sweep': True, 'show_proofing': False},
+        'defaults': {'hide_blinks': True, 'hide_bursts': True, 'hide_duplicates': True, 'hide_brackets': True, 'hide_panoramas': True, 'hide_details': True, 'hide_rejected': True, 'sort': 'aggregate', 'sort_direction': 'DESC', 'panel_activation': 'both'},
+        'features': {'show_similar_button': True, 'show_merge_suggestions': True, 'show_rating_controls': True, 'show_semantic_search': True, 'show_albums': True, 'show_critique': True, 'show_vlm_critique': False, 'show_embed_metadata': True, 'show_memories': True, 'show_captions': True, 'show_timeline': True, 'show_map': False, 'show_capsules': True, 'show_my_taste': True, 'show_scenes': True, 'show_junk_sweep': True, 'show_proofing': False, 'show_portfolio_export': True},
         'proofing': {'pin': '', 'session_minutes': 1440},
         'cache_ttl_seconds': 3600,
         'notification_duration_ms': 2000

--- a/api/db_helpers.py
+++ b/api/db_helpers.py
@@ -305,6 +305,7 @@ PHOTO_BASE_COLS = [
 PHOTO_OPTIONAL_COLS = [
     'histogram_spread', 'mean_luminance', 'power_point_score',
     'shadow_clipped', 'highlight_clipped', 'is_silhouette', 'is_group_portrait', 'leading_lines_score',
+    'channel_clip_shadow_pct', 'channel_clip_highlight_pct',
     'face_confidence', 'is_monochrome', 'mean_saturation',
     'dynamic_range_stops', 'noise_sigma', 'contrast_score', 'tags',
     'composition_pattern', 'quality_score', 'topiq_score',
@@ -313,6 +314,7 @@ PHOTO_OPTIONAL_COLS = [
     'subject_sharpness', 'subject_prominence', 'subject_placement', 'bg_separation',
     'star_rating', 'is_favorite', 'is_rejected',
     'duplicate_group_id', 'is_duplicate_lead',
+    'burst_group_id',
     'caption', 'caption_translated', 'gps_latitude', 'gps_longitude',
     'dominant_hue', 'color_temp',
     'form_symmetry', 'form_balance', 'form_edge_entropy', 'form_fractal', 'color_harmony',

--- a/api/models/gallery.py
+++ b/api/models/gallery.py
@@ -50,10 +50,6 @@ class Photo(BaseModel):
     mean_saturation: Optional[float] = None
     mean_luminance: Optional[float] = None
     histogram_spread: Optional[float] = None
-    # Worst-channel share of pixels pinned to bin 0 / bin 255, as a percentage.
-    # None means never measured (a pre-RGB histogram), never "clean".
-    channel_clip_shadow_pct: Optional[float] = None
-    channel_clip_highlight_pct: Optional[float] = None
     power_point_score: Optional[float] = None
     leading_lines_score: Optional[float] = None
     quality_score: Optional[float] = None

--- a/api/models/gallery.py
+++ b/api/models/gallery.py
@@ -50,6 +50,10 @@ class Photo(BaseModel):
     mean_saturation: Optional[float] = None
     mean_luminance: Optional[float] = None
     histogram_spread: Optional[float] = None
+    # Worst-channel share of pixels pinned to bin 0 / bin 255, as a percentage.
+    # None means never measured (a pre-RGB histogram), never "clean".
+    channel_clip_shadow_pct: Optional[float] = None
+    channel_clip_highlight_pct: Optional[float] = None
     power_point_score: Optional[float] = None
     leading_lines_score: Optional[float] = None
     quality_score: Optional[float] = None
@@ -196,6 +200,13 @@ class GalleryParams(BaseModel):
     max_luminance: str = ''
     min_histogram_spread: str = ''
     max_histogram_spread: str = ''
+    # Per-channel clipping (percent of pixels, worst of R/G/B). A row that was
+    # never measured is NULL and is excluded by either bound -- unknown is not
+    # clean, so it must not answer a "show me clipped photos" filter either way.
+    min_channel_clip_shadow: str = ''
+    max_channel_clip_shadow: str = ''
+    min_channel_clip_highlight: str = ''
+    max_channel_clip_highlight: str = ''
     min_power_point: str = ''
     max_power_point: str = ''
     min_leading_lines: str = ''
@@ -242,5 +253,12 @@ class GalleryParams(BaseModel):
     max_moment_confidence: str = ''
     # Path
     path_prefix: str = ''
+    # Set scope (photo-detail "open this set in the gallery"). Ephemeral: never
+    # round-tripped through the URL, because sequence_group_id is renumbered
+    # from 1 on every detection pass -- see gallery-filters.util.ts.
+    sequence_group_id: str = ''
+    sequence_kind: str = ''
+    burst_group_id: str = ''
+    duplicate_group_id: str = ''
 
     model_config = {'extra': 'ignore'}

--- a/api/raw_processing.py
+++ b/api/raw_processing.py
@@ -34,13 +34,17 @@ def _get_raw_config() -> dict:
 # Display conversion (always rawpy)
 # ---------------------------------------------------------------------------
 
-def convert_raw_to_jpeg(file_path: str, quality: int = 96) -> bytes:
+def convert_raw_to_jpeg(file_path: str, quality: int = 96,
+                        sequence_kind: str | None = None) -> bytes:
     """Convert a RAW file to JPEG bytes via rawpy/libraw.
 
     Used by the ``/image`` display endpoint.  Always uses rawpy so that the
     browser preview is independent of any darktable style configuration.
+
+    ``sequence_kind`` is the row's ``photos.sequence_kind``: a bracketed frame
+    renders with no correction at all rather than from the camera preview.
     """
-    return _convert_rawpy(file_path, quality)
+    return _convert_rawpy(file_path, quality, sequence_kind)
 
 
 # ---------------------------------------------------------------------------
@@ -213,19 +217,21 @@ def _find_companion_raw_cached(stem: str, parent_dir: str, raw_extensions: set[s
 # Internal backends
 # ---------------------------------------------------------------------------
 
-def _convert_rawpy(file_path: str, quality: int) -> bytes:
-    """Convert via rawpy/libraw."""
-    import rawpy
-    from PIL import Image as PILImage
+def _convert_rawpy(file_path: str, quality: int, sequence_kind: str | None = None) -> bytes:
+    """Convert via rawpy/libraw.
 
-    with rawpy.imread(file_path) as raw:
-        rgb = raw.postprocess(
-            use_camera_wb=True,
-            no_auto_bright=False,
-            output_color=rawpy.ColorSpace.sRGB,
-            output_bps=8,
-        )
-    pil_img = PILImage.fromarray(rgb)
+    Serves the camera-embedded preview when it covers enough of the sensor to
+    pass for the full frame; the rest demosaic. Preview coverage is a body
+    decision, not a brand one: Nikon, Pentax, Samsung and Canon CR3 embed a
+    near-full-size preview, while Sony, Fuji, Olympus and DNG embed a small one.
+    """
+    from utils.image_loading import get_raw_decode_settings, load_display_image
+
+    ratio = float(get_raw_decode_settings()['preview_min_sensor_ratio'])
+    pil_img = load_display_image(file_path, min_preview_sensor_ratio=ratio,
+                                decode_budget='viewer', sequence_kind=sequence_kind)
+    if pil_img is None:
+        raise RuntimeError(f"RAW decode failed: {file_path}")
     buffer = BytesIO()
     pil_img.save(buffer, format='JPEG', quality=quality)
     return buffer.getvalue()

--- a/api/routers/albums.py
+++ b/api/routers/albums.py
@@ -427,9 +427,10 @@ def list_albums(
         total = row[0] if row else 0
 
         # Paginated fetch
-        _SORT_MAP = {'updated_at': 'updated_at DESC', 'name': 'name ASC', 'photo_count': 'photo_count_cache DESC'}
+        _SORT_MAP = {'updated_at': 'updated_at DESC', 'name': 'name ASC'}
         order_by = _SORT_MAP.get(sort, 'updated_at DESC')
-        # photo_count sort needs a subquery since it's not a column
+        # photo_count has no column of its own — always resolved via this subquery,
+        # never through _SORT_MAP, since album_photos rows are not cached on albums
         if sort == 'photo_count':
             order_by = '(SELECT COUNT(*) FROM album_photos WHERE album_id = albums.id) DESC'
         total_pages, offset = paginate(total, page, per_page)

--- a/api/routers/burst_culling.py
+++ b/api/routers/burst_culling.py
@@ -1830,11 +1830,12 @@ def _fetch_bracket_groups(conn, user_id, vis_sql, vis_params, album_id=None,
             continue
         for photo in photos:
             photo['burst_score'] = round(_compute_burst_score(photo), 2)
-        span = max(abs(p.get('sequence_ev_offset') or 0) for p in photos)
+        offsets = [p.get('sequence_ev_offset') or 0 for p in photos]
+        span = max(offsets) - min(offsets)
         groups.append({
             'group_id': seq_id,
             'type': 'bracket',
-            'reason': f'{len(photos)} frames, ±{span:g} EV',
+            'reason': f'{len(photos)} frames, {span:g} EV span',
             'photos': photos,
             'best_path': photos[0]['path'],
             'count': len(photos),

--- a/api/routers/comparison.py
+++ b/api/routers/comparison.py
@@ -202,7 +202,7 @@ def _validate_and_resolve(path: str, user: Optional[CurrentUser]):
         user_id = user.user_id if user else None
         vis_sql, vis_params = get_visibility_clause(user_id)
         row = conn.execute(
-            f"SELECT path FROM photos WHERE path = ? AND {vis_sql}",
+            f"SELECT path, sequence_kind FROM photos WHERE path = ? AND {vis_sql}",
             [path] + vis_params
         ).fetchone()
 
@@ -211,7 +211,7 @@ def _validate_and_resolve(path: str, user: Optional[CurrentUser]):
 
     db_path = row['path']
     real_disk = resolve_photo_disk_path(db_path)
-    return db_path, real_disk
+    return db_path, real_disk, row['sequence_kind']
 
 
 @router.get("/api/download/options")
@@ -223,7 +223,7 @@ def api_download_options(
     """Return available download types for a photo."""
     from api.raw_processing import find_companion_raw, get_darktable_profiles
 
-    db_path, real_disk = _validate_and_resolve(path, user)
+    db_path, real_disk, _ = _validate_and_resolve(path, user)
 
     options: list[dict] = [{'type': 'original', 'label': 'original'}]
 
@@ -255,7 +255,7 @@ async def api_download_single(
     """
     from api.raw_processing import convert_raw_darktable_async, find_companion_raw
 
-    db_path, real_disk = _validate_and_resolve(path, user)
+    db_path, real_disk, sequence_kind = _validate_and_resolve(path, user)
 
     quality = VIEWER_CONFIG['display'].get('image_jpeg_quality', 96)
     stem = os.path.splitext(os.path.basename(db_path))[0]
@@ -265,7 +265,7 @@ async def api_download_single(
         raw_path = find_companion_raw(real_disk)
         if not raw_path:
             # Fall back to original when no RAW companion exists
-            return _serve_original(real_disk, db_path, quality)
+            return _serve_original(real_disk, db_path, quality, sequence_kind)
 
         try:
             jpeg_bytes = await convert_raw_darktable_async(raw_path, profile, quality)
@@ -287,7 +287,7 @@ async def api_download_single(
     if type == 'raw':
         raw_path = find_companion_raw(real_disk)
         if not raw_path:
-            return _serve_original(real_disk, db_path, quality)
+            return _serve_original(real_disk, db_path, quality, sequence_kind)
 
         return FileResponse(
             raw_path,
@@ -296,16 +296,25 @@ async def api_download_single(
         )
 
     # --- Original file download ---
-    return _serve_original(real_disk, db_path, quality)
+    return _serve_original(real_disk, db_path, quality, sequence_kind)
 
 
-def _serve_original(real_disk: str, db_path: str, quality: int):
-    """Serve a photo file as-is, converting standalone RAW via rawpy."""
+def _serve_original(real_disk: str, db_path: str, quality: int,
+                    sequence_kind: Optional[str] = None):
+    """Serve a photo file as-is, converting standalone RAW via rawpy.
+
+    "As-is" is why a bracketed frame is converted with no correction at all,
+    exactly as ``/image`` serves it: the camera preview's tone curve and the
+    ``bright`` gain both crush the highlight headroom the bracket was shot to
+    capture, and a downloaded bracket frame is on its way to an HDR merge where
+    that headroom is the payload. The edited look is what the ``darktable``
+    download type is for.
+    """
     from api.raw_processing import convert_raw_to_jpeg
 
     if Path(real_disk).suffix.lower() in RAW_EXTENSIONS:
         try:
-            jpeg_bytes = convert_raw_to_jpeg(real_disk, quality)
+            jpeg_bytes = convert_raw_to_jpeg(real_disk, quality, sequence_kind)
         except Exception:
             logger.exception("Failed to convert RAW file for download: %s", real_disk)
             raise HTTPException(status_code=500, detail='Failed to convert RAW file')

--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -256,16 +256,14 @@ def _validate_target_dir(target_dir):
     """Canonicalize ``target_dir`` and require it under an allowed export root.
 
     Without this an edition user could copy/symlink album photos to an arbitrary
-    host location (path traversal / symlink planting). Fail-closed: if no roots
-    are configured, copy/symlink export is refused rather than writing anywhere.
+    host location (path traversal / symlink planting). Fail-closed: a target
+    outside every configured root (including the case where none are
+    configured at all) is refused rather than writing anywhere. The caller is
+    already edition-authenticated, so the 403 names the config key and the
+    resolved roots — a misconfiguration is otherwise unfixable from the UI.
     """
     real = os.path.realpath(target_dir)
     roots = _allowed_export_roots()
-    if not roots:
-        raise HTTPException(
-            status_code=403,
-            detail="Copy/symlink export is disabled — configure viewer.export.allowed_target_dirs",
-        )
     # Two separate guards rather than any(...) or an or-condition: the direct
     # startswith true-branch is the containment shape static analysis credits
     # as a sanitizer, and the equality case returns the config-derived root
@@ -275,7 +273,14 @@ def _validate_target_dir(target_dir):
             return root
         if real.startswith(root + os.sep):
             return real
-    raise HTTPException(status_code=403, detail="target_dir is not an allowed export location")
+    allowed = ", ".join(roots) if roots else "none configured"
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            "target_dir is not an allowed export location. Configure "
+            f"viewer.export.allowed_target_dirs to add one — allowed roots: {allowed}"
+        ),
+    )
 
 
 def _contained_dest(target_dir, filename):

--- a/api/routers/gallery.py
+++ b/api/routers/gallery.py
@@ -30,6 +30,8 @@ from api.types import (
     JUNK_ANY, JUNK_NOT_JUNK,
     SEQUENCE_OVERRIDE_FORCED, SEQUENCE_OVERRIDE_SUPPRESSED, SEQUENCE_OVERRIDE_VALUES,
 )
+from utils.histogram import unpack_histogram
+from utils.sequence import BRACKET as BRACKET_KIND
 
 router = APIRouter(tags=["gallery"])
 logger = logging.getLogger(__name__)
@@ -265,6 +267,48 @@ def _apply_sequence_override_filter(where_clauses, params):
         f"WHERE 1=1{kind_sql})")
 
 
+def _active_set_scope(params):
+    """The (kind, group_id) of the set-scope filter in `params`, or (None, None).
+
+    Priority mirrors `GET /api/photo/set`: sequence, then burst, then
+    duplicate. Ephemeral -- see `sequence_group_id` on `GalleryParams` --
+    so this is read straight from the request params, never the URL.
+    """
+    sequence_kind = params.get('sequence_kind')
+    sequence_group_id = params.get('sequence_group_id')
+    if sequence_kind and sequence_group_id:
+        return sequence_kind, sequence_group_id
+    burst_group_id = params.get('burst_group_id')
+    if burst_group_id:
+        return 'burst', burst_group_id
+    duplicate_group_id = params.get('duplicate_group_id')
+    if duplicate_group_id:
+        return 'duplicate', duplicate_group_id
+    return None, None
+
+
+def _apply_set_scope_filter(where_clauses, sql_params, params):
+    """Narrow the gallery to one bracket/panorama/burst/duplicate set.
+
+    Powers the photo-detail "open this set in the gallery" action. Never
+    driven by the URL -- `sequence_group_id` is renumbered from 1 on every
+    detection pass, so a bookmarked scope would silently resolve to a
+    different set later (see gallery-filters.util.ts).
+    """
+    kind, group_id = _active_set_scope(params)
+    if kind is None:
+        return
+    if kind == 'burst':
+        where_clauses.append("photos.burst_group_id = ?")
+        sql_params.append(group_id)
+    elif kind == 'duplicate':
+        where_clauses.append("photos.duplicate_group_id = ?")
+        sql_params.append(group_id)
+    else:
+        where_clauses.append("photos.sequence_kind = ? AND photos.sequence_group_id = ?")
+        sql_params.extend([kind, group_id])
+
+
 def _quality_tier_bounds(tier):
     """Return (min, max) aggregate bounds for a quality tier, or None if invalid.
 
@@ -343,6 +387,23 @@ def _apply_visibility_and_hide_filters(where_clauses, sql_params, params, user_i
     hide_duplicates_val = params.get('hide_duplicates', '')
     hide_brackets_val = params.get('hide_brackets', '')
     hide_panoramas_val = params.get('hide_panoramas', '')
+
+    # A set-scope filter must show every frame of the set it scoped to, not
+    # just the one representative the matching hide toggle would keep -- the
+    # toggles default on, so without this the "open this set in the gallery"
+    # action would land on a gallery showing the single lead tile the user
+    # came from. ALL FOUR toggles are suppressed, not just the one matching
+    # the scope's own kind: a photo can belong to a bracket AND a burst AND a
+    # duplicate group at once (an AEB set fired in continuous drive mode is
+    # both a bracket and a burst), so any one of them could still collapse
+    # the very set the user asked to see.
+    scope_kind, _ = _active_set_scope(params)
+    if scope_kind is not None:
+        hide_bursts_val = ''
+        hide_duplicates_val = ''
+        hide_brackets_val = ''
+        hide_panoramas_val = ''
+
     where_clauses.extend(build_hide_clauses(
         hide_blinks_val, hide_bursts_val, hide_duplicates_val, hide_brackets_val,
         hide_panoramas_val))
@@ -382,6 +443,8 @@ SCORE_RANGE_COLUMNS = [
     ("mean_saturation", "min_saturation", "max_saturation", True),
     ("mean_luminance", "min_luminance", "max_luminance", True),
     ("histogram_spread", "min_histogram_spread", "max_histogram_spread", True),
+    ("channel_clip_shadow_pct", "min_channel_clip_shadow", "max_channel_clip_shadow", True),
+    ("channel_clip_highlight_pct", "min_channel_clip_highlight", "max_channel_clip_highlight", True),
     ("dynamic_range_stops", "min_dynamic_range", "max_dynamic_range", True),
     ("comp_score", "min_composition", "max_composition", True),
     ("power_point_score", "min_power_point", "max_power_point", True),
@@ -480,6 +543,7 @@ def _build_gallery_where(params, conn=None, user_id=None):
     _apply_exif_range_filters(where_clauses, sql_params, params)
     _apply_color_quality_filters(where_clauses, sql_params, params)
     _apply_date_album_geo_filters(where_clauses, sql_params, params)
+    _apply_set_scope_filter(where_clauses, sql_params, params)
     return where_clauses, sql_params
 
 
@@ -516,6 +580,106 @@ async def api_photo(
         raise
     except sqlite3.Error:
         logger.exception("Failed to fetch photo details")
+        raise HTTPException(status_code=500, detail='Internal server error')
+
+
+_EMPTY_PHOTO_SET = {'kind': None, 'group_id': None, 'count': 0, 'ev_span': None, 'members': []}
+
+
+async def _fetch_sequence_set(conn, vis_sql, vis_params, kind, group_id):
+    """A bracket/panorama/hdr_panorama set, base exposure or capture order.
+
+    Ordering and `ev_span` mirror the culling-group fetchers in
+    burst_culling.py: a bracket orders by distance from its base exposure, a
+    panorama has no base so it orders by capture time; only a bracket has an
+    EV span to report, since `sequence_ev_offset` is NULL for panoramas.
+    """
+    order_col = "ABS(sequence_ev_offset)" if kind == BRACKET_KIND else "date_taken"
+    cur = await conn.execute(
+        f"""SELECT path, sequence_ev_offset, is_sequence_lead
+            FROM photos
+            WHERE sequence_kind = ? AND sequence_group_id = ? AND {vis_sql}
+            ORDER BY {order_col}, path""",
+        [kind, group_id, *vis_params],
+    )
+    rows = await cur.fetchall()
+    await cur.close()
+    members = [
+        {'path': r['path'], 'ev_offset': r['sequence_ev_offset'], 'is_lead': bool(r['is_sequence_lead'])}
+        for r in rows
+    ]
+    ev_span = None
+    if kind == BRACKET_KIND:
+        offsets = [m['ev_offset'] for m in members if m['ev_offset'] is not None]
+        if offsets:
+            ev_span = max(abs(o) for o in offsets)
+    return {'kind': kind, 'group_id': group_id, 'count': len(members), 'ev_span': ev_span, 'members': members}
+
+
+async def _fetch_grouped_set(conn, vis_sql, vis_params, kind, group_col, lead_col, group_id):
+    """A burst or duplicate set, in capture order. Neither carries an EV offset."""
+    cur = await conn.execute(
+        f"""SELECT path, {lead_col}
+            FROM photos
+            WHERE {group_col} = ? AND {vis_sql}
+            ORDER BY date_taken, path""",
+        [group_id, *vis_params],
+    )
+    rows = await cur.fetchall()
+    await cur.close()
+    members = [
+        {'path': r['path'], 'ev_offset': None, 'is_lead': bool(r[lead_col])}
+        for r in rows
+    ]
+    return {'kind': kind, 'group_id': group_id, 'count': len(members), 'ev_span': None, 'members': members}
+
+
+@router.get("/api/photo/set")
+async def api_photo_set(
+    path: str = Query(...),
+    user: Optional[CurrentUser] = Depends(get_optional_user),
+):
+    """Resolve the bracket/panorama/burst/duplicate set a photo belongs to.
+
+    Precedence is sequence, then burst, then duplicate, resolved from the
+    photo's own row -- never from a group id, which is not stable across
+    runs. The pair `(sequence_kind, sequence_group_id)` is a sequence set's
+    real identity: the bracket and panorama passes each renumber their groups
+    from 1 on every run and own disjoint rows, so grouping by
+    `sequence_group_id` alone would merge unrelated sets. See
+    .claude/patterns/panorama-detection.md.
+    """
+    try:
+        async with get_async_db() as conn:
+            user_id = user.user_id if user else None
+            vis_sql, vis_params = get_visibility_clause(user_id)
+
+            cur = await conn.execute(
+                f"""SELECT sequence_kind, sequence_group_id, burst_group_id, duplicate_group_id
+                    FROM photos WHERE path = ? AND {vis_sql}""",
+                [path, *vis_params],
+            )
+            row = await cur.fetchone()
+            await cur.close()
+            if not row:
+                raise HTTPException(status_code=404, detail="Photo not found")
+
+            if row['sequence_kind'] and row['sequence_group_id'] is not None:
+                return await _fetch_sequence_set(
+                    conn, vis_sql, vis_params, row['sequence_kind'], row['sequence_group_id'])
+            if row['burst_group_id'] is not None:
+                return await _fetch_grouped_set(
+                    conn, vis_sql, vis_params, 'burst', 'burst_group_id', 'is_burst_lead', row['burst_group_id'])
+            if row['duplicate_group_id'] is not None:
+                return await _fetch_grouped_set(
+                    conn, vis_sql, vis_params, 'duplicate', 'duplicate_group_id', 'is_duplicate_lead',
+                    row['duplicate_group_id'])
+
+            return dict(_EMPTY_PHOTO_SET)
+    except HTTPException:
+        raise
+    except sqlite3.Error:
+        logger.exception("Failed to resolve photo set")
         raise HTTPException(status_code=500, detail='Internal server error')
 
 
@@ -1018,16 +1182,20 @@ def _find_similar_color(conn, source, photo_path, min_similarity, vis_sql, vis_p
     """Find photos with similar color palette using histogram intersection + saturation/luminance."""
     import numpy as np
 
-    src_hist_blob = source.get('histogram_data')
-    if not src_hist_blob:
+    src_decoded = unpack_histogram(source.get('histogram_data'))
+    if src_decoded is None:
         return [], 'no_histogram'
 
     src_mono = source.get('is_monochrome', 0)
     src_sat = source.get('mean_saturation', 0) or 0
     src_lum = source.get('mean_luminance', 0) or 0
 
-    # Decode source histogram (256 float32 = 1024 bytes)
-    src_hist = np.frombuffer(src_hist_blob, dtype=np.float32).copy()
+    # Luminance only, even for a photo whose blob carries the R/G/B channels: a
+    # library mid-rescan holds both formats, so a per-channel term would score
+    # rescanned candidates on a different scale than legacy ones and shuffle the
+    # ranking by scan order rather than by colour. The chroma signal stays in the
+    # saturation and monochrome terms below, which every row has.
+    src_hist = src_decoded['luma']
     src_norm = src_hist.sum()
     if src_norm > 0:
         src_hist = src_hist / src_norm
@@ -1046,7 +1214,10 @@ def _find_similar_color(conn, source, photo_path, min_similarity, vis_sql, vis_p
     results = []
     for r in rows:
         r = dict(r)
-        cand_hist = np.frombuffer(r['histogram_data'], dtype=np.float32).copy()
+        cand_decoded = unpack_histogram(r['histogram_data'])
+        if cand_decoded is None:
+            continue
+        cand_hist = cand_decoded['luma']
         cand_norm = cand_hist.sum()
         if cand_norm > 0:
             cand_hist = cand_hist / cand_norm
@@ -1244,6 +1415,25 @@ def _social_export_presets() -> dict:
     return {'presets': presets}
 
 
+def _render_migration_status():
+    """How many RAW rows still carry a thumbnail from the old render profile.
+
+    ``/api/config`` is on the SPA's startup path, so the number comes from the
+    ``stats_cache`` entry (``db.stats_cache.get_pending_render_count``) rather
+    than from a scan of ``photos``: the exact count is recomputed at most once
+    per TTL, and is refreshed outright by ``--refresh-thumbnails`` and
+    ``--refresh-stats``.
+    """
+    from db.stats_cache import get_pending_render_count
+
+    try:
+        pending = get_pending_render_count()
+    except sqlite3.Error:
+        logger.debug("Could not read the render-migration count", exc_info=True)
+        return {'pending': 0}
+    return {'pending': pending}
+
+
 @router.get("/api/config")
 def api_config(user: Optional[CurrentUser] = Depends(get_optional_user)):
     """Get viewer configuration for Angular client initialization."""
@@ -1285,6 +1475,8 @@ def api_config(user: Optional[CurrentUser] = Depends(get_optional_user)):
         'defaults': VIEWER_CONFIG['defaults'],
         'pagination': VIEWER_CONFIG['pagination'],
         'display': VIEWER_CONFIG['display'],
+        'badges': VIEWER_CONFIG['badges'],
+        'clipping': VIEWER_CONFIG['clipping'],
         'features': features,
         'quality_thresholds': VIEWER_CONFIG['quality_thresholds'],
         'social_export': _social_export_presets(),
@@ -1295,4 +1487,5 @@ def api_config(user: Optional[CurrentUser] = Depends(get_optional_user)):
         'is_multi_user': is_multi_user_enabled(),
         'edition_enabled': is_edition_enabled(),
         'edition_authenticated': is_edition_authenticated(user),
+        'render_migration': _render_migration_status(),
     }

--- a/api/routers/gallery.py
+++ b/api/routers/gallery.py
@@ -593,6 +593,10 @@ async def _fetch_sequence_set(conn, vis_sql, vis_params, kind, group_id):
     burst_culling.py: a bracket orders by distance from its base exposure, a
     panorama has no base so it orders by capture time; only a bracket has an
     EV span to report, since `sequence_ev_offset` is NULL for panoramas.
+
+    `ev_span` is the total stops between the darkest and the brightest frame,
+    NOT a symmetric ± bound: a set shot at -3/-1/+1 covers four stops, and the
+    largest offset in it says three.
     """
     order_col = "ABS(sequence_ev_offset)" if kind == BRACKET_KIND else "date_taken"
     cur = await conn.execute(
@@ -612,7 +616,7 @@ async def _fetch_sequence_set(conn, vis_sql, vis_params, kind, group_id):
     if kind == BRACKET_KIND:
         offsets = [m['ev_offset'] for m in members if m['ev_offset'] is not None]
         if offsets:
-            ev_span = max(abs(o) for o in offsets)
+            ev_span = max(offsets) - min(offsets)
     return {'kind': kind, 'group_id': group_id, 'count': len(members), 'ev_span': ev_span, 'members': members}
 
 

--- a/api/routers/histogram.py
+++ b/api/routers/histogram.py
@@ -1,0 +1,77 @@
+"""Per-photo RGB + luminance histogram, served from the stored BLOB.
+
+The bins come from ``photos.histogram_data``, which is computed during the scan
+on the full-resolution *metrics* decode of the file — the faithful demosaic for
+a RAW, not the embedded camera preview. That is strictly better than what the
+client can measure for itself: the widget's fallback samples a <=160px q80 JPEG
+thumbnail whose chroma is 4:2:0 subsampled, so its R and B curves are largely
+interpolated.
+
+A photo whose row predates the RGB format still answers with luminance only
+(``r``/``g``/``b`` null); a row with no blob at all 404s, which is the client's
+signal to fall back to sampling the thumbnail.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from api.auth import CurrentUser, get_optional_user
+from api.database import get_db
+from api.db_helpers import get_visibility_clause
+from utils.histogram import clip_percents, display_channels, unpack_histogram
+
+router = APIRouter(tags=["histogram"])
+
+# Divisors of the stored 256 bins, so downsampling is an exact regroup rather
+# than a resample. 64 matches the width the widget draws at.
+DISPLAY_BIN_CHOICES = (32, 64, 128, 256)
+DEFAULT_DISPLAY_BINS = 64
+
+# The blob only changes on a rescan, and the widget is re-rendered on every
+# gallery hover, so a short private cache saves a request per re-hover.
+_CACHE_CONTROL = "private, max-age=300"
+
+
+@router.get("/api/photo/histogram")
+def api_photo_histogram(
+    response: Response,
+    path: str = Query(...),
+    bins: int = Query(DEFAULT_DISPLAY_BINS),
+    user: Optional[CurrentUser] = Depends(get_optional_user),
+):
+    """Draw-ready luminance + R/G/B bins for one photo, in ``[0, 1]``.
+
+    Every channel is divided by the single largest bin across all four, never by
+    its own maximum: per-channel scaling would stretch a near-empty channel to
+    full height and show a colour cast the photo does not have.
+
+    The curves cover the interior bins only. ``clipped`` carries what bins 0 and
+    255 hold, as a percentage of pixels per channel, for the end markers — it is
+    ``null`` for a pre-RGB histogram, which means *unknown*, not clean.
+    """
+    if bins not in DISPLAY_BIN_CHOICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"bins must be one of {', '.join(str(b) for b in DISPLAY_BIN_CHOICES)}",
+        )
+
+    vis_sql, vis_params = get_visibility_clause(user.user_id if user else None)
+    with get_db() as conn:
+        row = conn.execute(
+            f"SELECT histogram_data FROM photos WHERE path = ? AND {vis_sql}",
+            [path] + vis_params,
+        ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Unknown photo")
+
+    decoded = unpack_histogram(row["histogram_data"])
+    if decoded is None:
+        raise HTTPException(status_code=404, detail="No histogram for this photo")
+
+    response.headers["Cache-Control"] = _CACHE_CONTROL
+    return {
+        "bins": bins,
+        **display_channels(decoded, bins),
+        "clipped": clip_percents(decoded),
+    }

--- a/api/routers/thumbnails.py
+++ b/api/routers/thumbnails.py
@@ -75,11 +75,17 @@ def _get_image_jpeg_quality() -> int:
 
 
 @lru_cache(maxsize=5)
-def _convert_raw_cached(file_path: str, mtime: float, quality: int = 96) -> bytes:
-    """Convert a RAW file to JPEG bytes, cached by path+mtime+quality."""
+def _convert_raw_cached(file_path: str, mtime: float, quality: int = 96,
+                        sequence_kind: Optional[str] = None) -> bytes:
+    """Convert a RAW file to JPEG bytes, cached by path+mtime+quality+sequence kind.
+
+    The sequence kind is part of the key because it selects the rendering: a
+    frame relabelled as a bracket by a later detection pass must not keep
+    serving the camera-preview render cached before it.
+    """
     from api.raw_processing import convert_raw_to_jpeg
 
-    return convert_raw_to_jpeg(file_path, quality)
+    return convert_raw_to_jpeg(file_path, quality, sequence_kind)
 
 
 @lru_cache(maxsize=32)
@@ -291,11 +297,15 @@ def image(
     404/500 when the original is unavailable (e.g. an offline volume) or fails to
     convert. The loupe in Scenes/Culling uses this so it degrades to the embedded
     thumbnail rather than going blank.
+
+    ``sequence_kind`` rides along on the visibility query rather than costing a
+    second round trip: it selects how a RAW renders (see
+    ``utils.image_loading.renders_faithfully``).
     """
     vis_sql, vis_params = get_visibility_clause(user.user_id if user else None)
     with get_db() as conn:
         row = conn.execute(
-            f"SELECT path FROM photos WHERE path = ? AND {vis_sql}",
+            f"SELECT path, sequence_kind FROM photos WHERE path = ? AND {vis_sql}",
             [path, *vis_params],
         ).fetchone()
     if not row:
@@ -315,7 +325,7 @@ def image(
         try:
             mtime = os.path.getmtime(real_disk)
             quality = _get_image_jpeg_quality()
-            jpeg_bytes = _convert_raw_cached(real_disk, mtime, quality)
+            jpeg_bytes = _convert_raw_cached(real_disk, mtime, quality, row['sequence_kind'])
             return _cached_image_response(jpeg_bytes, request)
         except (OSError, ValueError):
             logger.exception("Failed to convert RAW file: %s", real_disk)

--- a/api/routers/thumbnails.py
+++ b/api/routers/thumbnails.py
@@ -327,7 +327,7 @@ def image(
             quality = _get_image_jpeg_quality()
             jpeg_bytes = _convert_raw_cached(real_disk, mtime, quality, row['sequence_kind'])
             return _cached_image_response(jpeg_bytes, request)
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             logger.exception("Failed to convert RAW file: %s", real_disk)
             if want_fallback:
                 return _stored_thumbnail_response(path, request)

--- a/calibrate.py
+++ b/calibrate.py
@@ -61,7 +61,7 @@ EXTRA_COLUMNS = [
     'noise_sigma', 'shadow_clipped', 'highlight_clipped',
     'histogram_bimodality', 'mean_saturation', 'is_blink',
     'is_monochrome', 'is_silhouette', 'face_ratio', 'face_count',
-    'ISO', 'shutter_speed', 'tags', 'luminance',
+    'iso', 'shutter_speed', 'tags', 'mean_luminance',
 ]
 
 MIN_PHOTOS_FOR_CATEGORY = 100
@@ -746,7 +746,7 @@ def _analyze_numeric_filters(
     filter_metrics = {
         'face_ratio_min': ('face_ratio', 'min'),
         'face_ratio_max': ('face_ratio', 'max'),
-        'luminance_max': ('luminance', 'max'),
+        'luminance_max': ('mean_luminance', 'max'),
         'shutter_speed_min': ('shutter_speed', 'min'),
         'shutter_speed_max': ('shutter_speed', 'max'),
     }
@@ -895,7 +895,7 @@ def optimize_modifiers(
 
     weights = cat_cfg.get('weights', {})
     modifiers = cat_cfg.get('modifiers', {})
-    penalty_settings = config_data.get('penalty_settings', {})
+    penalty_settings = config_data.get('penalties', {})
 
     # Current modifier values
     current_bonus = modifiers.get('bonus', 0.0)

--- a/client/src/app/app.html
+++ b/client/src/app/app.html
@@ -272,10 +272,34 @@
               <mat-icon>view_sidebar</mat-icon>
               {{ I18N.gallery.tooltip_mode.panel | translate }}
             </button>
+            @if (store.filters().tooltip_mode === 'panel') {
+              <button mat-menu-item [matMenuTriggerFor]="panelActivationMenu">
+                <mat-icon>{{
+                  store.filters().panel_activation === 'hover' ? 'chat_bubble_outline'
+                  : store.filters().panel_activation === 'click' ? 'touch_app'
+                  : 'swap_horiz'
+                }}</mat-icon>
+                {{ I18N.gallery.panel_activation.label | translate }}
+              </button>
+            }
           }
           <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'off')">
             <mat-icon>visibility_off</mat-icon>
             {{ I18N.gallery.tooltip_mode.off | translate }}
+          </button>
+        </mat-menu>
+        <mat-menu #panelActivationMenu="matMenu">
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'hover')">
+            <mat-icon>chat_bubble_outline</mat-icon>
+            {{ I18N.gallery.panel_activation.hover | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'click')">
+            <mat-icon>touch_app</mat-icon>
+            {{ I18N.gallery.panel_activation.click | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'both')">
+            <mat-icon>swap_horiz</mat-icon>
+            {{ I18N.gallery.panel_activation.both | translate }}
           </button>
         </mat-menu>
       }
@@ -543,10 +567,34 @@
               <mat-icon>view_sidebar</mat-icon>
               {{ I18N.gallery.tooltip_mode.panel | translate }}
             </button>
+            @if (store.filters().tooltip_mode === 'panel') {
+              <button mat-menu-item [matMenuTriggerFor]="panelActivationMenuMobile">
+                <mat-icon>{{
+                  store.filters().panel_activation === 'hover' ? 'chat_bubble_outline'
+                  : store.filters().panel_activation === 'click' ? 'touch_app'
+                  : 'swap_horiz'
+                }}</mat-icon>
+                {{ I18N.gallery.panel_activation.label | translate }}
+              </button>
+            }
           }
           <button mat-menu-item (click)="store.updateFilter('tooltip_mode', 'off')">
             <mat-icon>visibility_off</mat-icon>
             {{ I18N.gallery.tooltip_mode.off | translate }}
+          </button>
+        </mat-menu>
+        <mat-menu #panelActivationMenuMobile="matMenu">
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'hover')">
+            <mat-icon>chat_bubble_outline</mat-icon>
+            {{ I18N.gallery.panel_activation.hover | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'click')">
+            <mat-icon>touch_app</mat-icon>
+            {{ I18N.gallery.panel_activation.click | translate }}
+          </button>
+          <button mat-menu-item (click)="store.updateFilter('panel_activation', 'both')">
+            <mat-icon>swap_horiz</mat-icon>
+            {{ I18N.gallery.panel_activation.both | translate }}
           </button>
         </mat-menu>
 

--- a/client/src/app/core/i18n/keys.ts
+++ b/client/src/app/core/i18n/keys.ts
@@ -560,6 +560,7 @@ export const I18N = {
     edition_expired: "errors.edition_expired",
     server_error: "errors.server_error",
     action_failed: "errors.action_failed",
+    server_detail: "errors.server_detail",
   },
   language: {
     en: "language.en",
@@ -2336,6 +2337,7 @@ export const I18N = {
       ev_span: "photo_detail.set.ev_span",
       kind_duplicate: "photo_detail.set.kind_duplicate",
       open_in_gallery: "photo_detail.set.open_in_gallery",
+      member_position: "photo_detail.set.member_position",
     },
   },
   photo: {

--- a/client/src/app/core/i18n/keys.ts
+++ b/client/src/app/core/i18n/keys.ts
@@ -218,7 +218,8 @@ export const I18N = {
     form_fractal: "tooltip.form_fractal",
     color_harmony: "tooltip.color_harmony",
     caption: "tooltip.caption",
-    persons: "tooltip.persons",
+    filter_by_person: "tooltip.filter_by_person",
+    set_section: "tooltip.set_section",
     histogram: "tooltip.histogram",
   },
   photoCard: {
@@ -1049,6 +1050,13 @@ export const I18N = {
       restore: "gallery.hidden_banner.restore",
       showing_all: "gallery.hidden_banner.showing_all",
     },
+    render_migration: {
+      message: "gallery.render_migration.message",
+      command_hint: "gallery.render_migration.command_hint",
+    },
+    set_scope: {
+      message: "gallery.set_scope.message",
+    },
     all_photos: "gallery.all_photos",
     sort: "gallery.sort",
     sort_aggregate: "gallery.sort_aggregate",
@@ -1095,6 +1103,12 @@ export const I18N = {
       panel: "gallery.tooltip_mode.panel",
       off: "gallery.tooltip_mode.off",
       panel_empty: "gallery.tooltip_mode.panel_empty",
+    },
+    panel_activation: {
+      label: "gallery.panel_activation.label",
+      hover: "gallery.panel_activation.hover",
+      click: "gallery.panel_activation.click",
+      both: "gallery.panel_activation.both",
     },
     hide_blinks: "gallery.hide_blinks",
     hide_bursts: "gallery.hide_bursts",
@@ -1255,6 +1269,12 @@ export const I18N = {
       hint: "gallery.compare.hint",
       reset_zoom: "gallery.compare.reset_zoom",
     },
+    clipping: {
+      badge_highlight: "gallery.clipping.badge_highlight",
+      badge_shadow: "gallery.clipping.badge_shadow",
+    },
+    channel_clip_highlight_range: "gallery.channel_clip_highlight_range",
+    channel_clip_shadow_range: "gallery.channel_clip_shadow_range",
   },
   composition_patterns: {
     none: "composition_patterns.none",
@@ -2311,6 +2331,12 @@ export const I18N = {
     translating_caption: "photo_detail.translating_caption",
     location: "photo_detail.location",
     social_crop: "photo_detail.social_crop",
+    set: {
+      title: "photo_detail.set.title",
+      ev_span: "photo_detail.set.ev_span",
+      kind_duplicate: "photo_detail.set.kind_duplicate",
+      open_in_gallery: "photo_detail.set.open_in_gallery",
+    },
   },
   photo: {
     category_override: {
@@ -2482,6 +2508,20 @@ export const I18N = {
       save_failed: "panorama.settings.save_failed",
       redetect_started: "panorama.settings.redetect_started",
       redetect_failed: "panorama.settings.redetect_failed",
+    },
+  },
+  histogram: {
+    mode: {
+      label: "histogram.mode.label",
+      luminance: "histogram.mode.luminance",
+      rgb: "histogram.mode.rgb",
+      red: "histogram.mode.red",
+      green: "histogram.mode.green",
+      blue: "histogram.mode.blue",
+    },
+    clipping: {
+      shadow: "histogram.clipping.shadow",
+      highlight: "histogram.clipping.highlight",
     },
   },
 } as const;

--- a/client/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/client/src/app/core/interceptors/error.interceptor.spec.ts
@@ -167,12 +167,12 @@ describe('errorInterceptor', () => {
     );
   });
 
-  it('appends the server-supplied detail to the 403 toast', async () => {
+  it('appends the server-supplied detail to the 403 toast, labelled as a server message', async () => {
     await raise403('/api/photos', { detail: 'target_dir is not an allowed export location' });
 
     await vi.waitFor(() =>
       expect(snackBarMock.open).toHaveBeenCalledWith(
-        'errors.access_denied: target_dir is not an allowed export location',
+        'errors.access_denied — errors.server_detail target_dir is not an allowed export location',
         '',
         { duration: 8000 },
       ),

--- a/client/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/client/src/app/core/interceptors/error.interceptor.spec.ts
@@ -129,10 +129,10 @@ describe('errorInterceptor', () => {
       });
     }));
 
-  const raise403 = (url = '/api/photos') =>
+  const raise403 = (url = '/api/photos', error: unknown = null) =>
     new Promise<void>((resolve) => {
       const req = new HttpRequest('GET', url);
-      next.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403, url })));
+      next.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403, url, error })));
       runInterceptor(req).subscribe({ error: () => resolve() });
     });
 
@@ -164,6 +164,34 @@ describe('errorInterceptor', () => {
 
     await vi.waitFor(() =>
       expect(snackBarMock.open).toHaveBeenCalledWith('errors.edition_expired', '', { duration: 6000 }),
+    );
+  });
+
+  it('appends the server-supplied detail to the 403 toast', async () => {
+    await raise403('/api/photos', { detail: 'target_dir is not an allowed export location' });
+
+    await vi.waitFor(() =>
+      expect(snackBarMock.open).toHaveBeenCalledWith(
+        'errors.access_denied: target_dir is not an allowed export location',
+        '',
+        { duration: 8000 },
+      ),
+    );
+  });
+
+  it('falls back to the generic 403 toast when no detail is present', async () => {
+    await raise403('/api/photos', {});
+
+    await vi.waitFor(() =>
+      expect(snackBarMock.open).toHaveBeenCalledWith('errors.access_denied', '', { duration: 3000 }),
+    );
+  });
+
+  it('does not crash on a non-string detail (FastAPI validation error list)', async () => {
+    await raise403('/api/photos', { detail: [{ loc: ['body', 'target_dir'], msg: 'field required' }] });
+
+    await vi.waitFor(() =>
+      expect(snackBarMock.open).toHaveBeenCalledWith('errors.access_denied', '', { duration: 3000 }),
     );
   });
 

--- a/client/src/app/core/interceptors/error.interceptor.ts
+++ b/client/src/app/core/interceptors/error.interceptor.ts
@@ -48,8 +48,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         void auth.revalidate().then(() => {
           const lostEdition = hadEdition && !auth.isEdition();
           const base = i18n.t(lostEdition ? I18N.errors.edition_expired : I18N.errors.access_denied);
+          // The detail is the server's own (untranslated) prose, so it is
+          // labelled as a server message rather than spliced straight after
+          // a translated sentence -- otherwise a non-English user sees their
+          // language switch to English mid-toast with nothing explaining why.
           snackBar.open(
-            detail ? `${base}: ${detail}` : base,
+            detail ? `${base} — ${i18n.t(I18N.errors.server_detail)} ${detail}` : base,
             '',
             { duration: detail ? 8000 : (lostEdition ? 6000 : 3000) },
           );

--- a/client/src/app/core/interceptors/error.interceptor.ts
+++ b/client/src/app/core/interceptors/error.interceptor.ts
@@ -5,6 +5,7 @@ import { catchError, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { I18nService } from '../services/i18n.service';
 import { I18N } from '../i18n/keys';
+import { extractErrorDetail } from '../utils/http-error.util';
 
 const CLIENT_ERRORS_URL = '/api/client-errors';
 
@@ -43,23 +44,21 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         // Reconcile before reporting, so the toast can say which of the two it
         // was and the Edition indicator stops lying either way.
         const hadEdition = auth.isEdition();
+        const detail = extractErrorDetail(error);
         void auth.revalidate().then(() => {
           const lostEdition = hadEdition && !auth.isEdition();
+          const base = i18n.t(lostEdition ? I18N.errors.edition_expired : I18N.errors.access_denied);
           snackBar.open(
-            i18n.t(lostEdition ? I18N.errors.edition_expired : I18N.errors.access_denied),
+            detail ? `${base}: ${detail}` : base,
             '',
-            { duration: lostEdition ? 6000 : 3000 },
+            { duration: detail ? 8000 : (lostEdition ? 6000 : 3000) },
           );
         });
       } else if (error.status >= 500) {
         snackBar.open(i18n.t(I18N.errors.server_error), '', { duration: 3000 });
         if (!isCrashReportUrl(req.url)) {
           let msg = `${req.method} ${req.url} -> ${error.status}`;
-          const body = error.error as Record<string, unknown> | null;
-          const detail = body && typeof body === 'object'
-            ? (typeof body['detail'] === 'string' ? body['detail'] :
-               typeof body['message'] === 'string' ? body['message'] : undefined)
-            : undefined;
+          const detail = extractErrorDetail(error);
           if (detail) msg += `: ${detail}`;
           crashReporter.post(CLIENT_ERRORS_URL, {
             message: msg.slice(0, 2000),

--- a/client/src/app/core/services/histogram-preferences.service.spec.ts
+++ b/client/src/app/core/services/histogram-preferences.service.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { HISTOGRAM_MODE_KEYS, HistogramPreferencesService } from './histogram-preferences.service';
+
+describe('HistogramPreferencesService', () => {
+  let service: HistogramPreferencesService;
+
+  beforeEach(() => {
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.detail);
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.tooltip);
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HistogramPreferencesService);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.detail);
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.tooltip);
+  });
+
+  it('starts with no persisted choice on either surface', () => {
+    expect(service.mode('detail')).toBeNull();
+    expect(service.mode('tooltip')).toBeNull();
+  });
+
+  it('persists a surface choice under its own localStorage key', () => {
+    service.setMode('detail', 'r');
+    expect(localStorage.getItem(HISTOGRAM_MODE_KEYS.detail)).toBe('r');
+    expect(localStorage.getItem(HISTOGRAM_MODE_KEYS.tooltip)).toBeNull();
+  });
+
+  it('setting the detail surface does not change what the tooltip surface resolves to', () => {
+    service.setMode('detail', 'r');
+    expect(service.mode('tooltip')).toBeNull();
+  });
+
+  it('setting the tooltip surface does not change what the detail surface resolves to', () => {
+    service.setMode('tooltip', 'g');
+    expect(service.mode('detail')).toBeNull();
+  });
+
+  it('the two surfaces can hold different modes at the same time', () => {
+    service.setMode('detail', 'rgb');
+    service.setMode('tooltip', 'luma');
+    expect(service.mode('detail')).toBe('rgb');
+    expect(service.mode('tooltip')).toBe('luma');
+  });
+
+  it('loads each surface\'s own persisted value on construction', () => {
+    localStorage.setItem(HISTOGRAM_MODE_KEYS.detail, 'b');
+    localStorage.setItem(HISTOGRAM_MODE_KEYS.tooltip, 'luma');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const fresh = TestBed.inject(HistogramPreferencesService);
+
+    expect(fresh.mode('detail')).toBe('b');
+    expect(fresh.mode('tooltip')).toBe('luma');
+  });
+
+  it('degrades a stale/unrecognised stored value to null (config default applies) instead of rendering nothing', () => {
+    localStorage.setItem(HISTOGRAM_MODE_KEYS.detail, 'sepia');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const fresh = TestBed.inject(HistogramPreferencesService);
+
+    expect(fresh.mode('detail')).toBeNull();
+  });
+});

--- a/client/src/app/core/services/histogram-preferences.service.ts
+++ b/client/src/app/core/services/histogram-preferences.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, signal } from '@angular/core';
+import { HistogramMode, isHistogramMode } from '../../shared/utils/histogram';
+
+/** The two independent surfaces the histogram widget renders on. Each has its
+ *  own persisted user choice and its own config-derived default — see
+ *  `HistogramPreferencesService`. */
+export type HistogramSurface = 'detail' | 'tooltip';
+
+export const HISTOGRAM_MODE_KEYS: Record<HistogramSurface, string> = {
+  detail: 'facet_histogram_mode',
+  tooltip: 'facet_histogram_mode_tooltip',
+};
+
+/**
+ * The user's channel-mode choice for the histogram widget, kept separately
+ * per surface.
+ *
+ * A service rather than component state so that every widget on the same
+ * surface agrees and the choice outlives the photo — following
+ * `ThemeService`, which persists its own preference the same way: a signal
+ * seeded from `localStorage`, with the config-derived default applying only
+ * while nothing is stored.
+ *
+ * The detail panel and the hover/pinned tooltip are deliberately independent:
+ * the panel is for studying one photo (RGB detail earns its space), the
+ * tooltip is for scanning many quickly (a plain luminance curve usually reads
+ * faster). A user's choice on one surface must not silently retune the other,
+ * and an admin sets each surface's default separately in `viewer.clipping`.
+ */
+@Injectable({ providedIn: 'root' })
+export class HistogramPreferencesService {
+  /** null until the user picks on that surface, so its config default still applies. */
+  private readonly detailMode = signal<HistogramMode | null>(this.loadSaved('detail'));
+  private readonly tooltipMode = signal<HistogramMode | null>(this.loadSaved('tooltip'));
+
+  mode(surface: HistogramSurface): HistogramMode | null {
+    return surface === 'tooltip' ? this.tooltipMode() : this.detailMode();
+  }
+
+  setMode(surface: HistogramSurface, mode: HistogramMode): void {
+    const target = surface === 'tooltip' ? this.tooltipMode : this.detailMode;
+    target.set(mode);
+    try {
+      localStorage.setItem(HISTOGRAM_MODE_KEYS[surface], mode);
+    } catch { /* private browsing — the choice just does not outlive the tab */ }
+  }
+
+  private loadSaved(surface: HistogramSurface): HistogramMode | null {
+    try {
+      const raw = localStorage.getItem(HISTOGRAM_MODE_KEYS[surface]);
+      return isHistogramMode(raw) ? raw : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/client/src/app/core/utils/http-error.util.spec.ts
+++ b/client/src/app/core/utils/http-error.util.spec.ts
@@ -1,0 +1,50 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { extractErrorDetail } from './http-error.util';
+
+describe('extractErrorDetail', () => {
+  it('returns a string detail field', () => {
+    const error = new HttpErrorResponse({ error: { detail: 'target_dir is not an allowed export location' } });
+    expect(extractErrorDetail(error)).toBe('target_dir is not an allowed export location');
+  });
+
+  it('falls back to a string message field when detail is absent', () => {
+    const error = new HttpErrorResponse({ error: { message: 'something went wrong' } });
+    expect(extractErrorDetail(error)).toBe('something went wrong');
+  });
+
+  it('prefers detail over message when both are present', () => {
+    const error = new HttpErrorResponse({ error: { detail: 'the detail', message: 'the message' } });
+    expect(extractErrorDetail(error)).toBe('the detail');
+  });
+
+  it('ignores a non-string detail (FastAPI validation error list)', () => {
+    const error = new HttpErrorResponse({ error: { detail: [{ loc: ['body', 'target_dir'], msg: 'field required' }] } });
+    expect(extractErrorDetail(error)).toBeUndefined();
+  });
+
+  it('ignores an object detail', () => {
+    const error = new HttpErrorResponse({ error: { detail: { nested: true } } });
+    expect(extractErrorDetail(error)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no error body', () => {
+    expect(extractErrorDetail(new HttpErrorResponse({}))).toBeUndefined();
+  });
+
+  it('returns undefined for a plain Error with no .error property', () => {
+    expect(extractErrorDetail(new Error('boom'))).toBeUndefined();
+  });
+
+  it('returns undefined for null/undefined input', () => {
+    expect(extractErrorDetail(null)).toBeUndefined();
+    expect(extractErrorDetail(undefined)).toBeUndefined();
+  });
+
+  it('caps a pathological detail length', () => {
+    const long = 'x'.repeat(1000);
+    const error = new HttpErrorResponse({ error: { detail: long } });
+    const result = extractErrorDetail(error);
+    expect(result!.length).toBeLessThan(400);
+    expect(result!.endsWith('…')).toBe(true);
+  });
+});

--- a/client/src/app/core/utils/http-error.util.ts
+++ b/client/src/app/core/utils/http-error.util.ts
@@ -1,0 +1,18 @@
+const MAX_ERROR_DETAIL_LENGTH = 300;
+
+/**
+ * Pull a human-readable `detail`/`message` string out of an HTTP error body.
+ * FastAPI validation errors put a list of objects in `detail`, so anything
+ * non-string is dropped rather than rendered, and the result is capped so a
+ * pathological server message cannot blow out a toast or dialog layout.
+ */
+export function extractErrorDetail(error: unknown): string | undefined {
+  const body = (error as { error?: unknown } | null | undefined)?.error;
+  if (!body || typeof body !== 'object') return undefined;
+  const record = body as Record<string, unknown>;
+  const raw = typeof record['detail'] === 'string' ? record['detail']
+    : typeof record['message'] === 'string' ? record['message']
+    : undefined;
+  if (!raw) return undefined;
+  return raw.length > MAX_ERROR_DETAIL_LENGTH ? `${raw.slice(0, MAX_ERROR_DETAIL_LENGTH)}…` : raw;
+}

--- a/client/src/app/features/comparison/comparison-ab-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-ab-tab.component.ts
@@ -32,7 +32,6 @@ interface ComparisonStats {
   winner_breakdown: Record<string, number>;
   category_breakdown: { category: string; count: number }[];
   unique_photos_compared: number;
-  photos_with_learned_scores: number;
   min_comparisons_for_optimization?: number;
 }
 

--- a/client/src/app/features/comparison/comparison-priority-tab.component.ts
+++ b/client/src/app/features/comparison/comparison-priority-tab.component.ts
@@ -296,7 +296,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
                   <div class="flex flex-wrap gap-2">
                     @for (name of promotableCategories(); track name) {
                       <button type="button"
-                        class="px-2 py-1 rounded-full text-xs border border-[var(--mat-sys-outline-variant)] text-gray-400 hover:text-gray-200"
+                        class="px-2 py-1 rounded-full text-xs border border-[var(--mat-sys-outline-variant)] text-gray-400 hover:text-gray-200 cursor-pointer"
                         (click)="promoteCategory(name)">
                         {{ ('category_names.' + name) | translate }}
                       </button>
@@ -316,6 +316,7 @@ export class CategoryFilterSummaryPipe implements PipeTransform {
               <div class="flex flex-wrap gap-2">
                 @for (chip of exclusionChips(); track chip.name) {
                   <button type="button"
+                    class="cursor-pointer"
                     [class]="chip.excluded
                       ? 'px-2 py-1 rounded-full text-xs border border-red-500/30 bg-red-500/10 text-red-400'
                       : 'px-2 py-1 rounded-full text-xs border border-[var(--mat-sys-outline-variant)] text-gray-400 hover:text-gray-200'"

--- a/client/src/app/features/gallery/burst-culling.component.ts
+++ b/client/src/app/features/gallery/burst-culling.component.ts
@@ -688,7 +688,7 @@ class RunGeneration {
                       </div>
                     }
                     @if (!(photo.path | isKept:selectionsMap():group.group_id)) {
-                      <button class="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/60 inline-flex items-center justify-center opacity-0 group-hover/photo:opacity-100 transition-opacity"
+                      <button class="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/60 inline-flex items-center justify-center opacity-0 group-hover/photo:opacity-100 transition-opacity cursor-pointer"
                               [matTooltip]="I18N.culling.view_detail | translate"
                               [attr.aria-label]="I18N.culling.view_detail | translate"
                               (click)="openDetail($event, photo.path)">
@@ -708,14 +708,14 @@ class RunGeneration {
                 @if (group.category; as category) {
                   @if (comparisonStats(); as stats) {
                     @if ((category | weightRemaining:stats); as remaining) {
-                      <button class="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--mat-sys-surface-container-high)] transition-colors"
+                      <button class="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--mat-sys-surface-container-high)] transition-colors cursor-pointer"
                               (click)="tuneCategory(category)"
                               [matTooltip]="I18N.culling.weight_remaining | translate:{ count: remaining }"
                               [attr.aria-label]="I18N.culling.weight_remaining | translate:{ count: remaining }">
                         <mat-icon class="!text-base !w-4 !h-4 !leading-4 opacity-60">tune</mat-icon>
                       </button>
                     } @else {
-                      <button class="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--mat-sys-surface-container-high)] transition-colors"
+                      <button class="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--mat-sys-surface-container-high)] transition-colors cursor-pointer"
                               (click)="tuneCategory(category)"
                               [matTooltip]="I18N.culling.weight_ready | translate"
                               [attr.aria-label]="I18N.culling.weight_ready | translate">
@@ -1059,7 +1059,7 @@ class RunGeneration {
                          actually looking at. Same write as those keys. -->
                     <div class="absolute bottom-2 right-2 flex items-center gap-2 pointer-events-auto">
                       <button type="button"
-                              class="w-7 h-7 rounded-full bg-green-600 inline-flex items-center justify-center shadow transition-opacity hover:opacity-100"
+                              class="w-7 h-7 rounded-full bg-green-600 inline-flex items-center justify-center shadow transition-opacity hover:opacity-100 cursor-pointer"
                               [class.opacity-70]="!(photo.path | isKept:selectionsMap():lbGroup.group_id)"
                               [attr.aria-pressed]="photo.path | isKept:selectionsMap():lbGroup.group_id"
                               [matTooltip]="I18N.culling.lightbox.keep | translate"
@@ -1068,7 +1068,7 @@ class RunGeneration {
                         <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-white">check</mat-icon>
                       </button>
                       <button type="button"
-                              class="w-7 h-7 rounded-full bg-red-600 inline-flex items-center justify-center shadow transition-opacity hover:opacity-100"
+                              class="w-7 h-7 rounded-full bg-red-600 inline-flex items-center justify-center shadow transition-opacity hover:opacity-100 cursor-pointer"
                               [class.opacity-70]="!(photo.path | isDecided:selectionsMap():lbGroup.group_id)"
                               [attr.aria-pressed]="photo.path | isDecided:selectionsMap():lbGroup.group_id"
                               [matTooltip]="I18N.culling.lightbox.reject | translate"

--- a/client/src/app/features/gallery/cull-dialog.component.spec.ts
+++ b/client/src/app/features/gallery/cull-dialog.component.spec.ts
@@ -68,4 +68,44 @@ describe('CullDialogComponent', () => {
     await component.apply();
     expect(dialogClose).not.toHaveBeenCalled();
   });
+
+  it('surfaces the server-supplied reason in the dialog on apply failure', async () => {
+    build();
+    set('targetDir', '/dest');
+    post.mockReturnValueOnce(throwError(() => ({
+      error: { detail: 'target_dir is not an allowed export location. Configure viewer.export.allowed_target_dirs' },
+    })));
+    await component.apply();
+    expect(read<string | null>('errorDetail')).toBe(
+      'target_dir is not an allowed export location. Configure viewer.export.allowed_target_dirs',
+    );
+  });
+
+  it('surfaces the server-supplied reason in the dialog on preview failure', async () => {
+    build();
+    set('targetDir', '/dest');
+    post.mockReturnValueOnce(throwError(() => ({ error: { detail: 'no allowed roots configured' } })));
+    await component.runPreview();
+    expect(read<string | null>('errorDetail')).toBe('no allowed roots configured');
+  });
+
+  it('falls back to null errorDetail when the error has no detail', async () => {
+    build();
+    set('targetDir', '/dest');
+    post.mockReturnValueOnce(throwError(() => new Error('boom')));
+    await component.apply();
+    expect(read<string | null>('errorDetail')).toBeNull();
+  });
+
+  it('clears a prior errorDetail on a new attempt', async () => {
+    build();
+    set('targetDir', '/dest');
+    post.mockReturnValueOnce(throwError(() => ({ error: { detail: 'first failure' } })));
+    await component.apply();
+    expect(read<string | null>('errorDetail')).toBe('first failure');
+
+    post.mockReturnValueOnce(of({ would_copy: [], skipped: [] }));
+    await component.runPreview();
+    expect(read<string | null>('errorDetail')).toBeNull();
+  });
 });

--- a/client/src/app/features/gallery/cull-dialog.component.ts
+++ b/client/src/app/features/gallery/cull-dialog.component.ts
@@ -83,7 +83,8 @@ interface CullResponse {
       }
 
       @if (errorDetail(); as detail) {
-        <p class="mt-3 text-sm text-[var(--mat-sys-error)]">{{ I18N.cull.error | translate }}: {{ detail }}</p>
+        <p class="mt-3 text-sm text-[var(--mat-sys-error)]">{{ I18N.cull.error | translate }}</p>
+        <p class="mt-1 text-xs text-[var(--mat-sys-error)] opacity-80">{{ I18N.errors.server_detail | translate }} {{ detail }}</p>
       }
     </mat-dialog-content>
     <mat-dialog-actions align="end">

--- a/client/src/app/features/gallery/cull-dialog.component.ts
+++ b/client/src/app/features/gallery/cull-dialog.component.ts
@@ -8,6 +8,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { firstValueFrom } from 'rxjs';
 import { ApiService } from '../../core/services/api.service';
 import { I18nService } from '../../core/services/i18n.service';
+import { extractErrorDetail } from '../../core/utils/http-error.util';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { I18N, I18N_KEYS } from '../../core/i18n/keys';
 
@@ -80,6 +81,10 @@ interface CullResponse {
           }
         </div>
       }
+
+      @if (errorDetail(); as detail) {
+        <p class="mt-3 text-sm text-[var(--mat-sys-error)]">{{ I18N.cull.error | translate }}: {{ detail }}</p>
+      }
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button mat-dialog-close>{{ I18N.cull.cancel | translate }}</button>
@@ -110,6 +115,7 @@ export class CullDialogComponent {
   protected readonly includeCompanions = signal(false);
   protected readonly preview = signal<{ affected: string[]; skipped: string[]; excluded: number } | null>(null);
   protected readonly busy = signal(false);
+  protected readonly errorDetail = signal<string | null>(null);
 
   protected readonly needsTarget = computed(() => this.action() !== 'trash_rejects');
   protected readonly count = this.data.paths.length;
@@ -117,11 +123,13 @@ export class CullDialogComponent {
   protected setAction(a: CullAction): void {
     this.action.set(a);
     this.preview.set(null);
+    this.errorDetail.set(null);
   }
 
   protected onTargetInput(event: Event): void {
     this.targetDir.set((event.target as HTMLInputElement).value);
     this.preview.set(null);
+    this.errorDetail.set(null);
   }
 
   private body(dryRun: boolean): CullRequest {
@@ -143,6 +151,7 @@ export class CullDialogComponent {
 
   async runPreview(): Promise<void> {
     this.busy.set(true);
+    this.errorDetail.set(null);
     const requested = this.body(true);
     try {
       const res = await firstValueFrom(this.api.post<CullResponse>('/cull/apply', requested));
@@ -151,7 +160,8 @@ export class CullDialogComponent {
       }
       const affected = res.would_copy ?? res.would_move ?? res.would_trash ?? [];
       this.preview.set({ affected, skipped: res.skipped ?? [], excluded: res.excluded_by_state ?? 0 });
-    } catch {
+    } catch (error) {
+      this.errorDetail.set(extractErrorDetail(error) ?? null);
       this.snackBar.open(this.i18n.t(I18N.cull.error), '', { duration: 3000 });
     } finally {
       this.busy.set(false);
@@ -160,11 +170,13 @@ export class CullDialogComponent {
 
   async apply(): Promise<void> {
     this.busy.set(true);
+    this.errorDetail.set(null);
     try {
       await firstValueFrom(this.api.post<CullResponse>('/cull/apply', this.body(false)));
       this.snackBar.open(this.i18n.t(I18N.cull.done), '', { duration: 2500 });
       this.dialogRef.close(true);
-    } catch {
+    } catch (error) {
+      this.errorDetail.set(extractErrorDetail(error) ?? null);
       this.snackBar.open(this.i18n.t(I18N.cull.error), '', { duration: 3000 });
     } finally {
       this.busy.set(false);

--- a/client/src/app/features/gallery/export-editor-dialog.component.spec.ts
+++ b/client/src/app/features/gallery/export-editor-dialog.component.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ExportService } from '../../core/services/export.service';
+import { I18nService } from '../../core/services/i18n.service';
+import { ExportEditorDialogComponent, ExportEditorDialogData } from './export-editor-dialog.component';
+
+describe('ExportEditorDialogComponent', () => {
+  let component: ExportEditorDialogComponent;
+  let exportAlbum: ReturnType<typeof vi.fn>;
+  let dialogClose: ReturnType<typeof vi.fn>;
+
+  function build(data: ExportEditorDialogData = { albumId: 7 }) {
+    exportAlbum = vi.fn(() => of({ ok: true, mode: 'copy', copied: 1, skipped: 0, errors: 0 }));
+    dialogClose = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ExportService, useValue: { exportAlbum, exportSidecars: vi.fn(() => of({})) } },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: I18nService, useValue: { t: (k: string) => k } },
+        { provide: MatDialogRef, useValue: { close: dialogClose } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+      ],
+    });
+    component = TestBed.runInInjectionContext(() => new ExportEditorDialogComponent());
+  }
+
+  it('clears errorDetail and closes on success', async () => {
+    build();
+    component.mode.set('copy');
+    component.targetDir.set('/dest');
+    await component.run();
+    expect(dialogClose).toHaveBeenCalled();
+    expect(component.errorDetail()).toBeNull();
+  });
+
+  it('surfaces the server-supplied reason instead of swallowing it', async () => {
+    build();
+    component.mode.set('copy');
+    component.targetDir.set('/dest');
+    exportAlbum.mockReturnValueOnce(throwError(() => ({
+      error: { detail: 'target_dir is not an allowed export location. Configure viewer.export.allowed_target_dirs' },
+    })));
+    await component.run();
+    expect(dialogClose).not.toHaveBeenCalled();
+    expect(component.errorDetail()).toBe(
+      'target_dir is not an allowed export location. Configure viewer.export.allowed_target_dirs',
+    );
+  });
+
+  it('falls back to null errorDetail when the error has no detail', async () => {
+    build();
+    component.mode.set('copy');
+    component.targetDir.set('/dest');
+    exportAlbum.mockReturnValueOnce(throwError(() => new Error('boom')));
+    await component.run();
+    expect(component.errorDetail()).toBeNull();
+  });
+
+  it('does not crash on a non-string detail (FastAPI validation error list)', async () => {
+    build();
+    component.mode.set('copy');
+    component.targetDir.set('/dest');
+    exportAlbum.mockReturnValueOnce(throwError(() => ({
+      error: { detail: [{ loc: ['body', 'target_dir'], msg: 'field required' }] },
+    })));
+    await component.run();
+    expect(component.errorDetail()).toBeNull();
+  });
+});

--- a/client/src/app/features/gallery/export-editor-dialog.component.ts
+++ b/client/src/app/features/gallery/export-editor-dialog.component.ts
@@ -12,6 +12,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { firstValueFrom } from 'rxjs';
 import { AlbumExportMode, ExportService } from '../../core/services/export.service';
 import { I18nService } from '../../core/services/i18n.service';
+import { extractErrorDetail } from '../../core/utils/http-error.util';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { I18N, I18N_KEYS } from '../../core/i18n/keys';
 
@@ -49,8 +50,12 @@ export interface ExportEditorDialogData {
       } @else {
         <mat-form-field class="w-full">
           <mat-label>{{ I18N.export.target_dir | translate }}</mat-label>
-          <input matInput [ngModel]="targetDir()" (ngModelChange)="targetDir.set($event)" />
+          <input matInput [ngModel]="targetDir()" (ngModelChange)="targetDir.set($event); errorDetail.set(null)" />
         </mat-form-field>
+      }
+
+      @if (errorDetail(); as detail) {
+        <p class="text-sm text-[var(--mat-sys-error)]">{{ I18N.export.failed | translate }}: {{ detail }}</p>
       }
     </mat-dialog-content>
     <mat-dialog-actions align="end">
@@ -74,6 +79,7 @@ export class ExportEditorDialogComponent {
   readonly overwrite = signal(false);
   readonly targetDir = signal('');
   readonly running = signal(false);
+  readonly errorDetail = signal<string | null>(null);
 
   readonly canRun = computed(() => {
     if (this.mode() === 'sidecars') {
@@ -85,6 +91,7 @@ export class ExportEditorDialogComponent {
   async run(): Promise<void> {
     if (!this.canRun() || this.running()) return;
     this.running.set(true);
+    this.errorDetail.set(null);
     try {
       const result = this.data.albumId
         ? await firstValueFrom(this.exportService.exportAlbum(this.data.albumId, this.mode(), this.targetDir().trim(), this.overwrite()))
@@ -92,7 +99,8 @@ export class ExportEditorDialogComponent {
       const count = ('copied' in result ? result.copied : result.written) ?? 0;
       this.snackBar.open(this.i18n.t(I18N.export.done, { count }), '', { duration: 2500 });
       this.dialogRef.close(result);
-    } catch {
+    } catch (error) {
+      this.errorDetail.set(extractErrorDetail(error) ?? null);
       this.snackBar.open(this.i18n.t(I18N.export.failed), '', { duration: 2500 });
       this.running.set(false);
     }

--- a/client/src/app/features/gallery/export-editor-dialog.component.ts
+++ b/client/src/app/features/gallery/export-editor-dialog.component.ts
@@ -55,7 +55,8 @@ export interface ExportEditorDialogData {
       }
 
       @if (errorDetail(); as detail) {
-        <p class="text-sm text-[var(--mat-sys-error)]">{{ I18N.export.failed | translate }}: {{ detail }}</p>
+        <p class="text-sm text-[var(--mat-sys-error)]">{{ I18N.export.failed | translate }}</p>
+        <p class="text-xs text-[var(--mat-sys-error)] opacity-80">{{ I18N.errors.server_detail | translate }} {{ detail }}</p>
       }
     </mat-dialog-content>
     <mat-dialog-actions align="end">

--- a/client/src/app/features/gallery/face-selector-dialog.component.ts
+++ b/client/src/app/features/gallery/face-selector-dialog.component.ts
@@ -39,7 +39,7 @@ interface PhotoFace {
         <div class="flex flex-wrap gap-2 justify-center">
           @for (face of unassignedFaces(); track face.id) {
             <button
-              class="relative rounded-full overflow-hidden border-2 border-transparent hover:border-[var(--mat-sys-primary)] transition-colors"
+              class="relative rounded-full overflow-hidden border-2 border-transparent hover:border-[var(--mat-sys-primary)] transition-colors cursor-pointer"
               (click)="dialogRef.close(face)">
               <img [src]="face.id | faceThumbnailUrl"
                    alt=""

--- a/client/src/app/features/gallery/folder-picker-dialog.component.ts
+++ b/client/src/app/features/gallery/folder-picker-dialog.component.ts
@@ -92,7 +92,7 @@ export interface FolderPickerData {
         <div class="flex flex-col gap-1 max-h-[360px] overflow-y-auto">
           @for (folder of filteredChildren(); track folder.path) {
             <button
-              class="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full"
+              class="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full cursor-pointer"
               (click)="navigateTo(folder.path)"
             >
               <mat-icon class="!text-base !w-5 !h-5 !leading-5 opacity-60 shrink-0">folder</mat-icon>

--- a/client/src/app/features/gallery/gallery-actions-sheet.component.ts
+++ b/client/src/app/features/gallery/gallery-actions-sheet.component.ts
@@ -42,11 +42,11 @@ export interface GalleryActionsSheetData {
       </div>
 
       @if (data.isEdition) {
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'favorite' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'favorite' })">
           <mat-icon aria-hidden="true">favorite</mat-icon>
           {{ I18N.gallery.selection.favorite | translate }}
         </button>
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'reject' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'reject' })">
           <mat-icon aria-hidden="true">thumb_down</mat-icon>
           {{ I18N.gallery.selection.reject | translate }}
         </button>
@@ -54,73 +54,73 @@ export interface GalleryActionsSheetData {
           <mat-icon class="mr-2 opacity-70" aria-hidden="true">star</mat-icon>
           @for (star of [1, 2, 3, 4, 5]; track star) {
             <button
-              class="w-9 h-9 rounded-full text-yellow-400 text-sm font-semibold hover:bg-white/10"
+              class="w-9 h-9 rounded-full text-yellow-400 text-sm font-semibold hover:bg-white/10 cursor-pointer"
               [attr.aria-label]="(I18N.gallery.selection.rate | translate) + ' ' + star"
               (click)="pick({ kind: 'rate', rating: star })"
             >{{ star }}★</button>
           }
-          <button class="w-9 h-9 rounded-full text-sm hover:bg-white/10"
+          <button class="w-9 h-9 rounded-full text-sm hover:bg-white/10 cursor-pointer"
                   [attr.aria-label]="I18N.gallery.selection.clear | translate"
                   (click)="pick({ kind: 'rate', rating: 0 })">0</button>
         </div>
         @if (data.showAlbums) {
           @for (album of data.albums; track album.id) {
-            <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'album', albumId: album.id })">
+            <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'album', albumId: album.id })">
               <mat-icon aria-hidden="true">photo_library</mat-icon>
               {{ album.name }}
             </button>
           }
-          <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'create-album' })">
+          <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'create-album' })">
             <mat-icon aria-hidden="true">add</mat-icon>
             {{ I18N.albums.create | translate }}
           </button>
         }
         <!-- Present on the desktop bar but previously unreachable on a phone,
              where this sheet is the only way to any bulk action. -->
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'export' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'export' })">
           <mat-icon aria-hidden="true">drive_file_move</mat-icon>
           {{ I18N.export.action | translate }}
         </button>
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'cull' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'cull' })">
           <mat-icon aria-hidden="true">folder_move</mat-icon>
           {{ I18N.cull.action | translate }}
         </button>
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'mark-panorama', sequenceKind: 'panorama' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'mark-panorama', sequenceKind: 'panorama' })">
           <mat-icon aria-hidden="true">{{ 'panorama' | sequenceKindIcon }}</mat-icon>
           {{ I18N.gallery.selection.mark_panorama | translate }}
         </button>
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'mark-panorama', sequenceKind: 'hdr_panorama' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'mark-panorama', sequenceKind: 'hdr_panorama' })">
           <mat-icon aria-hidden="true">{{ 'hdr_panorama' | sequenceKindIcon }}</mat-icon>
           {{ I18N.gallery.selection.mark_hdr_panorama | translate }}
         </button>
       }
 
-      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'invert' })">
+      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'invert' })">
         <mat-icon aria-hidden="true">flip</mat-icon>
         {{ I18N.gallery.selection.invert | translate }}
       </button>
       @if (data.canCompare) {
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'compare' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'compare' })">
           <mat-icon aria-hidden="true">compare</mat-icon>
           {{ I18N.gallery.selection.compare | translate }}
         </button>
       }
-      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'copy' })">
+      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'copy' })">
         <mat-icon aria-hidden="true">content_copy</mat-icon>
         {{ I18N.gallery.selection.copy_filenames | translate }}
       </button>
-      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'download', type: 'original' })">
+      <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'download', type: 'original' })">
         <mat-icon aria-hidden="true">download</mat-icon>
         {{ I18N.download.type_original | translate }}
       </button>
       @for (profile of data.downloadProfiles; track profile) {
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'download', type: 'darktable', profile })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'download', type: 'darktable', profile })">
           <mat-icon aria-hidden="true">photo_filter</mat-icon>
           {{ profile }}
         </button>
       }
       @if (data.downloadProfiles.length) {
-        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10" (click)="pick({ kind: 'download', type: 'raw' })">
+        <button class="flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-white/10 cursor-pointer" (click)="pick({ kind: 'download', type: 'raw' })">
           <mat-icon aria-hidden="true">raw_on</mat-icon>
           {{ I18N.download.type_raw | translate }}
         </button>

--- a/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
+++ b/client/src/app/features/gallery/gallery-filter-sidebar.component.ts
@@ -72,6 +72,12 @@ export const ADDITIONAL_FILTERS: AdditionalFilterDef[] = [
   { id: 'dynamic_range', labelKey: 'gallery.dynamic_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_dynamic_range', maxKey: 'max_dynamic_range', sliderMin: 0, sliderMax: 15, step: 0.5, displaySuffix: ' EV', spanWidth: 'w-16' },
   { id: 'luminance_range', labelKey: 'gallery.luminance_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_luminance', maxKey: 'max_luminance', sliderMin: 0, sliderMax: 1, step: 0.01, spanWidth: 'w-16' },
   { id: 'histogram_range', labelKey: 'gallery.histogram_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_histogram_spread', maxKey: 'max_histogram_spread', sliderMin: 0, sliderMax: 10, step: 0.5, spanWidth: 'w-16' },
+  // Percent of pixels, worst of R/G/B. Capped at 25 rather than 100: over 28
+  // sampled photos the worst highlight clipping seen was 12.7% and the worst
+  // shadow 30.4%, so a 0-100 slider would spend nine tenths of its travel on
+  // values no photo has.
+  { id: 'channel_clip_highlight_range', labelKey: 'gallery.channel_clip_highlight_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_channel_clip_highlight', maxKey: 'max_channel_clip_highlight', sliderMin: 0, sliderMax: 25, step: 0.5, displaySuffix: '%', spanWidth: 'w-16' },
+  { id: 'channel_clip_shadow_range', labelKey: 'gallery.channel_clip_shadow_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_channel_clip_shadow', maxKey: 'max_channel_clip_shadow', sliderMin: 0, sliderMax: 25, step: 0.5, displaySuffix: '%', spanWidth: 'w-16' },
   { id: 'iso_range', labelKey: 'gallery.iso_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_iso', maxKey: 'max_iso', sliderMin: 50, sliderMax: 25600, step: 50, spanWidth: 'w-20' },
   { id: 'aperture_range', labelKey: 'gallery.aperture_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_aperture', maxKey: 'max_aperture', sliderMin: 0.7, sliderMax: 64, step: 0.1, displayPrefix: 'f/', spanWidth: 'w-20' },
   { id: 'focal_range', labelKey: 'gallery.focal_range', sectionKey: 'gallery.sidebar.exposure_range', minKey: 'min_focal_length', maxKey: 'max_focal_length', sliderMin: 1, sliderMax: 1200, step: 1, displaySuffix: 'mm', spanWidth: 'w-24' },
@@ -309,7 +315,7 @@ function saveSectionStates(states: Record<string, boolean>): void {
             @if (selectedPersons().length) {
               <div class="flex flex-wrap gap-1.5">
                 @for (p of selectedPersons(); track p.id) {
-                  <button class="relative shrink-0 group/person" [matTooltip]="p.name || (I18N.gallery.unknown_person | translate)" (click)="removePersonChip(p.id)">
+                  <button class="relative shrink-0 group/person cursor-pointer" [matTooltip]="p.name || (I18N.gallery.unknown_person | translate)" (click)="removePersonChip(p.id)">
                     <img [src]="p.id | personThumbnailUrl" class="w-9 h-9 rounded-full object-cover" [alt]="p.name || (I18N.gallery.unknown_person | translate)" />
                     <div class="absolute inset-0 rounded-full bg-black/50 flex items-center justify-center opacity-0 group-hover/person:opacity-100 transition-opacity">
                       <mat-icon class="!text-sm !w-4 !h-4 !leading-4 text-white">close</mat-icon>
@@ -449,7 +455,7 @@ function saveSectionStates(states: Record<string, boolean>): void {
               <div class="flex flex-wrap gap-1.5">
                 @for (h of store.hueBuckets(); track h.value) {
                   <button type="button"
-                    class="flex items-center gap-1.5 rounded-full pl-1.5 pr-2.5 py-1 text-xs border border-[var(--mat-sys-outline-variant)]"
+                    class="flex items-center gap-1.5 rounded-full pl-1.5 pr-2.5 py-1 text-xs border border-[var(--mat-sys-outline-variant)] cursor-pointer"
                     [class.!border-[var(--mat-sys-primary)]]="store.filters().hue_bucket === h.value"
                     [class.bg-[var(--mat-sys-primary-container)]]="store.filters().hue_bucket === h.value"
                     [matTooltip]="('gallery.hue_buckets.' + h.value | translate) + ' (' + h.count + ')'"

--- a/client/src/app/features/gallery/gallery-filters.util.spec.ts
+++ b/client/src/app/features/gallery/gallery-filters.util.spec.ts
@@ -10,6 +10,7 @@ import {
   saveDisplayOptionsToStorage,
   DISPLAY_OPTIONS_KEY,
   TOOLTIP_MODES,
+  PANEL_ACTIVATIONS,
 } from './gallery-filters.util';
 
 function filters(overrides: Partial<GalleryFilters> = {}): GalleryFilters {
@@ -28,6 +29,13 @@ describe('countActiveFilters', () => {
   });
   it('counts similar_to and semanticQuery', () => {
     expect(countActiveFilters(filters({ similar_to: '/p.jpg', semanticQuery: 'dog' }))).toBe(2);
+  });
+  it('never counts the ephemeral set-scope fields', () => {
+    // They deliberately escape RANGE_AND_SELECT_KEYS so a set-scoped gallery
+    // needs its own dismissible chip -- the badge must stay silent about it.
+    expect(countActiveFilters(filters({
+      sequence_kind: 'bracket', sequence_group_id: '1', burst_group_id: '5', duplicate_group_id: '9',
+    }))).toBe(0);
   });
 });
 
@@ -51,6 +59,11 @@ describe('buildApiParams', () => {
     expect(buildApiParams(filters({ album_id: '7' }), true)['album_id']).toBeUndefined();
     expect(buildApiParams(filters({ album_id: '7' }), false)['album_id']).toBe('7');
   });
+  it('sends the set-scope fields to the API when set', () => {
+    const p = buildApiParams(filters({ sequence_kind: 'bracket', sequence_group_id: '1' }), false);
+    expect(p['sequence_kind']).toBe('bracket');
+    expect(p['sequence_group_id']).toBe('1');
+  });
 });
 
 describe('buildSyncParams', () => {
@@ -68,6 +81,18 @@ describe('buildSyncParams', () => {
   });
   it('emits hide_blinks=false when it differs from the true default', () => {
     expect(buildSyncParams(filters({ hide_blinks: false }), undefined)['hide_blinks']).toBe('false');
+  });
+  it('never writes the set-scope fields to the URL', () => {
+    // sequence_group_id is renumbered from 1 on every detection pass, so a
+    // bookmarked/shared URL carrying it would silently resolve to a
+    // different set later -- it must stay in-memory only.
+    const p = buildSyncParams(filters({
+      sequence_kind: 'bracket', sequence_group_id: '1', burst_group_id: '5', duplicate_group_id: '9',
+    }), undefined);
+    expect(p['sequence_kind']).toBeUndefined();
+    expect(p['sequence_group_id']).toBeUndefined();
+    expect(p['burst_group_id']).toBeUndefined();
+    expect(p['duplicate_group_id']).toBeUndefined();
   });
 });
 
@@ -95,9 +120,28 @@ describe('applyQueryParams', () => {
     expect(applyQueryParams(DEFAULT_FILTERS, { tooltip_mode: 'sidebar' }).tooltip_mode)
       .toBe(DEFAULT_FILTERS.tooltip_mode);
   });
+  it('accepts every panel activation and ignores anything else', () => {
+    for (const activation of PANEL_ACTIVATIONS) {
+      expect(applyQueryParams(DEFAULT_FILTERS, { panel_activation: activation }).panel_activation)
+        .toBe(activation);
+    }
+    expect(applyQueryParams(DEFAULT_FILTERS, { panel_activation: 'bogus' }).panel_activation)
+      .toBe(DEFAULT_FILTERS.panel_activation);
+  });
   it('parses page as int with fallback to 1', () => {
     expect(applyQueryParams(DEFAULT_FILTERS, { page: '3' }).page).toBe(3);
     expect(applyQueryParams(DEFAULT_FILTERS, { page: 'x' }).page).toBe(1);
+  });
+  it('ignores the set-scope fields even if present in the URL', () => {
+    // A crafted or stale URL must not resurrect a scope the server would
+    // resolve against a since-renumbered group id.
+    const r = applyQueryParams(DEFAULT_FILTERS, {
+      sequence_kind: 'bracket', sequence_group_id: '1', burst_group_id: '5', duplicate_group_id: '9',
+    });
+    expect(r.sequence_kind).toBe('');
+    expect(r.sequence_group_id).toBe('');
+    expect(r.burst_group_id).toBe('');
+    expect(r.duplicate_group_id).toBe('');
   });
   it('round-trips through buildSyncParams', () => {
     const original = filters({ camera: 'Canon', min_score: '7', hide_blinks: false, favorites_only: true });
@@ -118,6 +162,10 @@ describe('display options storage', () => {
     expect(loaded.tooltip_mode).toBe('click');
     expect(loaded.is_monochrome).toBe(true);
   });
+  it('saves and loads panel_activation, same channel as tooltip_mode', () => {
+    saveDisplayOptionsToStorage(filters({ panel_activation: 'click' }));
+    expect(loadDisplayOptionsFromStorage().panel_activation).toBe('click');
+  });
   it('returns {} when storage is empty', () => {
     expect(loadDisplayOptionsFromStorage()).toEqual({});
   });
@@ -126,3 +174,38 @@ describe('display options storage', () => {
     expect(loadDisplayOptionsFromStorage()).toEqual({});
   });
 });
+
+describe('per-channel clipping filters', () => {
+  const CLIPPING = {
+    min_channel_clip_highlight: '5',
+    max_channel_clip_shadow: '2',
+  };
+
+  it('reaches the API', () => {
+    const p = buildApiParams(filters(CLIPPING), false);
+    expect(p['min_channel_clip_highlight']).toBe('5');
+    expect(p['max_channel_clip_shadow']).toBe('2');
+  });
+
+  it('round-trips through the URL', () => {
+    // Unlike the ephemeral set-scope fields, this is a real filter: a link to
+    // "everything with blown highlights" has to survive being bookmarked.
+    const synced = buildSyncParams(filters(CLIPPING), undefined);
+    expect(synced['min_channel_clip_highlight']).toBe('5');
+    expect(synced['max_channel_clip_shadow']).toBe('2');
+
+    const restored = applyQueryParams(DEFAULT_FILTERS, synced);
+    expect(restored.min_channel_clip_highlight).toBe('5');
+    expect(restored.max_channel_clip_shadow).toBe('2');
+  });
+
+  it('counts towards the active-filter badge', () => {
+    expect(countActiveFilters(filters(CLIPPING))).toBe(2);
+  });
+
+  it('is absent from the defaults, so it never filters until asked for', () => {
+    expect(DEFAULT_FILTERS.min_channel_clip_highlight).toBe('');
+    expect(buildApiParams(DEFAULT_FILTERS, false)['min_channel_clip_highlight']).toBeUndefined();
+  });
+});
+

--- a/client/src/app/features/gallery/gallery-filters.util.ts
+++ b/client/src/app/features/gallery/gallery-filters.util.ts
@@ -11,6 +11,13 @@ export type TooltipMode = 'hover' | 'click' | 'off' | 'panel';
 /** Every accepted tooltip mode, so the URL parser and the mode picker cannot drift apart. */
 export const TOOLTIP_MODES: readonly TooltipMode[] = ['hover', 'click', 'off', 'panel'];
 
+/** Which gesture(s) retarget the docked panel (tooltip_mode 'panel'). Meaningless
+ *  for every other tooltip mode, which already has a single, fixed gesture.
+ *  Default 'both' preserves the original panel behaviour exactly. */
+export type PanelActivation = 'hover' | 'click' | 'both';
+
+export const PANEL_ACTIVATIONS: readonly PanelActivation[] = ['hover', 'click', 'both'];
+
 export const GALLERY_MODE_KEY = 'facet_gallery_mode';
 export const DRAWER_STATE_KEY = 'facet_filter_drawer_open';
 export const DISPLAY_OPTIONS_KEY = 'facet_display_options';
@@ -102,6 +109,13 @@ export interface GalleryFilters {
   max_luminance: string;
   min_histogram_spread: string;
   max_histogram_spread: string;
+  /** Per-channel clipping, percent of pixels in the worst of R/G/B. A photo
+   *  that was never measured is NULL server-side and matches neither bound:
+   *  unknown is not clean. */
+  min_channel_clip_shadow: string;
+  max_channel_clip_shadow: string;
+  min_channel_clip_highlight: string;
+  max_channel_clip_highlight: string;
   // User ratings
   min_star_rating: string;
   max_star_rating: string;
@@ -133,9 +147,18 @@ export interface GalleryFilters {
   gps_lat: string;
   gps_lng: string;
   gps_radius_km: string;
+  // Set scope (photo-detail "open this set in the gallery"). Ephemeral --
+  // NEVER added to RANGE_AND_SELECT_KEYS: sequence_group_id is renumbered
+  // from 1 on every detection pass, so round-tripping it through the URL
+  // would let a bookmarked link silently resolve to a different set later.
+  sequence_group_id: string;
+  sequence_kind: string;
+  burst_group_id: string;
+  duplicate_group_id: string;
   // Display
   hide_details: boolean;
   tooltip_mode: TooltipMode;
+  panel_activation: PanelActivation;
   hide_blinks: boolean;
   hide_bursts: boolean;
   hide_duplicates: boolean;
@@ -164,15 +187,17 @@ export interface FilterDefaults {
   hide_panoramas?: boolean;
   hide_rejected?: boolean;
   tooltip_mode?: TooltipMode;
+  panel_activation?: PanelActivation;
 }
 
 /** Keys excluded when building smart album filter JSON (display-only, ephemeral, or handled separately). */
 export const SMART_ALBUM_EXCLUDE_KEYS = new Set([
   'page', 'per_page', 'semanticQuery', 'album_id',
   'similar_to', 'similarity_mode', 'min_similarity',
-  'hide_details', 'tooltip_mode', 'hide_blinks', 'hide_bursts',
+  'hide_details', 'tooltip_mode', 'panel_activation', 'hide_blinks', 'hide_bursts',
   'hide_duplicates', 'hide_brackets', 'hide_panoramas', 'hide_rejected',
   'gps_lat', 'gps_lng', 'gps_radius_km',
+  'sequence_group_id', 'sequence_kind', 'burst_group_id', 'duplicate_group_id',
 ]);
 
 /** Common string-typed filter keys shared across URL sync, API params, and filter counting. */
@@ -187,6 +212,8 @@ export const RANGE_AND_SELECT_KEYS: (keyof GalleryFilters)[] = [
   'min_noise', 'max_noise', 'min_dynamic_range', 'max_dynamic_range',
   'min_saturation', 'max_saturation', 'min_luminance', 'max_luminance',
   'min_histogram_spread', 'max_histogram_spread',
+  'min_channel_clip_shadow', 'max_channel_clip_shadow',
+  'min_channel_clip_highlight', 'max_channel_clip_highlight',
   'min_power_point', 'max_power_point', 'min_leading_lines', 'max_leading_lines',
   'min_isolation', 'max_isolation',
   'min_aesthetic_iaa', 'max_aesthetic_iaa', 'min_face_quality_iqa', 'max_face_quality_iqa',
@@ -283,6 +310,10 @@ export const DEFAULT_FILTERS: GalleryFilters = {
   max_luminance: '',
   min_histogram_spread: '',
   max_histogram_spread: '',
+  min_channel_clip_shadow: '',
+  max_channel_clip_shadow: '',
+  min_channel_clip_highlight: '',
+  max_channel_clip_highlight: '',
   min_star_rating: '',
   max_star_rating: '',
   min_iso: '',
@@ -301,11 +332,16 @@ export const DEFAULT_FILTERS: GalleryFilters = {
   gps_lat: '',
   gps_lng: '',
   gps_radius_km: '',
+  sequence_group_id: '',
+  sequence_kind: '',
+  burst_group_id: '',
+  duplicate_group_id: '',
   similar_to: '',
   similarity_mode: 'visual',
   min_similarity: '70',
   hide_details: true,
   tooltip_mode: 'hover',
+  panel_activation: 'both',
   hide_blinks: true,
   hide_bursts: true,
   hide_duplicates: true,
@@ -321,11 +357,11 @@ export const DEFAULT_FILTERS: GalleryFilters = {
 };
 
 export type DisplayOptions = Pick<GalleryFilters,
-  'hide_details' | 'tooltip_mode' | 'hide_blinks' | 'hide_bursts' | 'hide_duplicates' | 'hide_brackets' | 'hide_panoramas' |
+  'hide_details' | 'tooltip_mode' | 'panel_activation' | 'hide_blinks' | 'hide_bursts' | 'hide_duplicates' | 'hide_brackets' | 'hide_panoramas' |
   'hide_rejected' | 'favorites_only' | 'is_monochrome'>;
 
 export const DISPLAY_OPTION_KEYS: (keyof DisplayOptions)[] = [
-  'hide_details', 'tooltip_mode', 'hide_blinks', 'hide_bursts', 'hide_duplicates', 'hide_brackets', 'hide_panoramas',
+  'hide_details', 'tooltip_mode', 'panel_activation', 'hide_blinks', 'hide_bursts', 'hide_duplicates', 'hide_brackets', 'hide_panoramas',
   'hide_rejected', 'favorites_only', 'is_monochrome',
 ];
 
@@ -391,6 +427,9 @@ export function applyQueryParams(
   if (params['tooltip_mode'] && TOOLTIP_MODES.includes(params['tooltip_mode'] as TooltipMode)) {
     result.tooltip_mode = params['tooltip_mode'] as TooltipMode;
   }
+  if (params['panel_activation'] && PANEL_ACTIVATIONS.includes(params['panel_activation'] as PanelActivation)) {
+    result.panel_activation = params['panel_activation'] as PanelActivation;
+  }
   if (params['page']) result.page = parseInt(params['page'], 10) || 1;
 
   return result;
@@ -429,6 +468,8 @@ export function buildSyncParams(
     params['hide_rejected'] = String(f.hide_rejected);
   if (f.tooltip_mode !== (defaults?.tooltip_mode ?? 'hover'))
     params['tooltip_mode'] = f.tooltip_mode;
+  if (f.panel_activation !== (defaults?.panel_activation ?? 'both'))
+    params['panel_activation'] = f.panel_activation;
   if (f.favorites_only) params['favorites_only'] = 'true';
   if (f.is_monochrome) params['is_monochrome'] = 'true';
 
@@ -447,7 +488,10 @@ export function buildApiParams(
     sort_direction: f.sort_direction,
   };
 
-  const stringKeys: (keyof GalleryFilters)[] = [...RANGE_AND_SELECT_KEYS, 'album_id'];
+  const stringKeys: (keyof GalleryFilters)[] = [
+    ...RANGE_AND_SELECT_KEYS, 'album_id',
+    'sequence_group_id', 'sequence_kind', 'burst_group_id', 'duplicate_group_id',
+  ];
   for (const key of stringKeys) {
     if (f[key]) params[key] = String(f[key]);
   }

--- a/client/src/app/features/gallery/gallery.component.spec.ts
+++ b/client/src/app/features/gallery/gallery.component.spec.ts
@@ -317,6 +317,79 @@ describe('GalleryComponent', () => {
       expect(mockStore.photos()).toHaveLength(1);
       expect(mockStore.initializing()).toBe(false);
     });
+
+    describe('set scope carried from photo-detail navigation state', () => {
+      afterEach(() => {
+        history.replaceState({}, '', '/');
+      });
+
+      it('applies the scope before the first load, then clears it so a reload falls back to the plain gallery', async () => {
+        history.replaceState({
+          setScope: {
+            sequence_group_id: '68', sequence_kind: 'bracket', burst_group_id: '', duplicate_group_id: '',
+            hide_brackets: false,
+          },
+        }, '', '/');
+
+        await component.ngOnInit();
+
+        expect(mockStore.loadConfig).toHaveBeenCalled();
+        expect(mockStore.filters()).toMatchObject({
+          sequence_group_id: '68', sequence_kind: 'bracket', hide_brackets: false,
+        });
+        // Cleared immediately: browsers keep history.state for the current
+        // entry across a reload, so leaving it would resolve a reload to a
+        // possibly different (renumbered) set instead of the plain gallery.
+        expect((history.state as Record<string, unknown> | null)?.['setScope']).toBeUndefined();
+      });
+
+      it('bypasses the restore-previous-view fast path even when the snapshot matches', async () => {
+        // Same setup as 'restores the previous view when the URL matches the
+        // snapshot' above, which normally skips loadConfig/loadPhotos entirely
+        // -- a scoped "open this set" request must still get a fresh load.
+        mockStore.photos.set([{ path: '/a.jpg' }]);
+        mockStore.viewSnapshot.set({ scrollTop: 0, albumId: null, filterKey: mockStore.filterKey() });
+        history.replaceState({
+          setScope: {
+            sequence_group_id: '5', sequence_kind: 'panorama', burst_group_id: '', duplicate_group_id: '',
+            hide_panoramas: false,
+          },
+        }, '', '/');
+
+        await component.ngOnInit();
+
+        expect(mockStore.loadConfig).toHaveBeenCalled();
+        expect(mockStore.loadPhotos).toHaveBeenCalled();
+        expect(mockStore.filters()).toMatchObject({
+          sequence_group_id: '5', sequence_kind: 'panorama', hide_panoramas: false,
+        });
+      });
+
+      it('preserves unrelated history-state keys when clearing the consumed scope', async () => {
+        history.replaceState({
+          setScope: {
+            sequence_group_id: '1', sequence_kind: '', burst_group_id: '1', duplicate_group_id: '',
+            hide_bursts: false,
+          },
+          unrelated: 'keep-me',
+        }, '', '/');
+
+        await component.ngOnInit();
+
+        const state = history.state as Record<string, unknown>;
+        expect(state['unrelated']).toBe('keep-me');
+        expect(state['setScope']).toBeUndefined();
+      });
+
+      it('does not touch filters when there is no set-scope state', async () => {
+        history.replaceState({}, '', '/');
+        const before = mockStore.filters();
+
+        await component.ngOnInit();
+
+        expect(mockStore.filters()).toBe(before);
+      });
+    });
   });
 
   describe('hidden-photos banner toggle', () => {
@@ -347,6 +420,50 @@ describe('GalleryComponent', () => {
       component.showAllHidden();
       mockStore.filters.set({ ...DEFAULT_FILTERS, hide_blinks: true, hide_bursts: false, hide_duplicates: false, hide_brackets: false, hide_panoramas: false });
       expect(component.canRestoreHidden()).toBe(false);
+    });
+  });
+
+  describe('thumbnail-migration banner', () => {
+    const RENDER_MIGRATION_KEY = 'facet_render_migration_dismissed';
+
+    function rebuild(): GalleryComponent {
+      return TestBed.runInInjectionContext(() => new GalleryComponent());
+    }
+
+    beforeEach(() => {
+      localStorage.removeItem(RENDER_MIGRATION_KEY);
+      component = rebuild();
+    });
+
+    afterEach(() => localStorage.removeItem(RENDER_MIGRATION_KEY));
+
+    it('stays hidden until the server reports rows awaiting regeneration', () => {
+      mockStore.config.set({ render_migration: { pending: 0 } });
+      expect(component.showRenderMigrationBanner()).toBe(false);
+    });
+
+    it('stays hidden on a build whose config carries no migration block', () => {
+      mockStore.config.set({ features: {} });
+      expect(component.renderMigrationPending()).toBe(0);
+      expect(component.showRenderMigrationBanner()).toBe(false);
+    });
+
+    it('shows the pending count once the server reports one', () => {
+      mockStore.config.set({ render_migration: { pending: 1234 } });
+      expect(component.renderMigrationPending()).toBe(1234);
+      expect(component.showRenderMigrationBanner()).toBe(true);
+    });
+
+    it('hides on dismiss and stays hidden for the next visit', () => {
+      mockStore.config.set({ render_migration: { pending: 12 } });
+      component.dismissRenderMigration();
+
+      expect(component.showRenderMigrationBanner()).toBe(false);
+      expect(localStorage.getItem(RENDER_MIGRATION_KEY)).toBe('true');
+
+      // A migration takes hours, so a reload must not raise the notice again.
+      const reloaded = rebuild();
+      expect(reloaded.showRenderMigrationBanner()).toBe(false);
     });
   });
 
@@ -423,6 +540,87 @@ describe('GalleryComponent', () => {
       component['tooltipPhoto'].set(photo);
       component.hideTooltip();
       expect(component['tooltipPhoto']()).toBeNull();
+    });
+  });
+
+  describe('tooltip mode switch clears a stale tooltipPhoto', () => {
+    function makeCard(): HTMLElement {
+      const card = document.createElement('div');
+      card.className = 'relative rounded-lg';
+      document.body.appendChild(card);
+      return card;
+    }
+    const photo = { path: '/a.jpg', image_width: 4000, image_height: 3000 } as never;
+
+    it('a hover-shown tooltip does not survive a switch to click mode', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'hover' });
+      TestBed.flushEffects();
+      const card = makeCard();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+      expect(component['tooltipPhoto']()).toBe(photo);
+
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'click' });
+      TestBed.flushEffects();
+
+      expect(component['tooltipPhoto']()).toBeNull();
+      card.remove();
+    });
+
+    it('the first click in the new mode shows the tooltip rather than hiding it', () => {
+      // A test asserting only "clicking twice toggles" would pass even if a
+      // stale hover-set tooltipPhoto made this very first click hide instead
+      // of show -- assert the show explicitly.
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'hover' });
+      TestBed.flushEffects();
+      const card = makeCard();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'click' });
+      TestBed.flushEffects();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+
+      expect(component['tooltipPhoto']()).toBe(photo);
+      card.remove();
+    });
+
+    it('a click-pinned tooltip does not survive a switch to hover mode', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'click' });
+      TestBed.flushEffects();
+      const card = makeCard();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+      expect(component['tooltipPhoto']()).toBe(photo);
+
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'hover' });
+      TestBed.flushEffects();
+
+      expect(component['tooltipPhoto']()).toBeNull();
+      card.remove();
+    });
+
+    it('a tooltip does not survive a switch to off mode', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'hover' });
+      TestBed.flushEffects();
+      const card = makeCard();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'off' });
+      TestBed.flushEffects();
+
+      expect(component['tooltipPhoto']()).toBeNull();
+      card.remove();
+    });
+
+    it('switching into panel mode does not carry over a stale hover tooltip', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'hover' });
+      TestBed.flushEffects();
+      const card = makeCard();
+      component.showTooltip({ currentTarget: card } as unknown as MouseEvent, photo);
+
+      mockStore.filters.set({ ...DEFAULT_FILTERS, tooltip_mode: 'panel' });
+      TestBed.flushEffects();
+
+      expect(component['tooltipPhoto']()).toBeNull();
+      card.remove();
     });
   });
 

--- a/client/src/app/features/gallery/gallery.component.spec.ts
+++ b/client/src/app/features/gallery/gallery.component.spec.ts
@@ -6,7 +6,7 @@ import { Subject, of, throwError } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { GalleryStore, GalleryFilters, DEFAULT_FILTERS } from './gallery.store';
-import { buildApiParams } from './gallery-filters.util';
+import { buildApiParams, DISPLAY_OPTIONS_KEY } from './gallery-filters.util';
 import { ApiService } from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
 import { I18nService } from '../../core/services/i18n.service';
@@ -388,6 +388,57 @@ describe('GalleryComponent', () => {
         await component.ngOnInit();
 
         expect(mockStore.filters()).toBe(before);
+      });
+    });
+  });
+
+  describe('clearSetScope()', () => {
+    afterEach(() => {
+      localStorage.removeItem(DISPLAY_OPTIONS_KEY);
+    });
+
+    it('does nothing when no set scope is active', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS });
+
+      component.clearSetScope();
+
+      expect(mockStore.updateFilters).not.toHaveBeenCalled();
+    });
+
+    it('restores the user\'s stored hide_bursts preference instead of hardcoding true', () => {
+      localStorage.setItem(DISPLAY_OPTIONS_KEY, JSON.stringify({ hide_bursts: false }));
+      mockStore.filters.set({ ...DEFAULT_FILTERS, burst_group_id: '7', hide_bursts: false });
+
+      component.clearSetScope();
+
+      expect(mockStore.updateFilters).toHaveBeenCalledWith({
+        sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
+        hide_bursts: false,
+      });
+    });
+
+    it('falls back to the config default when nothing is stored in localStorage', () => {
+      mockStore.config.set({ defaults: { hide_panoramas: false } });
+      mockStore.filters.set({
+        ...DEFAULT_FILTERS, sequence_kind: 'panorama', sequence_group_id: '3', hide_panoramas: false,
+      });
+
+      component.clearSetScope();
+
+      expect(mockStore.updateFilters).toHaveBeenCalledWith({
+        sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
+        hide_panoramas: false,
+      });
+    });
+
+    it('falls back to true when neither storage nor config supplies a value', () => {
+      mockStore.filters.set({ ...DEFAULT_FILTERS, duplicate_group_id: '9', hide_duplicates: false });
+
+      component.clearSetScope();
+
+      expect(mockStore.updateFilters).toHaveBeenCalledWith({
+        sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
+        hide_duplicates: true,
       });
     });
   });

--- a/client/src/app/features/gallery/gallery.component.ts
+++ b/client/src/app/features/gallery/gallery.component.ts
@@ -35,6 +35,7 @@ import { isTypingContext } from '../../shared/utils/keyboard';
 import { UndoService } from '../../core/services/undo.service';
 import { SequenceOverrideService, SequenceKind } from '../../core/services/sequence-override.service';
 import { SequenceKindIconPipe } from '../../shared/pipes/sequence-kind.pipe';
+import { PhotoSetKindIconPipe, PhotoSetKindLabelPipe } from '../../shared/pipes/photo-set-kind.pipe';
 import { AuthService } from '../../core/services/auth.service';
 import { useDesktopSignal, DETAILS_RAIL_MIN_WIDTH_PX } from '../../shared/utils/media-query';
 import { downloadAll } from '../../shared/utils/download';
@@ -62,10 +63,13 @@ import { I18N, I18N_KEYS } from '../../core/i18n/keys';
 import { PageHelpService } from '../../core/services/page-help.service';
 import { HeaderSlotService } from '../../core/services/header-slot.service';
 import { MAX_COMPARE_PANES } from './synced-zoom.component';
+import { HistogramMode, isHistogramMode } from '../../shared/utils/histogram';
 
 /** The three toggles the hidden-photos banner clears and restores together. */
 type HiddenFilterFlags = Pick<GalleryFilters,
   'hide_blinks' | 'hide_bursts' | 'hide_duplicates' | 'hide_brackets' | 'hide_panoramas'>;
+
+const RENDER_MIGRATION_DISMISSED_KEY = 'facet_render_migration_dismissed';
 
 
 @Component({
@@ -85,6 +89,8 @@ type HiddenFilterFlags = Pick<GalleryFilters,
     MatBottomSheetModule,
     TranslatePipe,
     SequenceKindIconPipe,
+    PhotoSetKindIconPipe,
+    PhotoSetKindLabelPipe,
     MatSnackBarModule,
     PhotoTooltipComponent,
     SlideshowComponent,
@@ -170,7 +176,10 @@ type HiddenFilterFlags = Pick<GalleryFilters,
         @if (detailsRailVisible()) {
           <div class="p-2">
             @if (tooltipPhoto(); as p) {
-              <app-photo-tooltip [photo]="p" [docked]="true" />
+              <app-photo-tooltip [photo]="p" [docked]="true" [pinned]="true"
+                                 [histogramDefaultMode]="tooltipHistogramDefaultMode()"
+                                 [indicatorPercent]="clippingIndicatorPercent()"
+                                 (personSelected)="store.updateFilter('person_id', $event)" />
             } @else {
               <div class="rounded-xl p-4 text-sm opacity-60 text-center"
                    style="background: var(--facet-tooltip-bg); border: 1px solid var(--facet-tooltip-border)">
@@ -205,6 +214,38 @@ type HiddenFilterFlags = Pick<GalleryFilters,
             </span>
             <button mat-button class="!min-w-0" (click)="restoreHidden()">
               {{ I18N.gallery.hidden_banner.restore | translate }}
+            </button>
+          </div>
+        }
+
+        <!-- Set-scope chip: the photo-detail "open this set in the gallery" action.
+             Never reflected in the URL (sequence_group_id is renumbered on every
+             detection pass), so this is the only affordance out of it. -->
+        @if (setScopeKind(); as kind) {
+          <div class="mx-2 md:mx-4 mt-2 md:mt-4 px-3 py-2 rounded-md bg-[var(--mat-sys-surface-container-high)] border border-[var(--mat-sys-outline-variant)] flex items-center gap-3 text-sm">
+            <mat-icon class="opacity-70 !text-base !w-5 !h-5">{{ kind | photoSetKindIcon }}</mat-icon>
+            <span class="flex-1">
+              {{ I18N.gallery.set_scope.message | translate:{ kind: (kind | photoSetKindLabel | translate) } }}
+            </span>
+            <button mat-button class="!min-w-0" (click)="clearSetScope()">
+              {{ I18N.ui.buttons.clear | translate }}
+            </button>
+          </div>
+        }
+
+        <!-- Thumbnail-migration notice. The grid reads photos.thumbnail, so a RAW
+             scanned before the render fix keeps showing the old rendering until it
+             is regenerated, and browsing never regenerates it. This banner is the
+             only place the command that does is surfaced. -->
+        @if (showRenderMigrationBanner()) {
+          <div class="mx-2 md:mx-4 mt-2 md:mt-4 px-3 py-2 rounded-md bg-[var(--mat-sys-surface-container-high)] border border-[var(--mat-sys-outline-variant)] flex items-center gap-3 text-sm">
+            <mat-icon class="opacity-70 !text-base !w-5 !h-5">auto_fix_high</mat-icon>
+            <span class="flex-1">
+              {{ I18N.gallery.render_migration.message | translate:{ n: renderMigrationPending() } }}
+              {{ I18N.gallery.render_migration.command_hint | translate:{ command: REFRESH_THUMBNAILS_COMMAND } }}
+            </span>
+            <button mat-button class="!min-w-0" (click)="dismissRenderMigration()">
+              {{ I18N.ui.buttons.dismiss | translate }}
             </button>
           </div>
         }
@@ -250,6 +291,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
                   @for (photo of row.photos; track photo.path; let i = $index) {
                     <app-photo-card
                   [collapsedSequenceKinds]="collapsedSequenceKinds()"
+                  [burstFramesVisible]="burstFramesVisible()"
                       [photo]="photo"
                       [attr.data-pidx]="row.startIndex + i"
                       [style.width.px]="row.widths[i]"
@@ -264,6 +306,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
                       [isEditionMode]="auth.isEdition()"
                       [personFilterId]="store.filters().person_id"
                       [tooltipMode]="tooltipMode()"
+                      [panelActivation]="panelActivation()"
                       (selectionChange)="toggleSelection($event.photo, $event.event)"
                       (tooltipShow)="showTooltip($event.event, $event.photo)"
                       (tooltipHide)="hideTooltip()"
@@ -296,6 +339,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
               @for (photo of store.photos(); track photo.path; let i = $index) {
                 <app-photo-card
                   [collapsedSequenceKinds]="collapsedSequenceKinds()"
+                  [burstFramesVisible]="burstFramesVisible()"
                   [photo]="photo"
                   [attr.data-pidx]="i"
                   [config]="store.config()"
@@ -306,6 +350,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
                   [isEditionMode]="auth.isEdition()"
                   [personFilterId]="store.filters().person_id"
                   [tooltipMode]="tooltipMode()"
+                      [panelActivation]="panelActivation()"
                   [style.content-visibility]="'auto'"
                   [style.contain-intrinsic-size]="'auto ' + (cardWidth() + 80) + 'px'"
                   (selectionChange)="toggleSelection($event.photo, $event.event)"
@@ -338,6 +383,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
                   @for (photo of row.photos; track photo.path; let i = $index) {
                     <app-photo-card
                   [collapsedSequenceKinds]="collapsedSequenceKinds()"
+                  [burstFramesVisible]="burstFramesVisible()"
                       [photo]="photo"
                       [attr.data-pidx]="row.startIndex + i"
                       [style.width.px]="row.widths[i]"
@@ -351,6 +397,7 @@ type HiddenFilterFlags = Pick<GalleryFilters,
                       [isEditionMode]="auth.isEdition()"
                       [personFilterId]="store.filters().person_id"
                       [tooltipMode]="tooltipMode()"
+                      [panelActivation]="panelActivation()"
                       (selectionChange)="toggleSelection($event.photo, $event.event)"
                       (tooltipShow)="showTooltip($event.event, $event.photo)"
                       (tooltipHide)="hideTooltip()"
@@ -459,6 +506,10 @@ type HiddenFilterFlags = Pick<GalleryFilters,
         [x]="tooltipX()"
         [y]="tooltipY()"
         [flipped]="tooltipFlipped()"
+        [pinned]="tooltipMode() === 'click'"
+        [histogramDefaultMode]="tooltipHistogramDefaultMode()"
+        [indicatorPercent]="clippingIndicatorPercent()"
+        (personSelected)="store.updateFilter('person_id', $event)"
       />
     }
 
@@ -670,6 +721,8 @@ export class GalleryComponent implements OnInit, OnDestroy {
 
   /** Tooltip mode signal — 'hover' | 'click' | 'off' */
   readonly tooltipMode = computed(() => this.store.filters().tooltip_mode);
+  /** Which gesture(s) retarget the docked panel — only meaningful when tooltipMode is 'panel'. */
+  readonly panelActivation = computed(() => this.store.filters().panel_activation);
   /** Whether tooltip is fully disabled (off mode) — used for skipping rendering and hover handlers */
   readonly tooltipDisabled = computed(() => this.tooltipMode() === 'off');
 
@@ -698,6 +751,25 @@ export class GalleryComponent implements OnInit, OnDestroy {
     if (f.hide_brackets) kinds.push('bracket');
     if (f.hide_panoramas) kinds.push('panorama', 'hdr_panorama');
     return kinds;
+  });
+
+  /** Whether a burst's non-lead frames are on screen.
+   *
+   *  Drives the "best" badge, and is the mirror of the rule above: with
+   *  `hide_bursts` on -- the default -- every burst photo in the grid is
+   *  already its group's lead, so badging each of them would say nothing. */
+  readonly burstFramesVisible = computed(() => !this.store.filters().hide_bursts);
+
+  /** Percent of clipped pixels a channel must exceed to earn a histogram marker. */
+  readonly clippingIndicatorPercent = computed(
+    () => this.store.config()?.clipping?.indicator_percent ?? 1);
+
+  /** House default for the tooltip's OWN histogram channel mode -- independent
+   *  of the detail panel's `viewer.clipping.histogram_mode`. A stale/unrecognised
+   *  config value degrades to 'luma' rather than the widget rendering nothing. */
+  readonly tooltipHistogramDefaultMode = computed<HistogramMode>(() => {
+    const configured = this.store.config()?.clipping?.tooltip_histogram_mode;
+    return isHistogramMode(configured) ? configured : 'luma';
   });
 
   /** Show the hidden-photos banner when filters are hiding rows and at least one is on. */
@@ -749,6 +821,54 @@ export class GalleryComponent implements OnInit, OnDestroy {
     if (!stash) return;
     this.hiddenFiltersStash.set(null);
     void this.store.updateFilters({ ...stash });
+  }
+
+  /** The active set-scope kind (from photo-detail's "open this set"), or null. */
+  readonly setScopeKind = computed(() => {
+    const f = this.store.filters();
+    if (f.sequence_kind && f.sequence_group_id) return f.sequence_kind;
+    if (f.burst_group_id) return 'burst';
+    if (f.duplicate_group_id) return 'duplicate';
+    return null;
+  });
+
+  /** The command that migrates the whole library in one go. */
+  protected readonly REFRESH_THUMBNAILS_COMMAND = 'python facet.py --refresh-thumbnails';
+
+  /** RAW rows still on the pre-fix rendering, as of the last config load. */
+  readonly renderMigrationPending = computed(
+    () => this.store.config()?.render_migration?.pending ?? 0,
+  );
+
+  /**
+   * Dismissal is remembered, like the culling swipe hint: the notice is advisory
+   * and the migration can take hours, so re-raising it on every visit would be
+   * nagging rather than informing.
+   */
+  private readonly renderMigrationDismissed = signal(
+    localStorage.getItem(RENDER_MIGRATION_DISMISSED_KEY) === 'true',
+  );
+
+  readonly showRenderMigrationBanner = computed(
+    () => this.renderMigrationPending() > 0 && !this.renderMigrationDismissed(),
+  );
+
+  dismissRenderMigration(): void {
+    localStorage.setItem(RENDER_MIGRATION_DISMISSED_KEY, 'true');
+    this.renderMigrationDismissed.set(true);
+  }
+
+  clearSetScope(): void {
+    const kind = this.setScopeKind();
+    if (!kind) return;
+    const updates: Partial<GalleryFilters> = {
+      sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
+    };
+    if (kind === 'burst') updates.hide_bursts = true;
+    else if (kind === 'duplicate') updates.hide_duplicates = true;
+    else if (kind === 'bracket') updates.hide_brackets = true;
+    else updates.hide_panoramas = true;
+    void this.store.updateFilters(updates);
   }
 
   /** Container width for mosaic layout (updated via ResizeObserver) */
@@ -874,15 +994,38 @@ export class GalleryComponent implements OnInit, OnDestroy {
       // Re-measure the virtual window once the new rows are in the DOM
       requestAnimationFrame(() => this.updateWindowPosition());
     });
+
+    // A tooltip shown under one mode's semantics (hover tracks the cursor,
+    // click toggles on the same photo, panel docks and keeps the last one on
+    // mouse-out) must not carry over into another's. Most visibly: a photo
+    // left in tooltipPhoto by hover survives a switch to click mode, so the
+    // FIRST click on that same photo matches showTooltip's toggle condition
+    // and hides instead of shows. A dedicated effect rather than folding this
+    // into the one above: that one also recomputes scroll/virtual-window
+    // layout, which a mode switch has no reason to trigger.
+    effect(() => {
+      this.tooltipMode(); // track dependency
+      untracked(() => this.tooltipPhoto.set(null));
+    });
   }
 
   async ngOnInit(): Promise<void> {
     this.pageHelp.setDescription(I18N.gallery.help);
-    if (this.tryRestoreView()) return;
+    // Read (and clear) BEFORE tryRestoreView: a scoped "open this set" request
+    // means the user wants that new scoped view, never a resumed previous one.
+    const setScope = this.consumeSetScopeState();
+    if (!setScope && this.tryRestoreView()) return;
     // Reset album state to avoid stale singleton data; loadConfig() resets filters from scratch
     this.store.currentAlbum.set(null);
     this.store.initializing.set(true);
     await this.store.loadConfig();
+    // Apply the ephemeral set scope AFTER loadConfig, which replaces `filters`
+    // wholesale -- applying it before would just be discarded. Never in the
+    // URL: sequence_group_id is renumbered on every detection pass, so a
+    // bookmarked/shared/reloaded link must never resolve to a different set.
+    if (setScope) {
+      this.store.filters.update(current => ({ ...current, ...setScope }));
+    }
     // Set album_id from route path param (for /album/:albumId route)
     const albumId = this.route.snapshot.paramMap.get('albumId');
     if (albumId) {
@@ -931,6 +1074,26 @@ export class GalleryComponent implements OnInit, OnDestroy {
       albumId: this.route.snapshot.paramMap.get('albumId'),
       filterKey: this.store.filterKey(),
     });
+  }
+
+  /**
+   * Read, and immediately clear, the ephemeral set-scope filters carried from
+   * photo-detail's "open this set in the gallery" action via router
+   * navigation `state` rather than the URL -- `sequence_group_id` is
+   * renumbered on every detection pass, so it must never be bookmarkable or
+   * shareable. Browsers keep `history.state` for the current history entry
+   * across a reload, so it is cleared right after being read: a reload of a
+   * scoped gallery must fall back to the normal unscoped view, not silently
+   * resolve to a possibly-different set.
+   */
+  private consumeSetScopeState(): Partial<GalleryFilters> | null {
+    const state = history.state as Record<string, unknown> | undefined;
+    const scope = state?.['setScope'] as Partial<GalleryFilters> | undefined;
+    if (!scope) return null;
+    const rest: Record<string, unknown> = { ...state };
+    delete rest['setScope'];
+    history.replaceState(rest, '', location.href);
+    return scope;
   }
 
   /**

--- a/client/src/app/features/gallery/gallery.component.ts
+++ b/client/src/app/features/gallery/gallery.component.ts
@@ -54,7 +54,7 @@ import {
   GalleryRow, aspectOf, buildGridRows, buildMosaicRows, gridColumnCount, totalRowsHeight,
   windowRange,
 } from './gallery-rows.util';
-import { GalleryFilters, applyQueryParams } from './gallery-filters.util';
+import { GalleryFilters, applyQueryParams, loadDisplayOptionsFromStorage } from './gallery-filters.util';
 import { AlbumService, Album } from '../../core/services/album.service';
 import { CreateAlbumDialogComponent } from '../albums/create-album-dialog.component';
 import { ExportEditorDialogComponent } from './export-editor-dialog.component';
@@ -864,10 +864,12 @@ export class GalleryComponent implements OnInit, OnDestroy {
     const updates: Partial<GalleryFilters> = {
       sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
     };
-    if (kind === 'burst') updates.hide_bursts = true;
-    else if (kind === 'duplicate') updates.hide_duplicates = true;
-    else if (kind === 'bracket') updates.hide_brackets = true;
-    else updates.hide_panoramas = true;
+    const stored = loadDisplayOptionsFromStorage();
+    const defaults = this.store.config()?.defaults;
+    if (kind === 'burst') updates.hide_bursts = stored.hide_bursts ?? (defaults?.hide_bursts ?? true);
+    else if (kind === 'duplicate') updates.hide_duplicates = stored.hide_duplicates ?? (defaults?.hide_duplicates ?? true);
+    else if (kind === 'bracket') updates.hide_brackets = stored.hide_brackets ?? (defaults?.hide_brackets ?? true);
+    else updates.hide_panoramas = stored.hide_panoramas ?? (defaults?.hide_panoramas ?? true);
     void this.store.updateFilters(updates);
   }
 

--- a/client/src/app/features/gallery/gallery.store.spec.ts
+++ b/client/src/app/features/gallery/gallery.store.spec.ts
@@ -61,7 +61,7 @@ function makePhoto(overrides: Partial<Photo> = {}): Photo {
     date_taken: null,
     image_width: 1920,
     image_height: 1080,
-    is_best_of_burst: null,
+    is_burst_lead: null,
     burst_group_id: null,
     duplicate_group_id: null,
     is_duplicate_lead: null,
@@ -106,6 +106,7 @@ function makeConfig(overrides: Partial<ViewerConfig> = {}): ViewerConfig {
       hide_panoramas: true,
       hide_details: true,
       tooltip_mode: "hover",
+      panel_activation: "both",
       hide_rejected: true,
       gallery_mode: 'mosaic',
     },
@@ -269,6 +270,7 @@ describe('GalleryStore', () => {
           hide_panoramas: false,
           hide_details: false,
           tooltip_mode: "hover",
+          panel_activation: "both",
           hide_rejected: false,
           gallery_mode: 'mosaic',
         },
@@ -744,6 +746,7 @@ describe('GalleryStore', () => {
           hide_panoramas: true,
           hide_details: true,
           tooltip_mode: "hover",
+          panel_activation: "both",
           hide_rejected: true,
           gallery_mode: 'mosaic',
         },
@@ -1102,6 +1105,27 @@ describe('GalleryStore optimistic mutations', () => {
     void store.toggleRejected('/b.jpg');
     expect(store.photos()[1].is_rejected).toBe(true);
     expect(store.photos()[1].is_favorite).toBe(false);
+  });
+
+  it('toggleRejected clears the star rating, not just is_rejected/is_favorite', () => {
+    apiPost.mockReturnValue(of({ is_rejected: true, star_rating: 0 }));
+    void store.toggleRejected('/a.jpg'); // starts at star_rating: 3
+    expect(store.photos()[0].star_rating).toBeNull();
+  });
+
+  it('toggleRejected reconciles the star rating from the server response', async () => {
+    apiPost.mockReturnValue(of({ is_rejected: true, star_rating: 0 }));
+    await store.toggleRejected('/a.jpg');
+    expect(store.photos()[0].star_rating).toBe(0);
+  });
+
+  it('un-rejecting keeps the prior star rating (server sends null = unchanged)', async () => {
+    store.photos.update(photos =>
+      photos.map(p => p.path === '/a.jpg' ? { ...p, is_rejected: true, star_rating: null } : p));
+    apiPost.mockReturnValue(of({ is_rejected: false, star_rating: null }));
+    await store.toggleRejected('/a.jpg');
+    expect(store.photos()[0].is_rejected).toBe(false);
+    expect(store.photos()[0].star_rating).toBeNull();
   });
 
   it('ignores a second toggleFavorite call for the same path while the first is still in flight', async () => {

--- a/client/src/app/features/gallery/gallery.store.spec.ts
+++ b/client/src/app/features/gallery/gallery.store.spec.ts
@@ -116,7 +116,6 @@ function makeConfig(overrides: Partial<ViewerConfig> = {}): ViewerConfig {
       show_similar_button: false,
       show_merge_suggestions: false,
       show_rating_controls: false,
-      show_rating_badge: false,
       show_semantic_search: false,
       show_albums: false,
       show_critique: false,

--- a/client/src/app/features/gallery/gallery.store.ts
+++ b/client/src/app/features/gallery/gallery.store.ts
@@ -9,7 +9,7 @@ import { I18nService } from '../../core/services/i18n.service';
 import { Photo, KeeperHint } from '../../shared/models/photo.model';
 import { I18N } from '../../core/i18n/keys';
 import {
-  type GalleryFilters, type GalleryMode, type TooltipMode, type DisplayOptions,
+  type GalleryFilters, type GalleryMode, type TooltipMode, type PanelActivation, type DisplayOptions,
   DEFAULT_FILTERS, SMART_ALBUM_EXCLUDE_KEYS, DISPLAY_OPTION_KEYS,
   GALLERY_MODE_KEY, DRAWER_STATE_KEY, CARD_WIDTH_KEY,
   loadDisplayOptionsFromStorage, saveDisplayOptionsToStorage,
@@ -17,7 +17,7 @@ import {
 } from './gallery-filters.util';
 
 // Re-export the filter types/consts so existing importers of gallery.store keep working.
-export type { GalleryFilters, GalleryMode, TooltipMode, DisplayOptions };
+export type { GalleryFilters, GalleryMode, TooltipMode, PanelActivation, DisplayOptions };
 export { DEFAULT_FILTERS, SMART_ALBUM_EXCLUDE_KEYS };
 
 export const FILTER_OPTIONS_TIMEOUT_MS = 20000;
@@ -90,6 +90,7 @@ export interface ViewerConfig {
     hide_panoramas: boolean;
     hide_details: boolean;
     tooltip_mode: TooltipMode;
+    panel_activation: PanelActivation;
     hide_rejected: boolean;
     gallery_mode: GalleryMode;
   };
@@ -131,6 +132,19 @@ export interface ViewerConfig {
     excellent: number;
     best: number;
   };
+  /** Per-badge opt-out for the gallery card (`viewer.badges`). Every key
+   *  defaults to true except shadow clipping — see DEFAULT_BADGE_VISIBILITY. */
+  badges?: Record<string, boolean>;
+  /** One definition of "clipped" shared by the card badge, the histogram
+   *  markers and the gallery filter, plus each histogram surface's own house
+   *  default channel mode (validated with `isHistogramMode` before use — the
+   *  server sends a plain string). */
+  clipping?: {
+    badge_percent?: number;
+    indicator_percent?: number;
+    histogram_mode?: string;
+    tooltip_histogram_mode?: string;
+  };
   /** Min narrative-moment posterior below which a moment label is shown dimmed + "(uncertain)". 0 = never dim. */
   moment_confidence_min?: number;
   /** Social-export crop presets surfaced to the download menu. */
@@ -139,6 +153,10 @@ export interface ViewerConfig {
   };
   /** Named darktable styles for the edited-look cull preview. Empty/absent = feature hidden. */
   cull_styles?: { name: string; label_key: string }[];
+  /** RAW rows whose stored thumbnail still comes from the pre-fix rendering.
+   *  Served from the stats cache, so it is an estimate that trails the last refresh
+   *  by at most one TTL — never a number to drive anything but the advisory banner. */
+  render_migration?: { pending: number };
   [key: string]: unknown;
 }
 
@@ -357,6 +375,7 @@ export class GalleryStore {
         type: defaults?.type ?? '',
         hide_details: storedDisplay.hide_details ?? (defaults?.hide_details ?? true),
         tooltip_mode: storedDisplay.tooltip_mode ?? (defaults?.tooltip_mode ?? 'hover'),
+        panel_activation: storedDisplay.panel_activation ?? (defaults?.panel_activation ?? 'both'),
         hide_blinks: storedDisplay.hide_blinks ?? (defaults?.hide_blinks ?? true),
         hide_bursts: storedDisplay.hide_bursts ?? (defaults?.hide_bursts ?? true),
         hide_duplicates: storedDisplay.hide_duplicates ?? (defaults?.hide_duplicates ?? true),
@@ -477,7 +496,7 @@ export class GalleryStore {
 
   /** Display-only keys that never affect the API query */
   private static readonly DISPLAY_ONLY_KEYS: ReadonlySet<keyof GalleryFilters> = new Set([
-    'hide_details', 'tooltip_mode',
+    'hide_details', 'tooltip_mode', 'panel_activation',
   ]);
 
   /** Update a single filter and reload photos from page 1 */
@@ -555,6 +574,7 @@ export class GalleryStore {
       sort_direction: defaults?.sort_direction ?? 'DESC',
       hide_details: defaults?.hide_details ?? true,
       tooltip_mode: defaults?.tooltip_mode ?? 'hover',
+      panel_activation: defaults?.panel_activation ?? 'both',
       hide_blinks: defaults?.hide_blinks ?? true,
       hide_bursts: defaults?.hide_bursts ?? true,
       hide_duplicates: defaults?.hide_duplicates ?? true,
@@ -794,14 +814,16 @@ export class GalleryStore {
       this.patchPhoto(photoPath, {
         is_rejected: next,
         is_favorite: next ? false : prev.is_favorite,
+        star_rating: next ? null : prev.star_rating,
       });
       try {
         const res = await firstValueFrom(
-          this.api.post<{ is_rejected: boolean }>('/photo/toggle_rejected', { photo_path: photoPath }),
+          this.api.post<{ is_rejected: boolean; star_rating: number | null }>('/photo/toggle_rejected', { photo_path: photoPath }),
         );
         this.patchPhoto(photoPath, {
           is_rejected: res.is_rejected,
           is_favorite: res.is_rejected ? false : prev.is_favorite,
+          star_rating: res.star_rating === null ? prev.star_rating : res.star_rating,
         });
       } catch {
         this.revertSnapshot(snap);

--- a/client/src/app/features/gallery/gallery.store.ts
+++ b/client/src/app/features/gallery/gallery.store.ts
@@ -110,7 +110,6 @@ export interface ViewerConfig {
     show_similar_button: boolean;
     show_merge_suggestions: boolean;
     show_rating_controls: boolean;
-    show_rating_badge: boolean;
     show_semantic_search: boolean;
     show_albums: boolean;
     show_critique: boolean;

--- a/client/src/app/features/gallery/person-selector-dialog.component.ts
+++ b/client/src/app/features/gallery/person-selector-dialog.component.ts
@@ -53,7 +53,7 @@ import { I18N_KEYS } from '../../core/i18n/keys';
 
         <div class="flex flex-col gap-1 max-h-[360px] overflow-y-auto">
           <button
-            class="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full border border-dashed border-neutral-600"
+            class="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full border border-dashed border-neutral-600 cursor-pointer"
             (click)="startCreate()"
           >
             <div class="w-14 h-14 rounded-full bg-[var(--mat-sys-surface-container-high)] flex items-center justify-center">
@@ -66,7 +66,7 @@ import { I18N_KEYS } from '../../core/i18n/keys';
 
           @for (person of filtered(); track person.id) {
             <button
-              class="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full"
+              class="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--mat-sys-surface-container-high)] transition-colors text-left w-full cursor-pointer"
               (click)="dialogRef.close({ kind: 'select', person })"
             >
               <img [src]="person.id | personThumbnailUrl"

--- a/client/src/app/features/gallery/photo-tooltip.component.spec.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.spec.ts
@@ -509,10 +509,31 @@ describe('PhotoTooltipComponent', () => {
       vi.advanceTimersByTime(300);
       setFixture.detectChanges();
 
-      const thumbs = setFixture.nativeElement.querySelectorAll('img[alt="/photos/a.jpg"], img[alt="/photos/test.jpg"], img[alt="/photos/c.jpg"]');
+      // size=96 scopes to the sibling strip's thumbnails specifically -- the
+      // main preview image reuses the same "test.jpg" filename at size=640.
+      const thumbs = setFixture.nativeElement.querySelectorAll(
+        'img[src*="size=96"][src*="a.jpg"], img[src*="size=96"][src*="test.jpg"], img[src*="size=96"][src*="c.jpg"]',
+      );
       expect(thumbs.length).toBe(3);
       expect(setFixture.nativeElement.textContent).toContain('+2');
       expect(setFixture.nativeElement.textContent).toContain('−2');
+    });
+
+    it('labels each sibling button with its position in the set and EV offset, not the filesystem path', () => {
+      mockSetWithMembers();
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      const img = setFixture.nativeElement.querySelector('img[src*="a.jpg"]') as HTMLElement;
+      const button = img.closest('button') as HTMLButtonElement;
+      // mockI18n.t() returns the raw key (no interpolation), so the position
+      // clause below is the untranslated key -- only the EV suffix comes from
+      // the real (unmocked) evOffset pipe.
+      expect(button.getAttribute('aria-label')).toBe('photo_detail.set.member_position, −2 EV');
+      expect(img.getAttribute('alt')).toBe('');
     });
 
     it('does not show sibling thumbnails in the floating (non-docked, non-pinned) tooltip', () => {
@@ -522,7 +543,7 @@ describe('PhotoTooltipComponent', () => {
       vi.advanceTimersByTime(300);
       setFixture.detectChanges();
 
-      expect(setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]')).toBeNull();
+      expect(setFixture.nativeElement.querySelector('img[src*="a.jpg"]')).toBeNull();
     });
 
     it('clicking a sibling thumbnail opens that frame\'s own detail page', () => {
@@ -533,7 +554,7 @@ describe('PhotoTooltipComponent', () => {
       vi.advanceTimersByTime(300);
       setFixture.detectChanges();
 
-      const img = setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]') as HTMLElement;
+      const img = setFixture.nativeElement.querySelector('img[src*="a.jpg"]') as HTMLElement;
       (img.closest('button') as HTMLButtonElement).click();
 
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/photo'], { queryParams: { path: '/photos/a.jpg' } });
@@ -547,8 +568,8 @@ describe('PhotoTooltipComponent', () => {
       vi.advanceTimersByTime(300);
       setFixture.detectChanges();
 
-      const currentImg = setFixture.nativeElement.querySelector('img[alt="/photos/test.jpg"]') as HTMLElement;
-      const otherImg = setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]') as HTMLElement;
+      const currentImg = setFixture.nativeElement.querySelector('img[src*="size=96"][src*="test.jpg"]') as HTMLElement;
+      const otherImg = setFixture.nativeElement.querySelector('img[src*="a.jpg"]') as HTMLElement;
       expect(currentImg.closest('button')!.className).toContain('ring-2');
       expect(otherImg.closest('button')!.className).not.toContain('ring-2');
     });

--- a/client/src/app/features/gallery/photo-tooltip.component.spec.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.spec.ts
@@ -1,8 +1,12 @@
+import type { Mock } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 import { PhotoTooltipComponent, CategoryLabelPipe } from './photo-tooltip.component';
+import { ApiService } from '../../core/services/api.service';
 import { I18nService } from '../../core/services/i18n.service';
-import type { Photo } from '../../shared/models/photo.model';
+import type { Photo, PhotoSet } from '../../shared/models/photo.model';
 
 const makePhoto = (overrides: Partial<Photo> = {}): Photo => ({
   path: '/photos/test.jpg',
@@ -47,7 +51,7 @@ const makePhoto = (overrides: Partial<Photo> = {}): Photo => ({
   date_taken: null,
   image_width: 1920,
   image_height: 1080,
-  is_best_of_burst: null,
+  is_burst_lead: null,
   burst_group_id: null,
   duplicate_group_id: null,
   is_duplicate_lead: null,
@@ -70,21 +74,29 @@ const makePhoto = (overrides: Partial<Photo> = {}): Photo => ({
 @Component({
   selector: 'test-host',
   imports: [PhotoTooltipComponent],
-  template: `<app-photo-tooltip [photo]="photo()" [x]="0" [y]="0" [flipped]="flipped()" />`,
+  template: `<app-photo-tooltip [photo]="photo()" [x]="0" [y]="0" [flipped]="flipped()"
+                                 [pinned]="pinned()" [docked]="docked()" />`,
 })
 class TestHostComponent {
   photo = signal<Photo | null>(null);
   flipped = signal(false);
+  pinned = signal(false);
+  docked = signal(false);
 }
 
 describe('PhotoTooltipComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   const mockI18n = { t: (key: string) => key, locale: vi.fn(() => 'en'), translations: vi.fn(() => ({})) };
+  const mockRouter = { navigate: vi.fn(() => Promise.resolve(true)) };
 
   beforeEach(async () => {
+    mockRouter.navigate.mockClear();
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [{ provide: I18nService, useValue: mockI18n }],
+      providers: [
+        { provide: I18nService, useValue: mockI18n },
+        { provide: Router, useValue: mockRouter },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
   });
@@ -285,18 +297,24 @@ describe('PhotoTooltipComponent', () => {
       expect(avatars[1].alt).toBe('Bob');
     });
 
-    it('does not render person section when persons array is empty', () => {
+    it('does not render any avatar when persons array is empty', () => {
       fixture.componentInstance.photo.set(makePhoto({ persons: [] }));
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).not.toContain('tooltip.persons');
+      expect(fixture.nativeElement.querySelectorAll('img[class*="rounded-full"]').length).toBe(0);
     });
 
-    it('renders persons label', () => {
+    it('renders a plain, non-interactive image (no button) in the floating hover tooltip', () => {
+      // showInteractiveControls() is false here: neither docked nor pinned
+      // was set on the host, so the avatar must not look clickable when it
+      // is not -- a hover bubble dismisses before a click could land.
       fixture.componentInstance.photo.set(makePhoto({
         persons: [{ id: 1, name: 'Alice' }],
       }));
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toContain('tooltip.persons');
+      expect(fixture.nativeElement.querySelector('button')).toBeNull();
+      const avatar = fixture.nativeElement.querySelector('img[class*="rounded-full"]');
+      expect(avatar).not.toBeNull();
+      expect(avatar.className).toContain('w-6');
     });
 
     it('handles person with empty name', () => {
@@ -308,6 +326,294 @@ describe('PhotoTooltipComponent', () => {
       expect(avatars.length).toBe(1);
       expect(avatars[0].src).toContain('/person_thumbnail/3');
       expect(avatars[0].alt).toBe('');
+    });
+  });
+
+  describe('Set section', () => {
+    let mockApi: { get: Mock };
+    let setFixture: ComponentFixture<TestHostComponent>;
+
+    beforeEach(async () => {
+      // Discriminates by URL: the histogram widget shares this same mocked
+      // ApiService and needs its own valid response to render anything at all.
+      mockApi = {
+        get: vi.fn((url: string) => {
+          if (url === '/photo/set') {
+            return of({ kind: 'bracket', group_id: 1, count: 3, ev_span: 4, members: [] });
+          }
+          if (url === '/photo/histogram') {
+            return of({ bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null });
+          }
+          return of(null);
+        }),
+      };
+      mockRouter.navigate.mockClear();
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TestHostComponent],
+        providers: [
+          { provide: I18nService, useValue: mockI18n },
+          { provide: ApiService, useValue: mockApi },
+          { provide: Router, useValue: mockRouter },
+        ],
+      }).compileComponents();
+      setFixture = TestBed.createComponent(TestHostComponent);
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows nothing for a photo that belongs to no set', () => {
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).not.toContain('tooltip.set_section');
+      expect(mockApi.get).not.toHaveBeenCalledWith('/photo/set', expect.anything());
+    });
+
+    it('shows the kind and this frame\'s own EV offset immediately, with zero set requests', () => {
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: 'bracket', sequence_ev_offset: 1.5,
+      }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).toContain('tooltip.set_section');
+      expect(setFixture.nativeElement.textContent).toContain('culling.bracket.label');
+      expect(setFixture.nativeElement.textContent).toContain('+1.5 EV');
+      expect(mockApi.get).not.toHaveBeenCalledWith('/photo/set', expect.anything());
+    });
+
+    it('fills in the frame count and EV span once the dwell-delayed fetch resolves', () => {
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: 'bracket', sequence_ev_offset: 0,
+      }));
+      setFixture.detectChanges();
+      expect(setFixture.nativeElement.textContent).not.toContain('capsules.photos_count');
+
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      expect(mockApi.get).toHaveBeenCalledWith('/photo/set', { path: '/photos/test.jpg' });
+      expect(setFixture.nativeElement.textContent).toContain('capsules.photos_count');
+      expect(setFixture.nativeElement.textContent).toContain('±4.0 EV');
+    });
+
+    it('never fires the request at all when the pointer only passes through', () => {
+      setFixture.componentInstance.photo.set(makePhoto({
+        path: '/photos/a.jpg', sequence_kind: 'bracket', sequence_ev_offset: 0,
+      }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(150); // half the dwell delay
+
+      setFixture.componentInstance.photo.set(makePhoto({
+        path: '/photos/b.jpg', sequence_kind: 'bracket', sequence_ev_offset: 0,
+      }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(150); // the first photo's timer never reaches 300ms
+
+      expect(mockApi.get).not.toHaveBeenCalledWith('/photo/set', expect.anything());
+    });
+
+    it('hides the histogram mode toggle in plain hover mode (neither pinned nor docked)', () => {
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.querySelectorAll('button').length).toBe(0);
+    });
+
+    it('shows the histogram mode toggle when pinned', () => {
+      setFixture.componentInstance.pinned.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.querySelectorAll('button').length).toBeGreaterThan(0);
+    });
+
+    it('shows the histogram mode toggle when docked', () => {
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.querySelectorAll('button').length).toBeGreaterThan(0);
+    });
+
+    // --- full-width histogram when the photo belongs to no set ---------------
+
+    function histogramContainer(): HTMLElement | null {
+      return setFixture.nativeElement.querySelector('app-histogram')?.parentElement ?? null;
+    }
+
+    it('the histogram is its own full-width block, not a grid column, when the photo belongs to no set', () => {
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).not.toContain('tooltip.set_section');
+      const container = histogramContainer();
+      expect(container).not.toBeNull();
+      expect(container!.parentElement?.classList.contains('grid')).toBe(false);
+    });
+
+    it('the layout is already full-width on the very first render, before the debounced fetch resolves -- no reflow once it does', () => {
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null }));
+      setFixture.detectChanges();
+
+      // Presence of the set block is decided by the synchronous
+      // p.sequence_kind, never by GET /api/photo/set -- assert the layout is
+      // already correct before advancing the fake timer past the dwell delay.
+      const beforeFetch = histogramContainer()!.parentElement?.classList.contains('grid');
+
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      const afterFetch = histogramContainer()!.parentElement?.classList.contains('grid');
+      expect(beforeFetch).toBe(false);
+      expect(afterFetch).toBe(false);
+    });
+
+    it('keeps the set block and the histogram as two stacked full-width blocks when the photo IS in a set', () => {
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).toContain('tooltip.set_section');
+      const container = histogramContainer();
+      expect(container!.parentElement?.classList.contains('grid')).toBe(false);
+    });
+
+    // --- docked-only sibling thumbnails ---------------------------------------
+
+    const MEMBERS: PhotoSet['members'] = [
+      { path: '/photos/a.jpg', ev_offset: -2, is_lead: false },
+      { path: '/photos/test.jpg', ev_offset: 0, is_lead: true },
+      { path: '/photos/c.jpg', ev_offset: 2, is_lead: false },
+    ];
+
+    function mockSetWithMembers(): void {
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo/set') {
+          return of({ kind: 'bracket', group_id: 1, count: 3, ev_span: 2, members: MEMBERS });
+        }
+        if (url === '/photo/histogram') {
+          return of({ bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null });
+        }
+        return of(null);
+      });
+    }
+
+    it('shows sibling thumbnails with an EV badge in the docked panel once the fetch resolves', () => {
+      mockSetWithMembers();
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      const thumbs = setFixture.nativeElement.querySelectorAll('img[alt="/photos/a.jpg"], img[alt="/photos/test.jpg"], img[alt="/photos/c.jpg"]');
+      expect(thumbs.length).toBe(3);
+      expect(setFixture.nativeElement.textContent).toContain('+2');
+      expect(setFixture.nativeElement.textContent).toContain('−2');
+    });
+
+    it('does not show sibling thumbnails in the floating (non-docked, non-pinned) tooltip', () => {
+      mockSetWithMembers();
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]')).toBeNull();
+    });
+
+    it('clicking a sibling thumbnail opens that frame\'s own detail page', () => {
+      mockSetWithMembers();
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      const img = setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]') as HTMLElement;
+      (img.closest('button') as HTMLButtonElement).click();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/photo'], { queryParams: { path: '/photos/a.jpg' } });
+    });
+
+    it('rings the current frame among its siblings', () => {
+      mockSetWithMembers();
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: 'bracket', sequence_ev_offset: 0 }));
+      setFixture.detectChanges();
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+
+      const currentImg = setFixture.nativeElement.querySelector('img[alt="/photos/test.jpg"]') as HTMLElement;
+      const otherImg = setFixture.nativeElement.querySelector('img[alt="/photos/a.jpg"]') as HTMLElement;
+      expect(currentImg.closest('button')!.className).toContain('ring-2');
+      expect(otherImg.closest('button')!.className).not.toContain('ring-2');
+    });
+
+    // --- clickable, per-surface-sized person avatars --------------------------
+
+    function personButton(): HTMLButtonElement | null {
+      return setFixture.nativeElement.querySelector('button[aria-label]');
+    }
+
+    it('renders person avatars as clickable 44px buttons in the docked panel', () => {
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: null, persons: [{ id: 1, name: 'Alice' }],
+      }));
+      setFixture.detectChanges();
+
+      const button = personButton();
+      expect(button).not.toBeNull();
+      expect(button!.className).toContain('w-11');
+      expect(button!.className).toContain('cursor-pointer');
+      expect(button!.getAttribute('aria-label')).toBe('tooltip.filter_by_person');
+      expect(button!.getAttribute('title')).toBe('Alice');
+    });
+
+    it('keeps person avatars small (24px) in a click-pinned floating tooltip, though still clickable', () => {
+      setFixture.componentInstance.pinned.set(true); // not docked
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: null, persons: [{ id: 1, name: 'Alice' }],
+      }));
+      setFixture.detectChanges();
+
+      const button = personButton();
+      expect(button).not.toBeNull();
+      expect(button!.className).toContain('w-6');
+      expect(button!.className).not.toContain('w-11');
+    });
+
+    it('renders a plain, non-clickable image in plain hover mode (neither docked nor pinned)', () => {
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: null, persons: [{ id: 1, name: 'Alice' }],
+      }));
+      setFixture.detectChanges();
+
+      expect(personButton()).toBeNull();
+      const img = setFixture.nativeElement.querySelector('img[alt="Alice"]');
+      expect(img).not.toBeNull();
+      expect(img.className).toContain('w-6');
+    });
+
+    it('clicking a person avatar emits its id as a plain string -- a bare number would silently match nothing or the wrong set', () => {
+      setFixture.componentInstance.docked.set(true);
+      setFixture.componentInstance.photo.set(makePhoto({
+        sequence_kind: null, persons: [{ id: 42, name: 'Alice' }],
+      }));
+      setFixture.detectChanges();
+
+      const tooltip = setFixture.debugElement.children[0].componentInstance as PhotoTooltipComponent;
+      const emitted: string[] = [];
+      tooltip.personSelected.subscribe((id: string) => emitted.push(id));
+
+      personButton()!.click();
+
+      expect(emitted).toEqual(['42']);
+      expect(typeof emitted[0]).toBe('string');
     });
   });
 });

--- a/client/src/app/features/gallery/photo-tooltip.component.spec.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.spec.ts
@@ -397,7 +397,7 @@ describe('PhotoTooltipComponent', () => {
 
       expect(mockApi.get).toHaveBeenCalledWith('/photo/set', { path: '/photos/test.jpg' });
       expect(setFixture.nativeElement.textContent).toContain('capsules.photos_count');
-      expect(setFixture.nativeElement.textContent).toContain('±4.0 EV');
+      expect(setFixture.nativeElement.textContent).toContain('4.0 EV');
     });
 
     it('never fires the request at all when the pointer only passes through', () => {

--- a/client/src/app/features/gallery/photo-tooltip.component.spec.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.spec.ts
@@ -329,6 +329,32 @@ describe('PhotoTooltipComponent', () => {
     });
   });
 
+  describe('pointer-events on the tooltip container', () => {
+    function container(): HTMLElement {
+      return fixture.nativeElement.querySelector('div[class*="pointer-events-none"]');
+    }
+
+    it('stays pointer-events: none in plain hover mode (neither pinned nor docked)', () => {
+      fixture.componentInstance.photo.set(makePhoto());
+      fixture.detectChanges();
+      expect(container().style.pointerEvents).not.toBe('auto');
+    });
+
+    it('accepts pointer events when click-pinned, so the person and histogram buttons are reachable', () => {
+      fixture.componentInstance.pinned.set(true);
+      fixture.componentInstance.photo.set(makePhoto());
+      fixture.detectChanges();
+      expect(container().style.pointerEvents).toBe('auto');
+    });
+
+    it('accepts pointer events when docked', () => {
+      fixture.componentInstance.docked.set(true);
+      fixture.componentInstance.photo.set(makePhoto());
+      fixture.detectChanges();
+      expect(container().style.pointerEvents).toBe('auto');
+    });
+  });
+
   describe('Set section', () => {
     let mockApi: { get: Mock };
     let setFixture: ComponentFixture<TestHostComponent>;
@@ -371,6 +397,43 @@ describe('PhotoTooltipComponent', () => {
 
       expect(setFixture.nativeElement.textContent).not.toContain('tooltip.set_section');
       expect(mockApi.get).not.toHaveBeenCalledWith('/photo/set', expect.anything());
+    });
+
+    it('shows the Set section for a burst frame even though sequence_kind is null', () => {
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo/set') {
+          return of({ kind: 'burst', group_id: 5, count: 4, ev_span: null, members: [] });
+        }
+        if (url === '/photo/histogram') {
+          return of({ bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null });
+        }
+        return of(null);
+      });
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null, burst_group_id: 'b1' }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).toContain('tooltip.set_section');
+      expect(setFixture.nativeElement.textContent).toContain('culling.type_burst');
+      vi.advanceTimersByTime(300);
+      setFixture.detectChanges();
+      expect(mockApi.get).toHaveBeenCalledWith('/photo/set', { path: '/photos/test.jpg' });
+    });
+
+    it('shows the Set section for a duplicate frame even though sequence_kind is null', () => {
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo/set') {
+          return of({ kind: 'duplicate', group_id: 9, count: 2, ev_span: null, members: [] });
+        }
+        if (url === '/photo/histogram') {
+          return of({ bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null });
+        }
+        return of(null);
+      });
+      setFixture.componentInstance.photo.set(makePhoto({ sequence_kind: null, duplicate_group_id: 'd1' }));
+      setFixture.detectChanges();
+
+      expect(setFixture.nativeElement.textContent).toContain('tooltip.set_section');
+      expect(setFixture.nativeElement.textContent).toContain('photo_detail.set.kind_duplicate');
     });
 
     it('shows the kind and this frame\'s own EV offset immediately, with zero set requests', () => {

--- a/client/src/app/features/gallery/photo-tooltip.component.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.ts
@@ -1,14 +1,28 @@
-import { Component, Pipe, PipeTransform, computed, input } from '@angular/core';
+import { Component, DestroyRef, Pipe, PipeTransform, computed, effect, inject, input, output, signal, untracked } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
-import { Photo } from '../../shared/models/photo.model';
+import { Router } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { catchError, of } from 'rxjs';
+import { Photo, PhotoSet } from '../../shared/models/photo.model';
+import { ApiService } from '../../core/services/api.service';
 import { FixedPipe } from '../../shared/pipes/fixed.pipe';
 import { ShutterSpeedPipe } from '../../shared/pipes/shutter-speed.pipe';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ThumbnailUrlPipe, PersonThumbnailUrlPipe } from '../../shared/pipes/thumbnail-url.pipe';
 import { IsLensNamePipe } from '../../shared/pipes/is-lens-name.pipe';
+import { PhotoSetKindIconPipe, PhotoSetKindLabelPipe } from '../../shared/pipes/photo-set-kind.pipe';
+import { EvOffsetPipe } from './burst-culling.pipes';
 import { MomentLabelPipe } from '../scenes/scenes.pipes';
 import { aspectOf } from './gallery-rows.util';
-import { HistogramComponent } from '../../shared/components/histogram/histogram.component';
+import { HistogramComponent, HISTOGRAM_TOOLTIP_HEIGHT } from '../../shared/components/histogram/histogram.component';
+import { HistogramMode } from '../../shared/utils/histogram';
+
+/** How long the pointer must rest on a photo before the tooltip fetches the
+ *  frame count + EV span for its set. Kind and this frame's own EV offset are
+ *  already on the Photo object and render with zero delay -- only the
+ *  cross-photo fields (`GET /api/photo/set`) are worth debouncing across a
+ *  dense gallery where the pointer crosses many tiles per second. */
+const SET_INFO_DWELL_MS = 300;
 
 // Intentionally keeps literal i18n keys instead of the shared I18N constants: this
 // spec renders right after a Leaflet map spec, and the Angular Vitest builder shares
@@ -27,7 +41,11 @@ export class CategoryLabelPipe implements PipeTransform {
 
 @Component({
   selector: 'app-photo-tooltip',
-  imports: [FixedPipe, ShutterSpeedPipe, TranslatePipe, ThumbnailUrlPipe, PersonThumbnailUrlPipe, CategoryLabelPipe, IsLensNamePipe, MomentLabelPipe, HistogramComponent],
+  imports: [
+    MatIconModule, FixedPipe, ShutterSpeedPipe, TranslatePipe, ThumbnailUrlPipe, PersonThumbnailUrlPipe,
+    CategoryLabelPipe, IsLensNamePipe, PhotoSetKindIconPipe, PhotoSetKindLabelPipe, EvOffsetPipe,
+    MomentLabelPipe, HistogramComponent,
+  ],
   template: `
     @if (photo(); as p) {
       <!-- The class list stays a literal string: Tailwind only generates a
@@ -131,7 +149,7 @@ export class CategoryLabelPipe implements PipeTransform {
                     @if (p.eye_sharpness !== null) {
                       <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.eye_sharpness' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.eye_sharpness | fixed:1 }}</span></div>
                     }
-                    @if (p.face_confidence !== null) {
+                    @if (p.face_confidence !== null && p.face_confidence !== undefined) {
                       <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.face_confidence' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.face_confidence * 100 | fixed:0 }}%</span></div>
                     }
                   }
@@ -219,8 +237,17 @@ export class CategoryLabelPipe implements PipeTransform {
           </div>
         </div>
 
-        <!-- Zone B: Technical + EXIF side-by-side -->
-        <div class="grid gap-3 border-t border-[var(--facet-tooltip-divider)] pt-1.5 mt-2 text-xs leading-relaxed text-[var(--facet-tooltip-text)]"
+        <!-- Zone B: Technical + EXIF side-by-side, then Set (if any) and the
+             histogram stacked below, each spanning the full zone width. Set and
+             the histogram used to share Technical/EXIF's grid-cols, so a set-less
+             photo left the histogram in a half-width column with dead space
+             beside it -- pulling them into their own block fixes that, and since
+             the block's presence is decided by the synchronous p.sequence_kind
+             (never by the debounced GET /api/photo/set fetch), the layout is
+             correct from the very first render and never reflows once the fetch
+             resolves. -->
+        <div class="border-t border-[var(--facet-tooltip-divider)] pt-1.5 mt-2 text-xs leading-relaxed text-[var(--facet-tooltip-text)]">
+        <div class="grid gap-3"
           [class.grid-cols-2]="hasExif()"
           [class.grid-cols-1]="!hasExif()"
         >
@@ -239,13 +266,13 @@ export class CategoryLabelPipe implements PipeTransform {
             @if (p.dynamic_range_stops !== null) {
               <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.dynamic_range' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.dynamic_range_stops | fixed:1 }}</span></div>
             }
-            @if (p.mean_saturation !== null) {
+            @if (p.mean_saturation !== null && p.mean_saturation !== undefined) {
               <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.saturation' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ (p.mean_saturation * 100) | fixed:0 }}%</span></div>
             }
             @if (p.noise_sigma !== null) {
               <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.noise' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.noise_sigma | fixed:1 }}</span></div>
             }
-            @if (p.mean_luminance !== null) {
+            @if (p.mean_luminance !== null && p.mean_luminance !== undefined) {
               <div class="flex justify-between"><span class="text-[var(--facet-tooltip-text-secondary)]">{{ 'tooltip.luminance' | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.mean_luminance * 100 | fixed:0 }}%</span></div>
             }
             @if (p.histogram_spread !== null) {
@@ -277,11 +304,66 @@ export class CategoryLabelPipe implements PipeTransform {
               }
             </div>
           }
+        </div>
 
-          <!-- Luminance histogram (computed from the cached thumbnail) -->
-          <div class="min-w-[120px]">
+          <!-- Set (bracket/panorama/hdr_panorama/burst/duplicate). Kind and this
+               frame's own EV offset are already on the photo object and render
+               instantly; frame count and EV span come from a debounced, dwell-
+               delayed GET /api/photo/set (see the constructor) and fill in once
+               it resolves -- never blocking the rest of the bubble. Sibling
+               thumbnails are docked-only: the rail is parked and reachable,
+               while reaching for one in the floating hover bubble would dismiss
+               it before the click could land -- the same problem that keeps the
+               histogram's mode toggle hover-only-hidden too. -->
+          @if (p.sequence_kind) {
+            <div class="mt-2">
+              <div class="text-[10px] text-[var(--facet-tooltip-text-muted)] uppercase tracking-wider mb-1">{{ 'tooltip.set_section' | translate }}</div>
+              <div class="flex items-center gap-1 flex-wrap">
+                <mat-icon class="!text-sm !w-3.5 !h-3.5 !leading-[14px] opacity-70">{{ p.sequence_kind | photoSetKindIcon }}</mat-icon>
+                <span class="text-[var(--mat-sys-primary)] font-medium">{{ p.sequence_kind | photoSetKindLabel | translate }}</span>
+                @if (p.sequence_ev_offset !== null && p.sequence_ev_offset !== undefined) {
+                  <span class="text-[var(--facet-tooltip-text-secondary)]">{{ p.sequence_ev_offset | evOffset }}</span>
+                }
+              </div>
+              @if (photoSet(); as set) {
+                <div class="flex justify-between gap-2 text-[var(--facet-tooltip-text-secondary)]">
+                  <span>{{ 'capsules.photos_count' | translate:{ count: set.count } }}</span>
+                  @if (set.ev_span !== null) {
+                    <span>&plusmn;{{ set.ev_span | fixed:1 }} EV</span>
+                  }
+                </div>
+                @if (docked() && set.members.length) {
+                  <div class="flex gap-2 flex-wrap mt-2">
+                    @for (member of set.members; track member.path) {
+                      <button type="button"
+                              class="relative rounded-lg overflow-hidden w-14 h-14 shrink-0 cursor-pointer hover:opacity-80 transition-opacity ring-[var(--mat-sys-primary)]"
+                              [class.ring-2]="member.path === p.path"
+                              (click)="openSetMember(member.path)">
+                        <img [src]="member.path | thumbnailUrl:96" [alt]="member.path" class="w-full h-full object-cover" />
+                        @if (member.ev_offset !== null) {
+                          <span class="absolute bottom-0 inset-x-0 text-center text-[0.625rem] leading-4 bg-black/60 text-white">{{ member.ev_offset | evOffset }}</span>
+                        }
+                      </button>
+                    }
+                  </div>
+                }
+              }
+            </div>
+          }
+
+          <!-- Histogram (stored bins, thumbnail sampling as fallback). Always
+               spans the full zone width now -- see the block comment above.
+               The tooltip remembers its OWN channel-mode choice, independent of
+               the detail panel's, and only offers the mode toggle while pinned
+               (docked rail or click-to-pin) -- moving the pointer toward it in
+               hover mode would just dismiss the bubble. -->
+          <div class="mt-2">
             <div class="text-[10px] text-[var(--facet-tooltip-text-muted)] uppercase tracking-wider mb-1">{{ 'tooltip.histogram' | translate }}</div>
-            <app-histogram [src]="p.path | thumbnailUrl:160" />
+            <app-histogram [path]="p.path" [src]="p.path | thumbnailUrl:160" [monochrome]="!!p.is_monochrome"
+                           [height]="HISTOGRAM_TOOLTIP_HEIGHT" [surface]="'tooltip'"
+                           [showModeToggle]="showInteractiveControls()"
+                           [defaultMode]="histogramDefaultMode()"
+                           [indicatorPercent]="indicatorPercent()" />
           </div>
         </div>
 
@@ -294,12 +376,32 @@ export class CategoryLabelPipe implements PipeTransform {
           </div>
         }
 
-        <!-- Zone D: Person avatars -->
+        <!-- Zone D: Person avatars. No label -- round face thumbnails are
+             self-explanatory and the label was just noise competing for width
+             in the rail. Clickable to filter the gallery by that person, but
+             only where showInteractiveControls() holds: a plain hover bubble
+             dismisses before a click could land, so an avatar there must stay
+             a non-interactive image, not a button that looks clickable but
+             is not. Bigger in the docked rail (w-11 = 44px, in the 40-48px
+             legible-face range and a comfortable touch target) since it now
+             has the width the removed label freed up; the floating bubble
+             keeps the original 24px -- it is a dense scan-many-photos
+             surface where large avatars would cost width against the
+             scoring grid, whether or not it happens to be click-pinned. -->
         @if (p.persons.length) {
-          <div class="flex items-center gap-1.5 mt-2 pt-1.5 border-t border-[var(--facet-tooltip-divider)]">
-            <span class="text-[10px] text-[var(--facet-tooltip-text-muted)] uppercase tracking-wider shrink-0">{{ 'tooltip.persons' | translate }}</span>
-            <div class="flex gap-1 flex-wrap">
-              @for (person of p.persons; track person.id) {
+          <div class="flex items-center gap-1.5 flex-wrap mt-2 pt-1.5 border-t border-[var(--facet-tooltip-divider)]">
+            @for (person of p.persons; track person.id) {
+              @if (showInteractiveControls()) {
+                <button type="button"
+                        class="rounded-full ring-1 ring-[var(--facet-tooltip-divider)] cursor-pointer hover:opacity-80 transition-opacity overflow-hidden"
+                        [class.w-11]="docked()" [class.h-11]="docked()"
+                        [class.w-6]="!docked()" [class.h-6]="!docked()"
+                        [attr.aria-label]="'tooltip.filter_by_person' | translate:{ name: person.name }"
+                        [title]="person.name"
+                        (click)="onPersonClick(person.id)">
+                  <img [src]="person.id | personThumbnailUrl" [alt]="person.name" class="w-full h-full object-cover" />
+                </button>
+              } @else {
                 <img
                   [src]="person.id | personThumbnailUrl"
                   [alt]="person.name"
@@ -307,7 +409,7 @@ export class CategoryLabelPipe implements PipeTransform {
                   class="w-6 h-6 rounded-full object-cover ring-1 ring-[var(--facet-tooltip-divider)]"
                 />
               }
-            </div>
+            }
           </div>
         }
 
@@ -317,6 +419,10 @@ export class CategoryLabelPipe implements PipeTransform {
 })
 export class PhotoTooltipComponent {
   readonly photo = input<Photo | null>(null);
+  /** Clipping threshold for the histogram's markers, from `viewer.clipping`.
+   *  Passed in rather than read from config here so the tooltip, the detail
+   *  panel and the gallery badge cannot disagree about what counts as clipped. */
+  readonly indicatorPercent = input(1);
   readonly x = input(0);
   readonly y = input(0);
   readonly flipped = input(false);
@@ -328,6 +434,18 @@ export class PhotoTooltipComponent {
    * across photos is guesswork when the box moves with the cursor.
    */
   readonly docked = input(false);
+  /**
+   * Whether this bubble is held in place rather than dismissed by moving the
+   * pointer -- a docked rail, or a floating bubble kept open by a click. Only
+   * a pinned bubble can host the histogram's mode-toggle buttons: in plain
+   * hover mode, moving the pointer toward them would dismiss the tooltip
+   * before a click could ever land.
+   */
+  readonly pinned = input(false);
+  /** House default for the tooltip's OWN histogram channel mode, from
+   *  `viewer.clipping.tooltip_histogram_mode` -- independent of the detail
+   *  panel's default and of the user's per-surface persisted choice. */
+  readonly histogramDefaultMode = input<HistogramMode>('luma');
 
   /** Whether the photo is landscape orientation (wider than tall).
    *
@@ -344,4 +462,81 @@ export class PhotoTooltipComponent {
     if (!p) return false;
     return !!(p.camera_model || p.lens_model || p.focal_length || p.f_stop || p.shutter_speed || p.iso);
   });
+
+  protected readonly HISTOGRAM_TOOLTIP_HEIGHT = HISTOGRAM_TOOLTIP_HEIGHT;
+  /** Whether this bubble is safe to host click targets beyond the
+   *  toggle-the-photo click itself: the docked rail is always parked, and a
+   *  click-pinned floating bubble does not dismiss on mouse-leave either (see
+   *  onMouseLeave/hoverDriven() in photo-card.component.ts) -- only a plain
+   *  hover bubble does, which is why it is excluded here. Gates the
+   *  histogram's mode-toggle buttons and the person-avatar filter buttons. */
+  protected readonly showInteractiveControls = computed(() => this.docked() || this.pinned());
+
+  private readonly api = inject(ApiService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  private destroyed = false;
+  // Bumped on every photo change so a slow response can't overwrite the set
+  // info of the photo the pointer has already moved on to.
+  private setGeneration = 0;
+
+  /** Frame count + EV span for the photo's set (kind and this frame's own EV
+   *  offset are already on `Photo` and need no fetch). null until the fetch
+   *  resolves, or when the photo has no `sequence_kind` at all. */
+  protected readonly photoSet = signal<PhotoSet | null>(null);
+
+  constructor() {
+    this.destroyRef.onDestroy(() => { this.destroyed = true; });
+    effect(onCleanup => {
+      const p = this.photo();
+      const token = ++this.setGeneration;
+      untracked(() => this.photoSet.set(null));
+      if (!p?.sequence_kind) return;
+      const requestedPath = p.path;
+      // Dwell delay: a pointer merely crossing many tiles never fires this
+      // request at all, since each new photo cancels the previous timer.
+      const timer = setTimeout(() => {
+        const subscription = this.api
+          .get<PhotoSet>('/photo/set', { path: requestedPath })
+          .pipe(catchError(() => of(null)))
+          .subscribe(res => {
+            if (this.destroyed || token !== this.setGeneration) return;
+            this.photoSet.set(res);
+          });
+        onCleanup(() => subscription.unsubscribe());
+      }, SET_INFO_DWELL_MS);
+      onCleanup(() => clearTimeout(timer));
+    });
+  }
+
+  /**
+   * Open a sibling frame's own detail page (docked-panel sibling strip only).
+   *
+   * Chosen over swapping the panel's subject in place: every other sibling-
+   * thumbnail strip in the app (photo-detail's own set block) already opens
+   * the clicked frame's detail page, and a `PhotoSetMember` carries only a
+   * path + EV offset -- not a full `Photo` -- so swapping in place would need
+   * its own fetch anyway. One interaction for the one visual affordance, on
+   * whichever surface it appears on. No `state: { photo }` pre-fetch payload
+   * (unlike the gallery grid's own double-click-to-open): the destination
+   * page's existing query-param fallback fetches it, same as a bookmarked link.
+   */
+  protected openSetMember(path: string): void {
+    this.router.navigate(['/photo'], { queryParams: { path } });
+  }
+
+  /** Emits the clicked person's id, comma-list-formatted the way `person_id`
+   *  filter values already are (a lone id is a valid one-element list) --
+   *  see gallery-filter-sidebar.component.ts's own `ids.join(',')`. Only
+   *  reachable where showInteractiveControls() renders the avatar as a
+   *  button in the first place (docked rail, or a click-pinned floating
+   *  bubble). The click REPLACES the current person filter rather than
+   *  adding to it -- the more predictable outcome for a single click on one
+   *  face -- while the sidebar's own multi-select remains the place to build
+   *  up a filter across several people. */
+  readonly personSelected = output<string>();
+
+  protected onPersonClick(id: number): void {
+    this.personSelected.emit(String(id));
+  }
 }

--- a/client/src/app/features/gallery/photo-tooltip.component.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.ts
@@ -56,7 +56,7 @@ export class CategoryLabelPipe implements PipeTransform {
         class="fixed z-[1000] pointer-events-none flex flex-col backdrop-blur-sm p-2.5 rounded-xl shadow-2xl"
         style="background: var(--facet-tooltip-bg); border: 1px solid var(--facet-tooltip-border)"
         [style.position]="docked() ? 'static' : null"
-        [style.pointer-events]="docked() ? 'auto' : null"
+        [style.pointer-events]="showInteractiveControls() ? 'auto' : null"
         [style.width]="docked() ? '100%' : null"
         [style.left.px]="docked() ? null : x()"
         [style.top.px]="docked() ? null : y()"
@@ -242,7 +242,7 @@ export class CategoryLabelPipe implements PipeTransform {
              the histogram used to share Technical/EXIF's grid-cols, so a set-less
              photo left the histogram in a half-width column with dead space
              beside it -- pulling them into their own block fixes that, and since
-             the block's presence is decided by the synchronous p.sequence_kind
+             the block's presence is decided by the synchronous setKind()
              (never by the debounced GET /api/photo/set fetch), the layout is
              correct from the very first render and never reflows once the fetch
              resolves. -->
@@ -315,12 +315,12 @@ export class CategoryLabelPipe implements PipeTransform {
                while reaching for one in the floating hover bubble would dismiss
                it before the click could land -- the same problem that keeps the
                histogram's mode toggle hover-only-hidden too. -->
-          @if (p.sequence_kind) {
+          @if (setKind(); as kind) {
             <div class="mt-2">
               <div class="text-[10px] text-[var(--facet-tooltip-text-muted)] uppercase tracking-wider mb-1">{{ 'tooltip.set_section' | translate }}</div>
               <div class="flex items-center gap-1 flex-wrap">
-                <mat-icon class="!text-sm !w-3.5 !h-3.5 !leading-[14px] opacity-70">{{ p.sequence_kind | photoSetKindIcon }}</mat-icon>
-                <span class="text-[var(--mat-sys-primary)] font-medium">{{ p.sequence_kind | photoSetKindLabel | translate }}</span>
+                <mat-icon class="!text-sm !w-3.5 !h-3.5 !leading-[14px] opacity-70">{{ kind | photoSetKindIcon }}</mat-icon>
+                <span class="text-[var(--mat-sys-primary)] font-medium">{{ kind | photoSetKindLabel | translate }}</span>
                 @if (p.sequence_ev_offset !== null && p.sequence_ev_offset !== undefined) {
                   <span class="text-[var(--facet-tooltip-text-secondary)]">{{ p.sequence_ev_offset | evOffset }}</span>
                 }
@@ -464,6 +464,19 @@ export class PhotoTooltipComponent {
     return !!(p.camera_model || p.lens_model || p.focal_length || p.f_stop || p.shutter_speed || p.iso);
   });
 
+  /** The set this frame resolves into, mirroring `GET /api/photo/set`'s own
+   *  precedence (sequence, then burst, then duplicate) from fields already on
+   *  the photo object -- 'burst' and 'duplicate' have no `sequence_kind`
+   *  counterpart, since neither is a value that column can hold. */
+  protected readonly setKind = computed(() => {
+    const p = this.photo();
+    if (!p) return null;
+    if (p.sequence_kind) return p.sequence_kind;
+    if (p.burst_group_id != null) return 'burst';
+    if (p.duplicate_group_id != null) return 'duplicate';
+    return null;
+  });
+
   protected readonly HISTOGRAM_TOOLTIP_HEIGHT = HISTOGRAM_TOOLTIP_HEIGHT;
   /** Whether this bubble is safe to host click targets beyond the
    *  toggle-the-photo click itself: the docked rail is always parked, and a
@@ -483,7 +496,7 @@ export class PhotoTooltipComponent {
 
   /** Frame count + EV span for the photo's set (kind and this frame's own EV
    *  offset are already on `Photo` and need no fetch). null until the fetch
-   *  resolves, or when the photo has no `sequence_kind` at all. */
+   *  resolves, or when the photo belongs to no set at all. */
   protected readonly photoSet = signal<PhotoSet | null>(null);
 
   constructor() {
@@ -492,7 +505,7 @@ export class PhotoTooltipComponent {
       const p = this.photo();
       const token = ++this.setGeneration;
       untracked(() => this.photoSet.set(null));
-      if (!p?.sequence_kind) return;
+      if (!p || !this.setKind()) return;
       const requestedPath = p.path;
       // Dwell delay: a pointer merely crossing many tiles never fires this
       // request at all, since each new photo cancels the previous timer.

--- a/client/src/app/features/gallery/photo-tooltip.component.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.ts
@@ -338,8 +338,9 @@ export class CategoryLabelPipe implements PipeTransform {
                       <button type="button"
                               class="relative rounded-lg overflow-hidden w-14 h-14 shrink-0 cursor-pointer hover:opacity-80 transition-opacity ring-[var(--mat-sys-primary)]"
                               [class.ring-2]="member.path === p.path"
+                              [attr.aria-label]="('photo_detail.set.member_position' | translate:{ position: $index + 1, count: set.members.length }) + (member.ev_offset !== null ? ', ' + (member.ev_offset | evOffset) : '')"
                               (click)="openSetMember(member.path)">
-                        <img [src]="member.path | thumbnailUrl:96" [alt]="member.path" class="w-full h-full object-cover" />
+                        <img [src]="member.path | thumbnailUrl:96" alt="" class="w-full h-full object-cover" />
                         @if (member.ev_offset !== null) {
                           <span class="absolute bottom-0 inset-x-0 text-center text-[0.625rem] leading-4 bg-black/60 text-white">{{ member.ev_offset | evOffset }}</span>
                         }

--- a/client/src/app/features/gallery/photo-tooltip.component.ts
+++ b/client/src/app/features/gallery/photo-tooltip.component.ts
@@ -329,7 +329,7 @@ export class CategoryLabelPipe implements PipeTransform {
                 <div class="flex justify-between gap-2 text-[var(--facet-tooltip-text-secondary)]">
                   <span>{{ 'capsules.photos_count' | translate:{ count: set.count } }}</span>
                   @if (set.ev_span !== null) {
-                    <span>&plusmn;{{ set.ev_span | fixed:1 }} EV</span>
+                    <span>{{ set.ev_span | fixed:1 }} EV</span>
                   }
                 </div>
                 @if (docked() && set.members.length) {

--- a/client/src/app/features/junk-sweep/junk-sweep.component.ts
+++ b/client/src/app/features/junk-sweep/junk-sweep.component.ts
@@ -133,14 +133,14 @@ const ANY_KIND = 'any';
               </span>
               <div class="absolute inset-x-0 bottom-0 flex justify-end items-center gap-1 p-1.5 bg-gradient-to-t from-black/70 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
                 <button
-                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-green-400"
+                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-green-400 cursor-pointer"
                   [matTooltip]="I18N.junk.keep_hint | translate"
                   [attr.aria-label]="I18N.junk.keep | translate"
                   (click)="keep(photo)">
                   <mat-icon class="!text-base !w-4 !h-4 !leading-4" aria-hidden="true">check</mat-icon>
                 </button>
                 <button
-                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-red-400"
+                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-red-400 cursor-pointer"
                   [matTooltip]="I18N.junk.reject_hint | translate"
                   [attr.aria-label]="I18N.junk.reject | translate"
                   (click)="reject(photo)">

--- a/client/src/app/features/map/map.component.ts
+++ b/client/src/app/features/map/map.component.ts
@@ -67,7 +67,7 @@ interface MapResponse {
              role="status">
           <mat-icon class="!text-base !w-4 !h-4 !leading-4 shrink-0">cloud_off</mat-icon>
           <span>{{ I18N.map.tiles_unavailable | translate }}</span>
-          <button type="button" class="inline-flex items-center justify-center shrink-0 rounded-full p-0.5 hover:bg-black/20 transition-colors"
+          <button type="button" class="inline-flex items-center justify-center shrink-0 rounded-full p-0.5 hover:bg-black/20 transition-colors cursor-pointer"
                   (click)="dismissTileError()"
                   [attr.aria-label]="I18N.ui.buttons.dismiss | translate">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4">close</mat-icon>

--- a/client/src/app/features/persons/manage-persons.component.ts
+++ b/client/src/app/features/persons/manage-persons.component.ts
@@ -27,6 +27,7 @@ import { PersonCardComponent, Person } from '../../shared/components/person-card
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 import { InfiniteScrollDirective } from '../../shared/directives/infinite-scroll.directive';
 import { PersonsFiltersService } from './persons-filters.service';
+import { GalleryStore } from '../gallery/gallery.store';
 import { I18N, I18N_KEYS } from '../../core/i18n/keys';
 
 interface PersonsResponse {
@@ -60,7 +61,7 @@ export interface SplitPersonResult {
       <div class="grid grid-cols-3 gap-3">
         @for (person of data.persons; track person.id) {
           <button
-            class="flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-colors"
+            class="flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-colors cursor-pointer"
             [class.border-blue-500]="selectedTarget === person.id"
             [class.border-transparent]="selectedTarget !== person.id"
             [class.bg-blue-900/30]="selectedTarget === person.id"
@@ -157,7 +158,7 @@ export class NewPersonDialogComponent {
         <div class="flex flex-wrap gap-2 justify-center">
           @for (face of faces(); track face.id; let i = $index) {
             <button
-              class="relative rounded-lg overflow-hidden border-2 transition-colors"
+              class="relative rounded-lg overflow-hidden border-2 transition-colors cursor-pointer"
               [class.border-blue-500]="selectedIds().has(face.id)"
               [class.border-transparent]="!selectedIds().has(face.id)"
               [attr.aria-pressed]="selectedIds().has(face.id)"
@@ -279,9 +280,11 @@ export class PersonFacesDialogComponent implements OnInit {
         <button mat-icon-button class="!hidden lg:!inline-flex" [matTooltip]="I18N.manage_persons.new_person | translate" [attr.aria-label]="I18N.manage_persons.new_person | translate" (click)="personsFilters.createRequested.set(personsFilters.createRequested() + 1)">
           <mat-icon>person_add</mat-icon>
         </button>
-        <a mat-icon-button class="!hidden lg:!inline-flex" routerLink="/merge-suggestions" [matTooltip]="I18N.persons.merge_suggestions | translate" [attr.aria-label]="I18N.persons.merge_suggestions | translate">
-          <mat-icon>auto_fix_high</mat-icon>
-        </a>
+        @if (store.config()?.features?.show_merge_suggestions) {
+          <a mat-icon-button class="!hidden lg:!inline-flex" routerLink="/merge-suggestions" [matTooltip]="I18N.persons.merge_suggestions | translate" [attr.aria-label]="I18N.persons.merge_suggestions | translate">
+            <mat-icon>auto_fix_high</mat-icon>
+          </a>
+        }
         <button
           class="!hidden lg:!inline-flex"
           mat-icon-button
@@ -308,7 +311,7 @@ export class PersonFacesDialogComponent implements OnInit {
       @if (auth.isEdition() && needsNaming().length > 0) {
         <div class="mb-6 rounded-xl border border-[var(--mat-sys-outline-variant)] bg-[var(--mat-sys-surface-container)] overflow-hidden">
           <button
-            class="flex items-center w-full px-4 py-2 gap-2 text-left hover:bg-[var(--mat-sys-surface-container-high)] transition-colors"
+            class="flex items-center w-full px-4 py-2 gap-2 text-left hover:bg-[var(--mat-sys-surface-container-high)] transition-colors cursor-pointer"
             (click)="needsNamingExpanded.set(!needsNamingExpanded())"
           >
             <mat-icon class="opacity-60">{{ needsNamingExpanded() ? 'expand_more' : 'chevron_right' }}</mat-icon>
@@ -393,6 +396,7 @@ export class PersonFacesDialogComponent implements OnInit {
 export class ManagePersonsComponent implements OnInit {
   protected readonly I18N = I18N_KEYS;
   readonly auth = inject(AuthService);
+  protected readonly store = inject(GalleryStore);
   private readonly api = inject(ApiService);
   private readonly i18n = inject(I18nService);
   private readonly pageHelp = inject(PageHelpService);

--- a/client/src/app/features/photo-detail/photo-detail.component.spec.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.spec.ts
@@ -392,6 +392,27 @@ describe('PhotoDetailComponent', () => {
       expect(component.photo().is_favorite).toBe(false);
     });
 
+    it('clears the star rating when the response reports a reject', async () => {
+      mockApi.post.mockReturnValue(of({ is_rejected: true, is_favorite: null, star_rating: 0 }));
+      createComponent();
+      component.photo.set({ ...samplePhoto, is_rejected: false, is_favorite: false, star_rating: 3 });
+
+      await component.toggleRejected('/photos/test.jpg');
+
+      expect(component.photo().star_rating).toBe(0);
+    });
+
+    it('keeps the prior star rating when un-rejecting (server sends null = unchanged)', async () => {
+      mockApi.post.mockReturnValue(of({ is_rejected: false, is_favorite: null, star_rating: null }));
+      createComponent();
+      component.photo.set({ ...samplePhoto, is_rejected: true, is_favorite: false, star_rating: 4 });
+
+      await component.toggleRejected('/photos/test.jpg');
+
+      expect(component.photo().is_rejected).toBe(false);
+      expect(component.photo().star_rating).toBe(4);
+    });
+
     it('should not call API when photo is null', async () => {
       createComponent();
       component.photo.set(null);
@@ -516,6 +537,167 @@ describe('PhotoDetailComponent', () => {
 
       expect(component.explainerOpen()).toBe(false);
       expect(mockApi.get).not.toHaveBeenCalledWith('/config/category_priorities');
+    });
+  });
+
+  describe('photo set', () => {
+    it('fetches the set for the photo and exposes it', async () => {
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo/set') {
+          return of({ kind: 'bracket', group_id: 1, count: 3, ev_span: 2, members: [] });
+        }
+        if (url === '/download/options') return of({ options: [{ type: 'original', label: 'original' }] });
+        return of(samplePhoto);
+      });
+      createComponent();
+
+      component.photo.set(samplePhoto);
+      TestBed.flushEffects();
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      expect(component.photoSet()).toEqual({ kind: 'bracket', group_id: 1, count: 3, ev_span: 2, members: [] });
+    });
+
+    it('ignores a stale set response after navigating to another photo', async () => {
+      const photoA = { ...samplePhoto, path: '/photos/a.jpg' };
+      const photoB = { ...samplePhoto, path: '/photos/b.jpg' };
+      const setSubjects: Subject<{ kind: string; group_id: number; count: number; ev_span: number | null; members: unknown[] }>[] = [];
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo/set') {
+          const subject = new Subject<{ kind: string; group_id: number; count: number; ev_span: number | null; members: unknown[] }>();
+          setSubjects.push(subject);
+          return subject.asObservable();
+        }
+        if (url === '/download/options') return of({ options: [{ type: 'original', label: 'original' }] });
+        return of(samplePhoto);
+      });
+
+      createComponent();
+      component.photo.set(photoA);
+      TestBed.flushEffects();
+      component.photo.set(photoB);
+      TestBed.flushEffects();
+
+      expect(setSubjects.length).toBe(2);
+
+      setSubjects[1].next({ kind: 'burst', group_id: 5, count: 2, ev_span: null, members: [] });
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+      expect(component.photoSet()?.kind).toBe('burst');
+
+      setSubjects[0].next({ kind: 'duplicate', group_id: 9, count: 2, ev_span: null, members: [] });
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+      expect(component.photoSet()?.kind).toBe('burst');
+    });
+  });
+
+  describe('openSetMember', () => {
+    it('does nothing when clicking the currently open photo', async () => {
+      createComponent();
+      component.photo.set(samplePhoto);
+
+      await component.openSetMember(samplePhoto.path);
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('loads and navigates to the sibling photo', async () => {
+      const sibling = { ...samplePhoto, path: '/photos/sibling.jpg', tags: '', tags_list: undefined, persons: undefined };
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/photo') return of(sibling);
+        if (url === '/download/options') return of({ options: [{ type: 'original', label: 'original' }] });
+        return of({ kind: null, group_id: null, count: 0, ev_span: null, members: [] });
+      });
+      createComponent();
+      component.photo.set(samplePhoto);
+
+      await component.openSetMember('/photos/sibling.jpg');
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/photo'], {
+        queryParams: { path: '/photos/sibling.jpg' },
+        state: { photo: expect.objectContaining({ path: '/photos/sibling.jpg' }) },
+      });
+      expect(component.photo()?.path).toBe('/photos/sibling.jpg');
+    });
+  });
+
+  describe('openSetInGallery', () => {
+    it('does nothing without an active set', () => {
+      createComponent();
+
+      component.openSetInGallery();
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('scopes to the bracket set and clears only hide_brackets, carried via navigation state', () => {
+      createComponent();
+      component.photoSet.set({ kind: 'bracket', group_id: 3, count: 3, ev_span: 2, members: [] });
+      mockRouter.navigate.mockResolvedValue(true);
+
+      component.openSetInGallery();
+
+      // Never the URL / a post-navigate updateFilters() call: the gallery
+      // route re-initialises filters from config + localStorage + URL on
+      // activation, which races a call made after navigate() resolves.
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/'], {
+        state: {
+          setScope: {
+            sequence_group_id: '3', sequence_kind: 'bracket', burst_group_id: '', duplicate_group_id: '',
+            hide_brackets: false,
+          },
+        },
+      });
+    });
+
+    it('scopes to the panorama set and clears only hide_panoramas', () => {
+      createComponent();
+      component.photoSet.set({ kind: 'panorama', group_id: 4, count: 5, ev_span: null, members: [] });
+      mockRouter.navigate.mockResolvedValue(true);
+
+      component.openSetInGallery();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/'], {
+        state: {
+          setScope: {
+            sequence_group_id: '4', sequence_kind: 'panorama', burst_group_id: '', duplicate_group_id: '',
+            hide_panoramas: false,
+          },
+        },
+      });
+    });
+
+    it('scopes to the burst set and clears only hide_bursts', () => {
+      createComponent();
+      component.photoSet.set({ kind: 'burst', group_id: 5, count: 2, ev_span: null, members: [] });
+      mockRouter.navigate.mockResolvedValue(true);
+
+      component.openSetInGallery();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/'], {
+        state: {
+          setScope: {
+            sequence_group_id: '', sequence_kind: '', burst_group_id: '5', duplicate_group_id: '',
+            hide_bursts: false,
+          },
+        },
+      });
+    });
+
+    it('scopes to the duplicate set and clears only hide_duplicates', () => {
+      createComponent();
+      component.photoSet.set({ kind: 'duplicate', group_id: 9, count: 2, ev_span: null, members: [] });
+      mockRouter.navigate.mockResolvedValue(true);
+
+      component.openSetInGallery();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/'], {
+        state: {
+          setScope: {
+            sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '9',
+            hide_duplicates: false,
+          },
+        },
+      });
     });
   });
 });

--- a/client/src/app/features/photo-detail/photo-detail.component.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.ts
@@ -538,7 +538,7 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
                   <span class="font-medium">{{ set.kind | photoSetKindLabel | translate }}</span>
                   <span class="text-xs text-[var(--mat-sys-on-surface-variant)]">{{ I18N.capsules.photos_count | translate:{ count: set.count } }}</span>
                   @if (set.ev_span !== null) {
-                    <span class="text-xs text-[var(--mat-sys-on-surface-variant)]">{{ I18N.photo_detail.set.ev_span | translate }}: &plusmn;{{ set.ev_span | fixed:1 }} EV</span>
+                    <span class="text-xs text-[var(--mat-sys-on-surface-variant)]">{{ I18N.photo_detail.set.ev_span | translate }}: {{ set.ev_span | fixed:1 }} EV</span>
                   }
                 </div>
                 <div class="flex gap-2 flex-wrap">

--- a/client/src/app/features/photo-detail/photo-detail.component.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.ts
@@ -545,8 +545,9 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
                   @for (member of set.members; track member.path) {
                     <button class="relative rounded-lg overflow-hidden w-16 h-16 shrink-0 cursor-pointer hover:opacity-80 transition-opacity ring-[var(--mat-sys-primary)]"
                             [class.ring-2]="member.path === p.path"
+                            [attr.aria-label]="(I18N.photo_detail.set.member_position | translate:{ position: $index + 1, count: set.members.length }) + (member.ev_offset !== null ? ', ' + (member.ev_offset | evOffset) : '')"
                             (click)="openSetMember(member.path)">
-                      <img [src]="member.path | thumbnailUrl:96" [alt]="member.path" class="w-full h-full object-cover" />
+                      <img [src]="member.path | thumbnailUrl:96" alt="" class="w-full h-full object-cover" />
                       @if (member.ev_offset !== null) {
                         <span class="absolute bottom-0 inset-x-0 text-center text-[0.625rem] leading-4 bg-black/60 text-white">{{ member.ev_offset | evOffset }}</span>
                       }

--- a/client/src/app/features/photo-detail/photo-detail.component.ts
+++ b/client/src/app/features/photo-detail/photo-detail.component.ts
@@ -11,7 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { firstValueFrom } from 'rxjs';
-import { Photo, KeeperHint } from '../../shared/models/photo.model';
+import { Photo, KeeperHint, PhotoSet } from '../../shared/models/photo.model';
 import { AuthService } from '../../core/services/auth.service';
 import { PhotoActionsService } from '../../core/services/photo-actions.service';
 import { PhotoDetailBase } from '../../shared/directives/photo-detail-base.directive';
@@ -23,11 +23,17 @@ import { PersonThumbnailUrlPipe } from '../../shared/pipes/thumbnail-url.pipe';
 import { CategoryLabelPipe } from '../gallery/photo-tooltip.component';
 import { IsLensNamePipe } from '../../shared/pipes/is-lens-name.pipe';
 import { DownloadIconPipe } from '../../shared/pipes/download-icon.pipe';
-import { HistogramComponent } from '../../shared/components/histogram/histogram.component';
+import { PhotoSetKindIconPipe, PhotoSetKindLabelPipe } from '../../shared/pipes/photo-set-kind.pipe';
+import { EvOffsetPipe } from '../gallery/burst-culling.pipes';
+import {
+  HISTOGRAM_PANEL_HEIGHT, HistogramComponent,
+} from '../../shared/components/histogram/histogram.component';
+import { HistogramMode, isHistogramMode } from '../../shared/utils/histogram';
 import { ComparisonCategoryExplainerComponent } from '../comparison/comparison-category-explainer.component';
 import { DownloadOption } from '../../shared/models/download.model';
 import { downloadAll } from '../../shared/utils/download';
 import { GalleryStore } from '../gallery/gallery.store';
+import { GalleryFilters } from '../gallery/gallery-filters.util';
 import * as L from 'leaflet';
 import { createLeafletMap } from '../../shared/leaflet';
 import { I18N, I18N_KEYS } from '../../core/i18n/keys';
@@ -60,6 +66,9 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
     CategoryLabelPipe,
     IsLensNamePipe,
     DownloadIconPipe,
+    PhotoSetKindIconPipe,
+    PhotoSetKindLabelPipe,
+    EvOffsetPipe,
     HistogramComponent,
     ComparisonCategoryExplainerComponent,
   ],
@@ -262,7 +271,7 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
               <div class="text-[0.625rem] uppercase tracking-wider text-[var(--mat-sys-on-surface-variant)]">{{ I18N.photo_detail.caption | translate }}</div>
               @if (auth.isEdition()) {
                 <div class="flex gap-1">
-                  @if (!p.caption) {
+                  @if (!p.caption && store.config()?.features?.show_captions) {
                     <button mat-icon-button class="!w-7 !h-7 !p-0" (click)="generateCaption(p.path)" [disabled]="generatingCaption()" [matTooltip]="I18N.photo_detail.generate_caption | translate">
                       @if (generatingCaption()) {
                         <mat-spinner diameter="16" />
@@ -312,7 +321,7 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
                 @if (p.eye_sharpness !== null) {
                   <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.eye_sharpness | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.eye_sharpness | fixed:1 }}</span></div>
                 }
-                @if (p.face_confidence !== null) {
+                @if (p.face_confidence !== null && p.face_confidence !== undefined) {
                   <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.face_confidence | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.face_confidence * 100 | fixed:0 }}%</span></div>
                 }
               }
@@ -396,13 +405,13 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
               @if (p.dynamic_range_stops !== null) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.dynamic_range | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.dynamic_range_stops | fixed:1 }}</span></div>
               }
-              @if (p.mean_saturation !== null) {
+              @if (p.mean_saturation !== null && p.mean_saturation !== undefined) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.saturation | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ (p.mean_saturation * 100) | fixed:0 }}%</span></div>
               }
               @if (p.noise_sigma !== null) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.noise | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.noise_sigma | fixed:1 }}</span></div>
               }
-              @if (p.mean_luminance !== null) {
+              @if (p.mean_luminance !== null && p.mean_luminance !== undefined) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.luminance | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.mean_luminance * 100 | fixed:0 }}%</span></div>
               }
               @if (p.histogram_spread !== null) {
@@ -438,10 +447,18 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
             </div>
           }
 
-          <!-- Luminance histogram -->
-          <div class="border-t border-[var(--mat-sys-outline-variant)] pt-3">
-            <div class="text-[0.625rem] uppercase tracking-wider text-[var(--mat-sys-on-surface-variant)] mb-2">{{ I18N.tooltip.histogram | translate }}</div>
-            <app-histogram [src]="p.path | thumbnailUrl:640" />
+          <!-- Histogram: the graph runs edge to edge (the panel's only full-width
+               block), so the negative margin cancelling the panel's own p-4
+               goes on this section's container. The label gets its own
+               horizontal padding back so it still lines up with every other
+               section's label above it. -->
+          <div class="border-t border-[var(--mat-sys-outline-variant)] pt-3 -mx-4">
+            <div class="text-[0.625rem] uppercase tracking-wider text-[var(--mat-sys-on-surface-variant)] mb-2 px-4">{{ I18N.tooltip.histogram | translate }}</div>
+            <app-histogram [path]="p.path" [src]="p.path | thumbnailUrl:640" [monochrome]="!!p.is_monochrome"
+                           [height]="HISTOGRAM_PANEL_HEIGHT" [showModeToggle]="true"
+                           [surface]="'detail'"
+                           [defaultMode]="histogramDefaultMode()"
+                           [indicatorPercent]="clippingIndicatorPercent()" />
           </div>
 
           <!-- Location -->
@@ -504,6 +521,40 @@ const SOCIAL_SOURCE_KEYS: Record<string, string> = {
                 }
               </div>
             </div>
+          }
+
+          <!-- Set section (bracket/panorama/hdr_panorama/burst/duplicate) -->
+          @if (photoSet(); as set) {
+            @if (set.kind) {
+              <div class="border-t border-[var(--mat-sys-outline-variant)] pt-3">
+                <div class="flex items-center justify-between mb-2">
+                  <div class="text-[0.625rem] uppercase tracking-wider text-[var(--mat-sys-on-surface-variant)]">{{ I18N.photo_detail.set.title | translate }}</div>
+                  <button mat-button class="!min-w-0" (click)="openSetInGallery()">
+                    <mat-icon>photo_library</mat-icon> {{ I18N.photo_detail.set.open_in_gallery | translate }}
+                  </button>
+                </div>
+                <div class="flex items-center gap-2 flex-wrap mb-2 text-sm">
+                  <mat-icon class="!text-base !w-4 !h-4 !leading-4 opacity-70">{{ set.kind | photoSetKindIcon }}</mat-icon>
+                  <span class="font-medium">{{ set.kind | photoSetKindLabel | translate }}</span>
+                  <span class="text-xs text-[var(--mat-sys-on-surface-variant)]">{{ I18N.capsules.photos_count | translate:{ count: set.count } }}</span>
+                  @if (set.ev_span !== null) {
+                    <span class="text-xs text-[var(--mat-sys-on-surface-variant)]">{{ I18N.photo_detail.set.ev_span | translate }}: &plusmn;{{ set.ev_span | fixed:1 }} EV</span>
+                  }
+                </div>
+                <div class="flex gap-2 flex-wrap">
+                  @for (member of set.members; track member.path) {
+                    <button class="relative rounded-lg overflow-hidden w-16 h-16 shrink-0 cursor-pointer hover:opacity-80 transition-opacity ring-[var(--mat-sys-primary)]"
+                            [class.ring-2]="member.path === p.path"
+                            (click)="openSetMember(member.path)">
+                      <img [src]="member.path | thumbnailUrl:96" [alt]="member.path" class="w-full h-full object-cover" />
+                      @if (member.ev_offset !== null) {
+                        <span class="absolute bottom-0 inset-x-0 text-center text-[0.625rem] leading-4 bg-black/60 text-white">{{ member.ev_offset | evOffset }}</span>
+                      }
+                    </button>
+                  }
+                </div>
+              </div>
+            }
           }
         </div>
       </div>
@@ -571,6 +622,17 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
   });
 
   // Social-export crop presets (from viewer config) + which signal frames the crop
+  protected readonly HISTOGRAM_PANEL_HEIGHT = HISTOGRAM_PANEL_HEIGHT;
+  /** House default for the histogram's channels, until the user picks one.
+   *  A stale/unrecognised config value degrades to 'rgb' rather than the
+   *  widget rendering nothing. */
+  protected readonly histogramDefaultMode = computed<HistogramMode>(() => {
+    const configured = this.store.config()?.clipping?.histogram_mode;
+    return isHistogramMode(configured) ? configured : 'rgb';
+  });
+  protected readonly clippingIndicatorPercent = computed(
+    () => this.store.config()?.clipping?.indicator_percent ?? 1);
+
   protected readonly socialPresets = computed(() => this.store.config()?.social_export?.presets ?? []);
   protected readonly socialExportEnabled = computed(() =>
     this.auth.isEdition() && !!this.store.config()?.features?.show_social_export && this.socialPresets().length > 0,
@@ -603,6 +665,18 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
     firstValueFrom(this.api.post<Record<string, KeeperHint>>('/photos/keeper_hints', { paths: [requestedPath] }))
       .then(hints => { if (this.photo()?.path === requestedPath) this.keeperHint.set(hints[requestedPath] ?? null); })
       .catch(() => { if (this.photo()?.path === requestedPath) this.keeperHint.set(null); });
+  });
+
+  // Set membership (bracket/panorama/hdr_panorama/burst/duplicate)
+  protected readonly photoSet = signal<PhotoSet | null>(null);
+  private photoSetEffect = effect(() => {
+    const p = this.photo();
+    this.photoSet.set(null);
+    if (!p) return;
+    const requestedPath = p.path;
+    firstValueFrom(this.api.get<PhotoSet>('/photo/set', { path: requestedPath }))
+      .then(res => { if (this.photo()?.path === requestedPath) this.photoSet.set(res); })
+      .catch(() => { if (this.photo()?.path === requestedPath) this.photoSet.set(null); });
   });
 
   // Location
@@ -692,15 +766,7 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
       const path = this.route.snapshot.queryParamMap.get('path');
       if (path) {
         try {
-          const photo = await firstValueFrom(this.api.get<Photo>('/photo', { path }));
-          // Ensure tags_list exists
-          if (!photo.tags_list) {
-            photo.tags_list = photo.tags ? photo.tags.split(',').map(t => t.trim()) : [];
-          }
-          if (!photo.persons) {
-            photo.persons = [];
-          }
-          this.photo.set(photo);
+          this.photo.set(await this.fetchPhoto(path));
         } catch {
           this.router.navigate(['/']);
         }
@@ -708,6 +774,61 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
         this.router.navigate(['/']);
       }
     }
+  }
+
+  private async fetchPhoto(path: string): Promise<Photo> {
+    const photo = await firstValueFrom(this.api.get<Photo>('/photo', { path }));
+    if (!photo.tags_list) {
+      photo.tags_list = photo.tags ? photo.tags.split(',').map(t => t.trim()) : [];
+    }
+    if (!photo.persons) {
+      photo.persons = [];
+    }
+    return photo;
+  }
+
+  protected async openSetMember(path: string): Promise<void> {
+    if (this.photo()?.path === path) return;
+    try {
+      const photo = await this.fetchPhoto(path);
+      this.router.navigate(['/photo'], { queryParams: { path }, state: { photo } });
+      this.photo.set(photo);
+      this.fullImageLoaded.set(false);
+    } catch {
+      this.snackBar.open(this.i18n.t(I18N.errors.action_failed), '', { duration: 3000 });
+    }
+  }
+
+  protected openSetInGallery(): void {
+    const set = this.photoSet();
+    if (!set?.kind || set.group_id == null) return;
+    const groupId = String(set.group_id);
+    const updates: Partial<GalleryFilters> = {
+      sequence_group_id: '', sequence_kind: '', burst_group_id: '', duplicate_group_id: '',
+    };
+    if (set.kind === 'burst') {
+      updates.burst_group_id = groupId;
+      updates.hide_bursts = false;
+    } else if (set.kind === 'duplicate') {
+      updates.duplicate_group_id = groupId;
+      updates.hide_duplicates = false;
+    } else if (set.kind === 'bracket') {
+      updates.sequence_kind = set.kind;
+      updates.sequence_group_id = groupId;
+      updates.hide_brackets = false;
+    } else {
+      updates.sequence_kind = set.kind;
+      updates.sequence_group_id = groupId;
+      updates.hide_panoramas = false;
+    }
+    // Carried via router navigation state, never the URL or a post-navigate
+    // updateFilters() call: the gallery route re-initialises its filters from
+    // config + localStorage + URL on activation, which either overwrites a
+    // post-navigate update or discards it as arriving too late. `state` is
+    // read by GalleryComponent.ngOnInit before its first load. See
+    // GalleryComponent.consumeSetScopeState for why it is also never
+    // bookmarkable: sequence_group_id is renumbered on every detection pass.
+    this.router.navigate(['/'], { state: { setScope: updates } });
   }
 
   @HostListener('document:keydown.escape')
@@ -798,8 +919,13 @@ export class PhotoDetailComponent extends PhotoDetailBase implements OnInit {
     const p = this.photo();
     if (!p) return;
     try {
-      const res = await firstValueFrom(this.api.post<{ is_rejected: boolean; is_favorite: boolean | null }>('/photo/toggle_rejected', { photo_path: path }));
-      this.photo.set({ ...p, is_rejected: res.is_rejected, is_favorite: res.is_favorite === null ? p.is_favorite : res.is_favorite });
+      const res = await firstValueFrom(this.api.post<{ is_rejected: boolean; is_favorite: boolean | null; star_rating: number | null }>('/photo/toggle_rejected', { photo_path: path }));
+      this.photo.set({
+        ...p,
+        is_rejected: res.is_rejected,
+        is_favorite: res.is_favorite === null ? p.is_favorite : res.is_favorite,
+        star_rating: res.star_rating === null ? p.star_rating : res.star_rating,
+      });
     } catch {
       this.snackBar.open(this.i18n.t(I18N.errors.action_failed), '', { duration: 3000 });
     }

--- a/client/src/app/shared/components/histogram/histogram.component.spec.ts
+++ b/client/src/app/shared/components/histogram/histogram.component.spec.ts
@@ -277,8 +277,57 @@ describe('HistogramComponent', () => {
     const label = fixture.nativeElement
       .querySelector('div.absolute.left-0')!.getAttribute('aria-label');
     expect(label).toBe('histogram.clipping.shadow');
+    // Channel names come from the same i18n keys as the mode buttons
+    // (histogram.mode.red/green/blue), not hardcoded letters, so a marker's
+    // tooltip never disagrees with the button that selects that channel.
     expect(mockI18n.t).toHaveBeenCalledWith(
-      'histogram.clipping.shadow', { channels: 'R 9.6% · G 2.9%' });
+      'histogram.clipping.shadow',
+      { channels: 'histogram.mode.red 9.6% · histogram.mode.green 2.9%' });
+  });
+
+  it('names a channel in the marker tooltip the same way the mode button does, in a non-English locale', () => {
+    // Simulates French, where the green mode button reads "V" (vert) rather
+    // than "G". The marker tooltip must resolve the SAME key, not a
+    // hardcoded English letter, so the two never disagree on screen. Uses
+    // its own TestBed configuration (rather than mutating the shared
+    // mockI18n) so this locale swap can't leak into later tests.
+    const FR_CHANNEL_LABEL: Record<string, string> = {
+      'histogram.mode.luminance': 'Lum',
+      'histogram.mode.rgb': 'RVB',
+      'histogram.mode.red': 'R',
+      'histogram.mode.green': 'V',
+      'histogram.mode.blue': 'B',
+      'histogram.clipping.shadow': 'Écrêtage des ombres : {channels}',
+    };
+    const frI18n = {
+      t: vi.fn((key: string, vars?: Record<string, string | number>) => {
+        const template = FR_CHANNEL_LABEL[key] ?? key;
+        return Object.entries(vars ?? {}).reduce(
+          (out, [k, v]) => out.replaceAll(`{${k}}`, String(v)), template);
+      }),
+      currentLang: vi.fn(() => 'fr'),
+      locale: vi.fn(() => 'fr'),
+      translations: vi.fn(() => ({})),
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ApiService, useValue: mockApi },
+        { provide: I18nService, useValue: frI18n },
+      ],
+    });
+    fixture = TestBed.createComponent(HistogramComponent);
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', showModeToggle: true, indicatorPercent: 2 });
+
+    const greenButtonLabel = modeButtons()[3].textContent?.trim();
+    expect(greenButtonLabel).toBe('V');
+
+    const shadowLabel = fixture.nativeElement
+      .querySelector('div.absolute.left-0')!.getAttribute('aria-label');
+    expect(shadowLabel).toContain('V 2.9%');
+    expect(shadowLabel).not.toContain('G 2.9%');
   });
 
   it('shows no markers at all for a photo that was never measured', () => {

--- a/client/src/app/shared/components/histogram/histogram.component.spec.ts
+++ b/client/src/app/shared/components/histogram/histogram.component.spec.ts
@@ -1,0 +1,437 @@
+import type { Mock } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ApiService } from '../../../core/services/api.service';
+import { HISTOGRAM_MODE_KEYS } from '../../../core/services/histogram-preferences.service';
+import { I18nService } from '../../../core/services/i18n.service';
+import { HistogramComponent } from './histogram.component';
+
+/** A 2x1 frame: one pure-red pixel, one pure-blue one. */
+const SAMPLED_PIXELS = new Uint8ClampedArray([255, 0, 0, 255, 0, 0, 255, 255]);
+
+describe('HistogramComponent', () => {
+  let fixture: ComponentFixture<HistogramComponent>;
+  let mockApi: { get: Mock };
+  let getContext: Mock;
+  let loadedImages: { src: string; onload: (() => void) | null }[];
+
+  // Echoes the key with its params substituted, so a test can see the values
+  // the component passed rather than only the key it chose.
+  const mockI18n = {
+    t: vi.fn((key: string, vars?: Record<string, string | number>) =>
+      Object.entries(vars ?? {}).reduce(
+        (out, [k, v]) => out.replaceAll(`{${k}}`, String(v)), key)),
+    currentLang: vi.fn(() => 'en'),
+    locale: vi.fn(() => 'en'),
+    translations: vi.fn(() => ({})),
+  };
+
+  function svg(): SVGElement | null {
+    return fixture.nativeElement.querySelector('svg');
+  }
+
+  function polylines(): SVGPolylineElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('polyline'));
+  }
+
+  function markers(side: 'left' | 'right'): Element[] {
+    const holder = fixture.nativeElement.querySelector(`div.absolute.${side}-0`);
+    return holder ? Array.from(holder.querySelectorAll('span')) : [];
+  }
+
+  function modeButtons(): HTMLButtonElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('button'));
+  }
+
+  function render(inputs: {
+    path?: string; src?: string; monochrome?: boolean; height?: number;
+    showModeToggle?: boolean; defaultMode?: string; indicatorPercent?: number;
+    surface?: string;
+  }): void {
+    for (const [key, value] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(key, value);
+    }
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    mockApi = { get: vi.fn(() => of({ bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null })) };
+    loadedImages = [];
+    getContext = vi.fn(() => ({
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => ({ data: SAMPLED_PIXELS })),
+    }));
+
+    HTMLCanvasElement.prototype.getContext = getContext as unknown as
+      typeof HTMLCanvasElement.prototype.getContext;
+    // jsdom never fetches an <img>, so onload would never fire: record every
+    // instance and let each test decide when it "loads".
+    vi.stubGlobal('Image', class {
+      decoding = '';
+      naturalWidth = 2;
+      naturalHeight = 1;
+      onload: (() => void) | null = null;
+      private url = '';
+      get src(): string { return this.url; }
+      set src(value: string) {
+        this.url = value;
+        loadedImages.push(this as unknown as { src: string; onload: (() => void) | null });
+      }
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ApiService, useValue: mockApi },
+        { provide: I18nService, useValue: mockI18n },
+      ],
+    });
+    fixture = TestBed.createComponent(HistogramComponent);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.detail);
+    localStorage.removeItem(HISTOGRAM_MODE_KEYS.tooltip);
+  });
+
+  it('draws the stored bins without sampling the thumbnail', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: [0.25, 0, 0, 0], g: [0, 1, 0, 0], b: [0, 0, 0.5, 0],
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg' });
+
+    expect(mockApi.get).toHaveBeenCalledWith('/photo/histogram', { path: '/a.jpg', bins: 64 });
+    expect(loadedImages).toHaveLength(0);
+    expect(polylines()).toHaveLength(3);
+    expect(polylines()[0].getAttribute('points'))
+      .toBe('0.0,30.0 42.7,40.0 85.3,40.0 128.0,40.0');
+  });
+
+  it('draws the filled luminance curve in luminance mode', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: [0.25, 0, 0, 0], g: [0, 1, 0, 0], b: [0, 0, 0.5, 0],
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', defaultMode: 'luma' });
+
+    expect(polylines()).toHaveLength(0);
+    expect(fixture.nativeElement.querySelector('polygon').getAttribute('points'))
+      .toBe('0,40 0.0,0.0 42.7,20.0 85.3,40.0 128.0,40.0 128,40');
+  });
+
+  it('shows luma immediately for a legacy row, without eagerly sampling', () => {
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', defaultMode: 'luma' });
+
+    expect(svg()).not.toBeNull();
+    expect(polylines()).toHaveLength(0);
+    // luma mode never needs channel data -- no eager canvas sample.
+    expect(loadedImages).toHaveLength(0);
+  });
+
+  it('lazily samples the thumbnail for RGB once a legacy (luma-only) stored measurement resolves in RGB mode', () => {
+    // A 200 with a real luma array and null r/g/b: distinct from both a 404
+    // (which falls straight to sample()) and a full per-channel row.
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null,
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', defaultMode: 'rgb' });
+    fixture.detectChanges();
+
+    expect(loadedImages).toHaveLength(1);
+    loadedImages[0].onload!();
+    fixture.detectChanges();
+
+    expect(getContext).toHaveBeenCalled();
+    expect(polylines()).toHaveLength(3);
+  });
+
+  it('lazily samples once the user switches to a channel mode after a legacy load', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null,
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', showModeToggle: true, defaultMode: 'luma' });
+    expect(loadedImages).toHaveLength(0);
+
+    modeButtons()[1].click(); // 'rgb'
+    fixture.detectChanges();
+
+    expect(loadedImages).toHaveLength(1);
+    loadedImages[0].onload!();
+    fixture.detectChanges();
+
+    expect(polylines()).toHaveLength(3);
+  });
+
+  it('keeps clipping markers governed exclusively by the stored measurement, never fabricated from the sample', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null, clipped: null,
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', defaultMode: 'rgb', indicatorPercent: 0 });
+    fixture.detectChanges();
+    loadedImages[0].onload!();
+    fixture.detectChanges();
+
+    // The canvas sample has real pixel data (a pure-red and a pure-blue
+    // pixel) that would clip at threshold 0 if markers were computed from
+    // it -- they must stay absent because the stored measurement is null.
+    expect(markers('left')).toHaveLength(0);
+    expect(markers('right')).toHaveLength(0);
+  });
+
+  it('draws luminance only for a monochrome photo even with RGB bins', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0, 0, 0], r: [1, 0, 0, 0], g: [1, 0, 0, 0], b: [1, 0, 0, 0],
+    }));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg', monochrome: true });
+
+    expect(svg()).not.toBeNull();
+    expect(polylines()).toHaveLength(0);
+  });
+
+  it('falls back to sampling the thumbnail when the photo has no stored histogram', () => {
+    mockApi.get.mockReturnValue(throwError(() => new Error('404')));
+
+    render({ path: '/a.jpg', src: '/thumb/a.jpg' });
+    expect(svg()).toBeNull();
+
+    expect(loadedImages).toHaveLength(1);
+    expect(loadedImages[0].src).toBe('/thumb/a.jpg');
+    loadedImages[0].onload!();
+    fixture.detectChanges();
+
+    expect(getContext).toHaveBeenCalled();
+    expect(polylines()).toHaveLength(3);
+  });
+
+  it('samples the thumbnail when no path is provided at all', () => {
+    render({ src: '/thumb/a.jpg' });
+
+    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(loadedImages).toHaveLength(1);
+    loadedImages[0].onload!();
+    fixture.detectChanges();
+    expect(svg()).not.toBeNull();
+  });
+
+  it('renders nothing when neither a path nor a thumbnail is given', () => {
+    render({});
+
+    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(loadedImages).toHaveLength(0);
+    expect(svg()).toBeNull();
+  });
+
+  it('ignores a stale sampled frame after the photo changed', () => {
+    render({ src: '/thumb/a.jpg' });
+    const stale = loadedImages[0];
+
+    render({ src: '/thumb/b.jpg' });
+    stale.onload!();
+    fixture.detectChanges();
+
+    expect(svg()).toBeNull();
+  });
+
+  // --- clipping markers ---------------------------------------------------
+
+  const CLIPPED = {
+    bins: 4,
+    luma: [0, 1, 0.5, 0], r: [0, 1, 0, 0], g: [0, 1, 0, 0], b: [0, 1, 0, 0],
+    clipped: {
+      shadow: { luma: 0, r: 9.58, g: 2.94, b: 1.63 },
+      highlight: { luma: 0, r: 0.0035, g: 0, b: 0 },
+    },
+  };
+
+  it('marks only the channels above the indicator threshold', () => {
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', indicatorPercent: 2 });
+
+    // Shadows: R 9.58% and G 2.94% clear 2%, B 1.63% does not.
+    expect(markers('left')).toHaveLength(2);
+    // Highlights: R is 0.0035%, far below the threshold.
+    expect(markers('right')).toHaveLength(0);
+  });
+
+  it('a lower threshold catches the single-channel clip luminance cannot see', () => {
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', indicatorPercent: 0.001 });
+
+    const right = markers('right');
+    expect(right).toHaveLength(1);
+    expect(right[0].className).toContain('bg-red-500');
+  });
+
+  it('names the offending channels and their percentages in the tooltip', () => {
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', indicatorPercent: 2 });
+
+    const label = fixture.nativeElement
+      .querySelector('div.absolute.left-0')!.getAttribute('aria-label');
+    expect(label).toBe('histogram.clipping.shadow');
+    expect(mockI18n.t).toHaveBeenCalledWith(
+      'histogram.clipping.shadow', { channels: 'R 9.6% · G 2.9%' });
+  });
+
+  it('shows no markers at all for a photo that was never measured', () => {
+    // A legacy row answers with clipped: null. Unknown is NOT clean, so the
+    // widget must stay silent rather than draw an all-clear.
+    mockApi.get.mockReturnValue(of({ ...CLIPPED, clipped: null }));
+
+    render({ path: '/a.jpg', indicatorPercent: 0 });
+
+    expect(markers('left')).toHaveLength(0);
+    expect(markers('right')).toHaveLength(0);
+  });
+
+  it('shows one neutral marker for a monochrome photo, not three colour ones', () => {
+    mockApi.get.mockReturnValue(of({
+      ...CLIPPED,
+      clipped: {
+        shadow: { luma: 8, r: 8, g: 8, b: 8 },
+        highlight: { luma: 0, r: 0, g: 0, b: 0 },
+      },
+    }));
+
+    render({ path: '/a.jpg', monochrome: true, indicatorPercent: 1 });
+
+    const left = markers('left');
+    expect(left).toHaveLength(1);
+    expect(left[0].className).toContain('bg-neutral-300');
+  });
+
+  it('keeps the markers in luminance mode', () => {
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', defaultMode: 'luma', indicatorPercent: 2 });
+
+    expect(fixture.nativeElement.querySelector('polygon')).not.toBeNull();
+    expect(markers('left')).toHaveLength(2);
+  });
+
+  // --- height + mode toggle ------------------------------------------------
+
+  it('draws at the requested height, in both the box and the geometry', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: null, g: null, b: null,
+    }));
+
+    render({ path: '/a.jpg', height: 112 });
+
+    expect(svg()!.getAttribute('viewBox')).toBe('0 0 128 112');
+    expect((svg() as SVGElement & { style: CSSStyleDeclaration }).style.height).toBe('112px');
+    // The curve is re-laid-out for the taller box, not stretched from a 40px one.
+    expect(fixture.nativeElement.querySelector('polygon').getAttribute('points'))
+      .toContain('112');
+  });
+
+  it('hides the mode toggle unless it is asked for', () => {
+    render({ path: '/a.jpg' });
+    expect(modeButtons()).toHaveLength(0);
+  });
+
+  it('hides the mode toggle for a monochrome photo', () => {
+    render({ path: '/a.jpg', showModeToggle: true, monochrome: true });
+    expect(modeButtons()).toHaveLength(0);
+  });
+
+  it('switches to luminance and remembers the choice', () => {
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: [0.25, 0, 0, 0], g: [0, 1, 0, 0], b: [0, 0, 0.5, 0],
+    }));
+
+    render({ path: '/a.jpg', showModeToggle: true });
+    expect(polylines()).toHaveLength(3);
+
+    modeButtons()[0].click();
+    fixture.detectChanges();
+
+    expect(polylines()).toHaveLength(0);
+    expect(fixture.nativeElement.querySelector('polygon')).not.toBeNull();
+    expect(localStorage.getItem(HISTOGRAM_MODE_KEYS.detail)).toBe('luma');
+  });
+
+  // --- single-channel modes -------------------------------------------------
+
+  const RGB_BINS = {
+    bins: 4, luma: [1, 0.5, 0, 0], r: [0.25, 0, 0, 0], g: [0, 1, 0, 0], b: [0, 0, 0.5, 0],
+  };
+
+  it.each([
+    ['r', 'fill-red-500'],
+    ['g', 'fill-green-500'],
+    ['b', 'fill-blue-500'],
+  ] as const)('fills a %s-only polygon coloured %s, not a bare stroke', (mode, fillClass) => {
+    mockApi.get.mockReturnValue(of(RGB_BINS));
+
+    render({ path: '/a.jpg', defaultMode: mode });
+
+    expect(polylines()).toHaveLength(0);
+    const polygon = fixture.nativeElement.querySelector('polygon');
+    expect(polygon).not.toBeNull();
+    expect(polygon.getAttribute('points')).not.toBe('');
+    expect(polygon.getAttribute('class')).toContain(fillClass);
+  });
+
+  it('keeps markers for every channel in a single-channel mode, not just the active one', () => {
+    mockApi.get.mockReturnValue(of(CLIPPED));
+
+    render({ path: '/a.jpg', defaultMode: 'g', indicatorPercent: 2 });
+
+    // Same R 9.58% / G 2.94% clear-2% shadow markers as RGB/luma mode -- a
+    // blown channel is lost data whichever curve happens to be on screen.
+    expect(markers('left')).toHaveLength(2);
+  });
+
+  it('offers all five channel-mode buttons when the toggle is shown', () => {
+    render({ path: '/a.jpg', showModeToggle: true });
+    expect(modeButtons()).toHaveLength(5);
+    expect(modeButtons().map(b => b.textContent?.trim()))
+      .toEqual(['histogram.mode.luminance', 'histogram.mode.rgb',
+        'histogram.mode.red', 'histogram.mode.green', 'histogram.mode.blue']);
+  });
+
+  it('detail and tooltip surfaces persist their channel mode independently', () => {
+    mockApi.get.mockReturnValue(of(RGB_BINS));
+    render({ path: '/a.jpg', showModeToggle: true, surface: 'detail' });
+    modeButtons()[2].click(); // 'r' on the detail surface
+    fixture.detectChanges();
+    expect(localStorage.getItem(HISTOGRAM_MODE_KEYS.detail)).toBe('r');
+    expect(localStorage.getItem(HISTOGRAM_MODE_KEYS.tooltip)).toBeNull();
+
+    // A second instance on the tooltip surface, sharing the same injector
+    // (and therefore the same HistogramPreferencesService singleton), must
+    // resolve its OWN default rather than the detail surface's stored 'r'.
+    const tooltipFixture = TestBed.createComponent(HistogramComponent);
+    mockApi.get.mockReturnValue(of(RGB_BINS));
+    for (const [key, value] of Object.entries(
+      { path: '/a.jpg', showModeToggle: true, surface: 'tooltip', defaultMode: 'rgb' })) {
+      tooltipFixture.componentRef.setInput(key, value);
+    }
+    tooltipFixture.detectChanges();
+
+    expect(Array.from(tooltipFixture.nativeElement.querySelectorAll('polyline'))).toHaveLength(3);
+  });
+
+  it('prefers a stored choice over the configured default', () => {
+    localStorage.setItem(HISTOGRAM_MODE_KEYS.detail, 'luma');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ providers: [{ provide: ApiService, useValue: mockApi }] });
+    fixture = TestBed.createComponent(HistogramComponent);
+    mockApi.get.mockReturnValue(of({
+      bins: 4, luma: [1, 0.5, 0, 0], r: [0.25, 0, 0, 0], g: [0, 1, 0, 0], b: [0, 0, 0.5, 0],
+    }));
+
+    render({ path: '/a.jpg', defaultMode: 'rgb' });
+
+    expect(polylines()).toHaveLength(0);
+  });
+});

--- a/client/src/app/shared/components/histogram/histogram.component.ts
+++ b/client/src/app/shared/components/histogram/histogram.component.ts
@@ -1,59 +1,359 @@
 import {
-  ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, signal, untracked,
+  ChangeDetectionStrategy, Component, DestroyRef, computed, effect, inject, input, signal,
+  untracked,
 } from '@angular/core';
-import { computeLuminanceHistogram, histogramPolygonPoints } from '../../utils/histogram';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { catchError, of } from 'rxjs';
+import { ApiService } from '../../../core/services/api.service';
+import { HistogramPreferencesService, HistogramSurface } from '../../../core/services/histogram-preferences.service';
+import { TranslatePipe } from '../../pipes/translate.pipe';
+import { I18N_KEYS } from '../../../core/i18n/keys';
+import {
+  ClipChannel, ClipPercents, HistogramChannels, HistogramMode, clippedChannels,
+  computeRgbHistogram, histogramLinePoints, histogramPolygonPoints, toInteriorChannels,
+} from '../../utils/histogram';
+
+/** One end-of-scale marker: a channel that ran out of range on this photo. */
+interface ClipMarker {
+  channel: ClipChannel;
+  percent: number;
+  colorClass: string;
+}
+
+/** A single colour channel, drawn filled like luma rather than a bare 1px
+ *  stroke — a lone line in a large box reads poorly, and filling it keeps
+ *  every mode visually consistent. */
+type SingleChannel = 'r' | 'g' | 'b';
+
+const VIEW_WIDTH = 128;
+const SAMPLE_BINS = 256;
+const DISPLAY_BINS = 64;
+const SAMPLE_MAX_EDGE = 160;
+
+const BUTTON_CLASS = 'px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider transition-colors cursor-pointer';
+const BUTTON_ACTIVE_CLASS = 'bg-[var(--mat-sys-primary)] text-black';
+const BUTTON_IDLE_CLASS = 'text-neutral-400 hover:text-neutral-200';
+
+const MARKER_COLOR_CLASS: Record<ClipChannel, string> = {
+  luma: 'bg-neutral-300', r: 'bg-red-500', g: 'bg-green-500', b: 'bg-blue-500',
+};
+
+const CHANNEL_FILL_CLASS: Record<SingleChannel, string> = {
+  r: 'fill-red-500 opacity-70', g: 'fill-green-500 opacity-70', b: 'fill-blue-500 opacity-70',
+};
+
+/** Compact enough for a tooltip that follows the pointer around the gallery. */
+export const HISTOGRAM_COMPACT_HEIGHT = 40;
+/**
+ * The pinned/docked tooltip's height: readable at a glance without the
+ * scoring grid it sits beside losing its share of a bubble that also has to
+ * fit on screen next to the cursor. Clearly larger than the 40px hover
+ * default, clearly smaller than the detail panel's 160px — the tooltip is a
+ * scan-many-photos surface, not a study-one-photo surface.
+ */
+export const HISTOGRAM_TOOLTIP_HEIGHT = 64;
+/**
+ * The detail panel's height. Tall enough that an ordinary tonal curve has real
+ * vertical range to move in — at 40px the difference between a mid-tone hump
+ * and a shadow hump is a couple of pixels — while still leaving the panel room
+ * for everything below it.
+ */
+export const HISTOGRAM_PANEL_HEIGHT = 160;
 
 /**
- * Compact luminance histogram computed client-side from an already-cached
- * thumbnail (same-origin, so the canvas stays untainted). Pass `bins` to
- * bypass the canvas path with precomputed values (future backend feed).
+ * Compact histogram with five channel modes: luminance, RGB combined, or a
+ * single R/G/B channel filled on its own.
+ *
+ * Prefers the bins the scan stored for the photo (`/api/photo/histogram`):
+ * those are measured on the full-resolution image before any JPEG encoding.
+ * Falls back to sampling the cached thumbnail in a canvas (same-origin, so it
+ * stays untainted) for a photo whose row has no stored histogram — an
+ * un-migrated scan, or a viewer DB exported before the column was kept. That
+ * fallback reads a <=160px q80 JPEG with 4:2:0 chroma subsampling, so its R and
+ * B curves are largely interpolated; the stored bins are not.
+ *
+ * The curve is drawn from the interior bins only. A clipped frame piles a large
+ * share of its pixels onto bin 0 or bin 255, and normalizing against that spike
+ * flattens the whole curve into a hairline at the baseline — useless for the
+ * one thing a histogram is for. The extremes are shown as end markers instead,
+ * which is also the only place they are legible.
+ *
+ * Markers come exclusively from the stored measurement. The sampled fallback
+ * reads a re-encoded thumbnail whose extremes are an artifact of the JPEG
+ * rather than of the exposure, so a photo on that path shows no markers at all
+ * — unknown, rather than fabricated.
  */
 @Component({
   selector: 'app-histogram',
+  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatTooltipModule, TranslatePipe],
   template: `
-    @if (points()) {
-      <svg viewBox="0 0 128 40" preserveAspectRatio="none" class="w-full h-10 block" aria-hidden="true">
-        <polygon [attr.points]="points()" class="fill-current opacity-60" />
-      </svg>
+    @if (curves(); as c) {
+      <div class="relative">
+        <svg [attr.viewBox]="viewBox()" preserveAspectRatio="none"
+             [style.height.px]="height()" class="w-full block" aria-hidden="true">
+          @if (effectiveMode() === 'luma') {
+            <polygon [attr.points]="c.luma" class="fill-current opacity-60" />
+          } @else if (effectiveMode() === 'rgb') {
+            @if (c.r) {
+              <polyline [attr.points]="c.r" fill="none" stroke-width="1" vector-effect="non-scaling-stroke" class="stroke-red-500 opacity-90" />
+              <polyline [attr.points]="c.g" fill="none" stroke-width="1" vector-effect="non-scaling-stroke" class="stroke-green-500 opacity-90" />
+              <polyline [attr.points]="c.b" fill="none" stroke-width="1" vector-effect="non-scaling-stroke" class="stroke-blue-500 opacity-90" />
+            } @else {
+              <polygon [attr.points]="c.luma" class="fill-current opacity-60" />
+            }
+          } @else if (singleChannelPoints()) {
+            <!-- Single channel modes fill like luma rather than a bare 1px
+                 stroke -- a lone line in a large box reads poorly -- coloured
+                 with that channel's own colour. -->
+            <polygon [attr.points]="singleChannelPoints()" [class]="singleChannelFillClass()" />
+          } @else {
+            <polygon [attr.points]="c.luma" class="fill-current opacity-60" />
+          }
+        </svg>
+
+        <!-- Clipping markers, drawn as elements over the chart rather than
+             inside it: preserveAspectRatio="none" stretches the viewBox
+             unevenly, so a square drawn in SVG units would not render square.
+             Kept per-channel in EVERY mode — a blown blue channel is lost data
+             whichever curve is on screen, and merging them into one grey marker
+             would hide exactly the single-channel case luma cannot show. This
+             also means a single-channel mode still shows markers for the other
+             two channels, which is deliberate: the point of a marker is "this
+             data is gone", not "this is the channel you are currently looking at". -->
+        @if (shadowMarkers().length) {
+          <div class="absolute top-0 left-0 flex flex-col gap-px"
+               [matTooltip]="I18N.histogram.clipping.shadow | translate:{ channels: shadowDetail() }"
+               [attr.aria-label]="I18N.histogram.clipping.shadow | translate:{ channels: shadowDetail() }">
+            @for (marker of shadowMarkers(); track marker.channel) {
+              <span class="block w-1.5 h-1.5 rounded-[1px]" [class]="marker.colorClass"></span>
+            }
+          </div>
+        }
+        @if (highlightMarkers().length) {
+          <div class="absolute top-0 right-0 flex flex-col gap-px"
+               [matTooltip]="I18N.histogram.clipping.highlight | translate:{ channels: highlightDetail() }"
+               [attr.aria-label]="I18N.histogram.clipping.highlight | translate:{ channels: highlightDetail() }">
+            @for (marker of highlightMarkers(); track marker.channel) {
+              <span class="block w-1.5 h-1.5 rounded-[1px]" [class]="marker.colorClass"></span>
+            }
+          </div>
+        }
+      </div>
+
+      @if (showModeToggle() && !monochrome()) {
+        <div class="flex items-center gap-1 mt-1 flex-wrap" role="group"
+             [attr.aria-label]="I18N.histogram.mode.label | translate">
+          <button type="button" [class]="lumaButtonClass()"
+                  [attr.aria-pressed]="effectiveMode() === 'luma'"
+                  (click)="selectMode('luma')">{{ I18N.histogram.mode.luminance | translate }}</button>
+          <button type="button" [class]="rgbButtonClass()"
+                  [attr.aria-pressed]="effectiveMode() === 'rgb'"
+                  (click)="selectMode('rgb')">{{ I18N.histogram.mode.rgb | translate }}</button>
+          <button type="button" [class]="rButtonClass()"
+                  [attr.aria-pressed]="effectiveMode() === 'r'"
+                  (click)="selectMode('r')">{{ I18N.histogram.mode.red | translate }}</button>
+          <button type="button" [class]="gButtonClass()"
+                  [attr.aria-pressed]="effectiveMode() === 'g'"
+                  (click)="selectMode('g')">{{ I18N.histogram.mode.green | translate }}</button>
+          <button type="button" [class]="bButtonClass()"
+                  [attr.aria-pressed]="effectiveMode() === 'b'"
+                  (click)="selectMode('b')">{{ I18N.histogram.mode.blue | translate }}</button>
+        </div>
+      }
     }
   `,
   host: { class: 'block text-neutral-400' },
 })
 export class HistogramComponent {
-  /** Thumbnail URL to sample (ignored when bins are provided). */
+  /** Photo path — its stored bins are fetched and preferred when set. */
+  readonly path = input<string>('');
+  /** Thumbnail URL sampled in-browser when no stored histogram exists. */
   readonly src = input<string>('');
-  /** Optional precomputed normalized bins (skips the canvas path). */
-  readonly bins = input<number[] | null>(null);
+  /** B&W photo: the R/G/B curves would just triple-trace the luminance one. */
+  readonly monochrome = input(false);
+  /** Drawing height in CSS pixels. */
+  readonly height = input(HISTOGRAM_COMPACT_HEIGHT);
+  /** Whether to offer the channel-mode switch (the detail panel and a pinned tooltip do). */
+  readonly showModeToggle = input(false);
+  /** House default from `viewer.clipping.histogram_mode` (detail panel) or
+   *  `viewer.clipping.tooltip_histogram_mode` (tooltip), until the user picks. */
+  readonly defaultMode = input<HistogramMode>('rgb');
+  /** Percent of clipped pixels a channel must exceed to earn a marker. */
+  readonly indicatorPercent = input(1);
+  /** Which surface's persisted mode choice this instance reads/writes — the
+   *  detail panel and the tooltip remember their channel mode independently. */
+  readonly surface = input<HistogramSurface>('detail');
 
-  protected readonly points = signal('');
+  protected readonly I18N = I18N_KEYS;
+
+  // Two independent sources, never mixed within a single rendered curve (the
+  // widget only ever draws one mode at a time, so there is no view where
+  // they would need to agree on scale):
+  //  - storedChannels: from /photo/histogram. Its luma is the more accurate
+  //    measurement (full resolution, pre-JPEG) and is preferred for luma
+  //    mode whenever present, including a legacy row that has it alone.
+  //  - sampledChannels: canvas-sampled from the thumbnail, computed lazily
+  //    (see the second effect below) only once a channel mode is actually
+  //    selected AND the stored measurement turned out to lack per-channel
+  //    data. Deferred rather than eager: it is real CPU cost (image decode +
+  //    canvas draw + getImageData) that would otherwise run on every render
+  //    across a library that, measured, is 100% legacy 1024-byte histograms.
+  //    All four of its channels come from the one canvas pass, so RGB/single-
+  //    channel modes stay internally consistent with each other.
+  private readonly storedChannels = signal<HistogramChannels | null>(null);
+  private readonly sampledChannels = signal<HistogramChannels | null>(null);
+  protected readonly clipped = signal<ClipPercents | null>(null);
+
+  /** A monochrome photo has no colour channels to separate, so it never leaves luma. */
+  protected readonly effectiveMode = computed<HistogramMode>(
+    () => this.monochrome() ? 'luma' : (this.preferences.mode(this.surface()) ?? this.defaultMode()));
+
+  protected readonly viewBox = computed(() => `0 0 ${VIEW_WIDTH} ${this.height()}`);
+
+  protected readonly curves = computed(() => {
+    const mode = this.effectiveMode();
+    const stored = this.storedChannels();
+    const sampled = this.sampledChannels();
+    // luma mode: prefer the more accurate stored measurement. Every other
+    // mode needs per-channel data: prefer the self-consistent sampled set,
+    // falling back to the (channel-less) stored one only until sampling
+    // resolves -- the template already degrades that to a luma polygon.
+    const source = mode === 'luma' ? (stored ?? sampled) : (sampled ?? stored);
+    if (!source) return null;
+    const height = this.height();
+    const rgb = this.monochrome() ? null : source;
+    const line = (values: number[] | null | undefined) =>
+      values?.length ? histogramLinePoints(values, VIEW_WIDTH, height) : '';
+    const fill = (values: number[] | null | undefined) =>
+      values?.length ? histogramPolygonPoints(values, VIEW_WIDTH, height) : '';
+    return {
+      luma: histogramPolygonPoints(source.luma, VIEW_WIDTH, height),
+      r: line(rgb?.r),
+      g: line(rgb?.g),
+      b: line(rgb?.b),
+      rFill: fill(rgb?.r),
+      gFill: fill(rgb?.g),
+      bFill: fill(rgb?.b),
+    };
+  });
+
+  /** Filled polygon points for the active single-channel mode, or '' outside one. */
+  protected readonly singleChannelPoints = computed(() => {
+    const c = this.curves();
+    const mode = this.effectiveMode();
+    if (!c || (mode !== 'r' && mode !== 'g' && mode !== 'b')) return '';
+    return mode === 'r' ? c.rFill : mode === 'g' ? c.gFill : c.bFill;
+  });
+
+  protected readonly singleChannelFillClass = computed(() => {
+    const mode = this.effectiveMode();
+    return mode === 'r' || mode === 'g' || mode === 'b' ? CHANNEL_FILL_CLASS[mode] : '';
+  });
+
+  protected readonly shadowMarkers = computed(() => this.markersFor('shadow'));
+  protected readonly highlightMarkers = computed(() => this.markersFor('highlight'));
+  protected readonly shadowDetail = computed(() => describeMarkers(this.shadowMarkers()));
+  protected readonly highlightDetail = computed(() => describeMarkers(this.highlightMarkers()));
+
+  protected readonly lumaButtonClass = computed(() => this.buttonClass('luma'));
+  protected readonly rgbButtonClass = computed(() => this.buttonClass('rgb'));
+  protected readonly rButtonClass = computed(() => this.buttonClass('r'));
+  protected readonly gButtonClass = computed(() => this.buttonClass('g'));
+  protected readonly bButtonClass = computed(() => this.buttonClass('b'));
+
+  private readonly api = inject(ApiService);
+  private readonly preferences = inject(HistogramPreferencesService);
+  private readonly destroyRef = inject(DestroyRef);
   private destroyed = false;
-  private currentUrl = '';
+  // Bumped on every input change so a slow response can't overwrite the curves
+  // of the photo the user has already moved on to.
+  private generation = 0;
 
   constructor() {
-    inject(DestroyRef).onDestroy(() => { this.destroyed = true; });
-    effect(() => {
-      const precomputed = this.bins();
-      if (precomputed?.length) {
-        this.points.set(histogramPolygonPoints(precomputed, 128, 40));
-        return;
-      }
+    this.destroyRef.onDestroy(() => { this.destroyed = true; });
+    effect(onCleanup => {
+      const path = this.path();
       const url = this.src();
-      untracked(() => this.points.set(''));
-      if (!url) return;
-      this.sample(url);
+      const token = ++this.generation;
+      untracked(() => {
+        this.storedChannels.set(null);
+        this.sampledChannels.set(null);
+        this.clipped.set(null);
+      });
+      if (path) {
+        // Unsubscribing aborts the request, so scrubbing the gallery cancels
+        // the tooltips the pointer already left instead of queueing them.
+        onCleanup(this.loadStored(path, url, token));
+      } else if (url) {
+        this.sample(url, token);
+      }
+    });
+
+    // Lazy channel sampling: a legacy row's stored measurement has luma but
+    // no r/g/b. Re-runs whenever the resolved mode changes (the user picking
+    // a channel mode) or a fresh storedChannels arrives (in case the mode
+    // already needed channels the moment it loaded) -- either way, sample
+    // exactly once per photo, only if something actually needs it.
+    effect(() => {
+      const mode = this.effectiveMode();
+      const stored = this.storedChannels();
+      const url = this.src();
+      if (mode === 'luma' || !stored || stored.r?.length || this.sampledChannels() || !url) return;
+      this.sample(url, this.generation);
     });
   }
 
-  private sample(url: string): void {
-    this.currentUrl = url;
+  protected selectMode(mode: HistogramMode): void {
+    this.preferences.setMode(this.surface(), mode);
+  }
+
+  private buttonClass(mode: HistogramMode): string {
+    const state = this.effectiveMode() === mode ? BUTTON_ACTIVE_CLASS : BUTTON_IDLE_CLASS;
+    return `${BUTTON_CLASS} ${state}`;
+  }
+
+  private markersFor(direction: 'shadow' | 'highlight'): ClipMarker[] {
+    const clipped = this.clipped();
+    if (!clipped) return [];
+    return clippedChannels(clipped, direction, this.indicatorPercent(), this.monochrome())
+      .map(channel => ({
+        channel,
+        percent: clipped[direction][channel],
+        colorClass: MARKER_COLOR_CLASS[channel],
+      }));
+  }
+
+  private loadStored(path: string, url: string, token: number): () => void {
+    const subscription = this.api
+      .get<HistogramChannels & { clipped?: ClipPercents | null }>(
+        '/photo/histogram', { path, bins: DISPLAY_BINS })
+      .pipe(catchError(() => of(null)))
+      .subscribe(stored => {
+        if (this.destroyed || token !== this.generation) return;
+        if (stored?.luma?.length) {
+          // Markers come exclusively from this stored measurement -- a legacy
+          // row genuinely was never measured for clipping, and that must stay
+          // "unknown", never get filled in from the (also legacy) fallback.
+          this.clipped.set(stored.clipped ?? null);
+          this.storedChannels.set(stored);
+        } else if (url) {
+          this.sample(url, token);
+        }
+      });
+    return () => subscription.unsubscribe();
+  }
+
+  private sample(url: string, token: number): void {
     const img = new Image();
     img.decoding = 'async';
     img.onload = () => {
-      if (this.destroyed || this.currentUrl !== url) return;
+      if (this.destroyed || token !== this.generation) return;
       try {
-        const scale = Math.min(1, 160 / (img.naturalWidth || 160));
-        const w = Math.max(1, Math.round((img.naturalWidth || 160) * scale));
+        const naturalWidth = img.naturalWidth || SAMPLE_MAX_EDGE;
+        const scale = Math.min(1, SAMPLE_MAX_EDGE / naturalWidth);
+        const w = Math.max(1, Math.round(naturalWidth * scale));
         const h = Math.max(1, Math.round((img.naturalHeight || 120) * scale));
         const canvas = document.createElement('canvas');
         canvas.width = w;
@@ -61,10 +361,17 @@ export class HistogramComponent {
         const ctx = canvas.getContext('2d', { willReadFrequently: true });
         if (!ctx) return;
         ctx.drawImage(img, 0, 0, w, h);
-        const values = computeLuminanceHistogram(ctx.getImageData(0, 0, w, h).data);
-        this.points.set(histogramPolygonPoints(values, 128, 40));
+        const data = ctx.getImageData(0, 0, w, h).data;
+        // Sampled at full resolution first, so the bins dropped as clipping are
+        // exactly the values 0 and 255 rather than a four-value bucket around them.
+        this.sampledChannels.set(toInteriorChannels(computeRgbHistogram(data, SAMPLE_BINS), DISPLAY_BINS));
       } catch { /* canvas unavailable - histogram stays hidden */ }
     };
     img.src = url;
   }
+}
+
+/** "R 21.0% · B 41.7%" for a marker tooltip. */
+function describeMarkers(markers: ClipMarker[]): string {
+  return markers.map(m => `${m.channel.toUpperCase()} ${m.percent.toFixed(1)}%`).join(' · ');
 }

--- a/client/src/app/shared/components/histogram/histogram.component.ts
+++ b/client/src/app/shared/components/histogram/histogram.component.ts
@@ -6,6 +6,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { catchError, of } from 'rxjs';
 import { ApiService } from '../../../core/services/api.service';
 import { HistogramPreferencesService, HistogramSurface } from '../../../core/services/histogram-preferences.service';
+import { I18nService } from '../../../core/services/i18n.service';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 import { I18N_KEYS } from '../../../core/i18n/keys';
 import {
@@ -36,6 +37,16 @@ const BUTTON_IDLE_CLASS = 'text-neutral-400 hover:text-neutral-200';
 
 const MARKER_COLOR_CLASS: Record<ClipChannel, string> = {
   luma: 'bg-neutral-300', r: 'bg-red-500', g: 'bg-green-500', b: 'bg-blue-500',
+};
+
+/** Same channel labels as the mode buttons, so a marker's tooltip never names
+ *  a channel differently than the button that selects it (e.g. French "V"
+ *  for vert vs. a hardcoded "G"). */
+const CHANNEL_LABEL_KEY: Record<ClipChannel, string> = {
+  luma: I18N_KEYS.histogram.mode.luminance,
+  r: I18N_KEYS.histogram.mode.red,
+  g: I18N_KEYS.histogram.mode.green,
+  b: I18N_KEYS.histogram.mode.blue,
 };
 
 const CHANNEL_FILL_CLASS: Record<SingleChannel, string> = {
@@ -254,8 +265,8 @@ export class HistogramComponent {
 
   protected readonly shadowMarkers = computed(() => this.markersFor('shadow'));
   protected readonly highlightMarkers = computed(() => this.markersFor('highlight'));
-  protected readonly shadowDetail = computed(() => describeMarkers(this.shadowMarkers()));
-  protected readonly highlightDetail = computed(() => describeMarkers(this.highlightMarkers()));
+  protected readonly shadowDetail = computed(() => this.describeMarkers(this.shadowMarkers()));
+  protected readonly highlightDetail = computed(() => this.describeMarkers(this.highlightMarkers()));
 
   protected readonly lumaButtonClass = computed(() => this.buttonClass('luma'));
   protected readonly rgbButtonClass = computed(() => this.buttonClass('rgb'));
@@ -265,6 +276,7 @@ export class HistogramComponent {
 
   private readonly api = inject(ApiService);
   private readonly preferences = inject(HistogramPreferencesService);
+  private readonly i18n = inject(I18nService);
   private readonly destroyRef = inject(DestroyRef);
   private destroyed = false;
   // Bumped on every input change so a slow response can't overwrite the curves
@@ -325,6 +337,14 @@ export class HistogramComponent {
       }));
   }
 
+  /** "R 21.0% · B 41.7%" for a marker tooltip, using the same translated
+   *  channel labels as the mode buttons so the two never disagree. */
+  private describeMarkers(markers: ClipMarker[]): string {
+    return markers
+      .map(m => `${this.i18n.t(CHANNEL_LABEL_KEY[m.channel])} ${m.percent.toFixed(1)}%`)
+      .join(' · ');
+  }
+
   private loadStored(path: string, url: string, token: number): () => void {
     const subscription = this.api
       .get<HistogramChannels & { clipped?: ClipPercents | null }>(
@@ -369,9 +389,4 @@ export class HistogramComponent {
     };
     img.src = url;
   }
-}
-
-/** "R 21.0% · B 41.7%" for a marker tooltip. */
-function describeMarkers(markers: ClipMarker[]): string {
-  return markers.map(m => `${m.channel.toUpperCase()} ${m.percent.toFixed(1)}%`).join(' · ');
 }

--- a/client/src/app/shared/components/photo-card/photo-card.component.spec.ts
+++ b/client/src/app/shared/components/photo-card/photo-card.component.spec.ts
@@ -266,7 +266,7 @@ describe('PhotoCardComponent', () => {
       // Every earlier spec asserted a falsy one, which is why a badge keyed on
       // a field no backend ever sent passed for the life of the viewer.
       fixture.componentInstance.burstFramesVisible.set(true);
-      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true, burst_group_id: 'burst-1' }));
       fixture.detectChanges();
 
       expect(hasBestBadge()).toBe(true);
@@ -274,7 +274,7 @@ describe('PhotoCardComponent', () => {
 
     it('stays hidden while the burst is collapsed behind its lead', () => {
       fixture.componentInstance.burstFramesVisible.set(false);
-      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true, burst_group_id: 'burst-1' }));
       fixture.detectChanges();
 
       expect(hasBestBadge()).toBe(false);
@@ -282,7 +282,15 @@ describe('PhotoCardComponent', () => {
 
     it('stays hidden for a frame that does not lead its burst', () => {
       fixture.componentInstance.burstFramesVisible.set(true);
-      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: false }));
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: false, burst_group_id: 'burst-1' }));
+      fixture.detectChanges();
+
+      expect(hasBestBadge()).toBe(false);
+    });
+
+    it('stays hidden for a standalone photo that is in no burst at all, even though is_burst_lead is also the sentinel for "not a hidden burst member"', () => {
+      fixture.componentInstance.burstFramesVisible.set(true);
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true, burst_group_id: null }));
       fixture.detectChanges();
 
       expect(hasBestBadge()).toBe(false);
@@ -291,7 +299,7 @@ describe('PhotoCardComponent', () => {
     it('can be turned off in the config', () => {
       fixture.componentInstance.config.set({ badges: { best_of_burst: false } });
       fixture.componentInstance.burstFramesVisible.set(true);
-      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true, burst_group_id: 'burst-1' }));
       fixture.detectChanges();
 
       expect(hasBestBadge()).toBe(false);

--- a/client/src/app/shared/components/photo-card/photo-card.component.spec.ts
+++ b/client/src/app/shared/components/photo-card/photo-card.component.spec.ts
@@ -47,7 +47,7 @@ const makePhoto = (overrides: Partial<Photo> = {}): Photo => ({
   date_taken: null,
   image_width: 1920,
   image_height: 1080,
-  is_best_of_burst: null,
+  is_burst_lead: null,
   burst_group_id: null,
   duplicate_group_id: null,
   is_duplicate_lead: null,
@@ -71,10 +71,13 @@ const makePhoto = (overrides: Partial<Photo> = {}): Photo => ({
   selector: 'test-host',
   standalone: true,
   imports: [PhotoCardComponent],
-  template: `<app-photo-card [photo]="photo()" />`,
+  template: `<app-photo-card [photo]="photo()" [config]="config()"
+                             [burstFramesVisible]="burstFramesVisible()" />`,
 })
 class TestHostComponent {
   photo = signal<Photo>(makePhoto());
+  config = signal<Record<string, unknown> | null>(null);
+  burstFramesVisible = signal(false);
 }
 
 describe('PhotoCardComponent', () => {
@@ -225,13 +228,158 @@ describe('PhotoCardComponent', () => {
       expect(getTile().getAttribute('aria-label')).toBe('shot.jpg');
     });
   });
+
+  describe('badge visibility config', () => {
+    function iconNames(): string[] {
+      return (Array.from(fixture.nativeElement.querySelectorAll('mat-icon')) as HTMLElement[])
+        .map(icon => icon.textContent?.trim() ?? '');
+    }
+
+    it('draws every badge by default, so an install that configures nothing is unchanged', () => {
+      fixture.componentInstance.photo.set(
+        makePhoto({ keeper_hint: { has_better: true, best_path: '/o.jpg', keeper_prob: 0.2 } }),
+      );
+      fixture.detectChanges();
+
+      expect(iconNames()).toContain('arrow_circle_up');
+    });
+
+    it('hides a badge the config turns off', () => {
+      fixture.componentInstance.config.set({ badges: { keeper_hint: false } });
+      fixture.componentInstance.photo.set(
+        makePhoto({ keeper_hint: { has_better: true, best_path: '/o.jpg', keeper_prob: 0.2 } }),
+      );
+      fixture.detectChanges();
+
+      expect(iconNames()).not.toContain('arrow_circle_up');
+    });
+  });
+
+  describe('best-of-burst badge', () => {
+    function hasBestBadge(): boolean {
+      return Array.from(fixture.nativeElement.querySelectorAll('span'))
+        .some(el => (el as HTMLElement).textContent?.trim() === 'ui.badges.best');
+    }
+
+    it('renders when the photo leads a burst whose other frames are on screen', () => {
+      // The assertion this whole badge lacked: PRESENT for a truthy value.
+      // Every earlier spec asserted a falsy one, which is why a badge keyed on
+      // a field no backend ever sent passed for the life of the viewer.
+      fixture.componentInstance.burstFramesVisible.set(true);
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.detectChanges();
+
+      expect(hasBestBadge()).toBe(true);
+    });
+
+    it('stays hidden while the burst is collapsed behind its lead', () => {
+      fixture.componentInstance.burstFramesVisible.set(false);
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.detectChanges();
+
+      expect(hasBestBadge()).toBe(false);
+    });
+
+    it('stays hidden for a frame that does not lead its burst', () => {
+      fixture.componentInstance.burstFramesVisible.set(true);
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: false }));
+      fixture.detectChanges();
+
+      expect(hasBestBadge()).toBe(false);
+    });
+
+    it('can be turned off in the config', () => {
+      fixture.componentInstance.config.set({ badges: { best_of_burst: false } });
+      fixture.componentInstance.burstFramesVisible.set(true);
+      fixture.componentInstance.photo.set(makePhoto({ is_burst_lead: true }));
+      fixture.detectChanges();
+
+      expect(hasBestBadge()).toBe(false);
+    });
+  });
+
+  describe('clipping badge', () => {
+    function clipIcon(): string | null {
+      const icons = Array.from(fixture.nativeElement.querySelectorAll('mat-icon')) as HTMLElement[];
+      const found = icons.find(
+        icon => icon.textContent?.trim() === 'flare' || icon.textContent?.trim() === 'brightness_low',
+      );
+      return found ? found.textContent!.trim() : null;
+    }
+
+    it('badges a photo whose highlights clip past the threshold', () => {
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_highlight_pct: 41.7 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBe('flare');
+    });
+
+    it('leaves a photo below the threshold alone', () => {
+      // 2.35% is the p90 of the sampled library — common, and not worth a badge.
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_highlight_pct: 2.35 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBeNull();
+    });
+
+    it('says nothing about a photo that was never measured', () => {
+      // null is unknown, not clean — and must not be compared as if it were 0.
+      fixture.componentInstance.photo.set(
+        makePhoto({ channel_clip_highlight_pct: null, channel_clip_shadow_pct: null }),
+      );
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBeNull();
+    });
+
+    it('ignores shadow clipping by default, because it is usually deliberate', () => {
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_shadow_pct: 30.4 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBeNull();
+    });
+
+    it('badges shadows once they are opted in', () => {
+      fixture.componentInstance.config.set({ badges: { clipping_shadow: true } });
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_shadow_pct: 30.4 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBe('brightness_low');
+    });
+
+    it('prefers the highlight badge when both directions clip', () => {
+      fixture.componentInstance.config.set({ badges: { clipping_shadow: true } });
+      fixture.componentInstance.photo.set(
+        makePhoto({ channel_clip_highlight_pct: 20, channel_clip_shadow_pct: 30 }),
+      );
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBe('flare');
+    });
+
+    it('honours a configured threshold', () => {
+      fixture.componentInstance.config.set({ clipping: { badge_percent: 1 } });
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_highlight_pct: 2.35 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBe('flare');
+    });
+
+    it('can be turned off entirely', () => {
+      fixture.componentInstance.config.set({ badges: { clipping_highlight: false } });
+      fixture.componentInstance.photo.set(makePhoto({ channel_clip_highlight_pct: 41.7 }));
+      fixture.detectChanges();
+
+      expect(clipIcon()).toBeNull();
+    });
+  });
 });
 
 describe('PhotoCardComponent tooltip emission', () => {
   const mockI18n = { t: vi.fn((key: string) => key), currentLang: vi.fn(() => 'en'), locale: vi.fn(() => 'en'), translations: vi.fn(() => ({})) };
 
   /** Drive the card directly: this is about which gesture emits, not markup. */
-  function card(mode: 'hover' | 'click' | 'off' | 'panel') {
+  function card(mode: 'hover' | 'click' | 'off' | 'panel', panelActivation?: 'hover' | 'click' | 'both') {
     TestBed.configureTestingModule({
       imports: [PhotoCardComponent],
       providers: [{ provide: I18nService, useValue: mockI18n }],
@@ -239,6 +387,7 @@ describe('PhotoCardComponent tooltip emission', () => {
     const fixture = TestBed.createComponent(PhotoCardComponent);
     fixture.componentRef.setInput('photo', makePhoto());
     fixture.componentRef.setInput('tooltipMode', mode);
+    if (panelActivation) fixture.componentRef.setInput('panelActivation', panelActivation);
     fixture.detectChanges();
     const shown: string[] = [];
     let hidden = 0;
@@ -278,6 +427,57 @@ describe('PhotoCardComponent tooltip emission', () => {
     const { c, hidden } = card('panel');
     c.onMouseLeave();
     expect(hidden()).toBe(1);
+  });
+
+  // --- panelActivation: which gesture(s) retarget panel mode ----------------
+
+  it('activation "both" (the default) retargets on hover AND click', () => {
+    const { c, shown } = card('panel', 'both');
+    c.onMouseEnter(clickEvent);
+    c.onSelect(clickEvent);
+    expect(shown).toEqual(['/test.jpg', '/test.jpg']);
+  });
+
+  it('activation "hover" retargets on hover but does NOT retarget on click', () => {
+    const { c, shown } = card('panel', 'hover');
+    c.onMouseEnter(clickEvent);
+    expect(shown).toEqual(['/test.jpg']);
+    c.onSelect(clickEvent);
+    // A test that only checked the 'both' default would pass even if 'hover'
+    // also retargeted on click -- assert the click contributed nothing.
+    expect(shown).toEqual(['/test.jpg']);
+  });
+
+  it('activation "click" retargets on click but does NOT retarget on hover', () => {
+    const { c, shown } = card('panel', 'click');
+    c.onMouseEnter(clickEvent);
+    // A test that only checked the 'both' default would pass even if 'click'
+    // also retargeted on hover -- assert the hover contributed nothing.
+    expect(shown).toEqual([]);
+    c.onSelect(clickEvent);
+    expect(shown).toEqual(['/test.jpg']);
+  });
+
+  it('activation "click" does not clear the panel on mouse-out -- it was deliberately pinned there', () => {
+    const { c, hidden } = card('panel', 'click');
+    c.onMouseLeave();
+    expect(hidden()).toBe(0);
+  });
+
+  it('activation "hover" still clears the panel on mouse-out', () => {
+    const { c, hidden } = card('panel', 'hover');
+    c.onMouseLeave();
+    expect(hidden()).toBe(1);
+  });
+
+  it('Space retargets the panel regardless of activation -- a keyboard user has no hover to fall back on', () => {
+    const keyEvent = { preventDefault: () => {} } as unknown as Event;
+    for (const activation of ['hover', 'click', 'both'] as const) {
+      const { c, shown } = card('panel', activation);
+      c.onKeySelect(keyEvent);
+      expect(shown).toEqual(['/test.jpg']);
+      TestBed.resetTestingModule();
+    }
   });
 
   it('off mode reports nothing at all', () => {
@@ -334,4 +534,5 @@ describe('PhotoCardComponent tooltip emission', () => {
       TestBed.resetTestingModule();
     }
   });
+
 });

--- a/client/src/app/shared/components/photo-card/photo-card.component.ts
+++ b/client/src/app/shared/components/photo-card/photo-card.component.ts
@@ -17,7 +17,6 @@ interface AppConfig {
   features?: {
     show_similar_button?: boolean;
     show_rating_controls?: boolean;
-    show_rating_badge?: boolean;
     show_critique?: boolean;
     show_embed_metadata?: boolean;
   };
@@ -323,7 +322,7 @@ const DEFAULT_CLIPPING_BADGE_PERCENT = 5;
           <div class="flex items-center gap-1">
             <span class="font-medium text-neutral-200 truncate">{{ photo().filename }}</span>
             <span class="ml-auto flex items-center gap-1 shrink-0">
-              @if (badges().best_of_burst && burstFramesVisible() && photo().is_burst_lead) {
+              @if (badges().best_of_burst && burstFramesVisible() && photo().is_burst_lead && photo().burst_group_id) {
                 <span class="px-1 py-0.5 rounded text-[10px] font-bold bg-[var(--facet-accent-dim)] text-white">{{ 'ui.badges.best' | translate }}</span>
               }
               @if (currentSort() !== 'aggregate') {

--- a/client/src/app/shared/components/photo-card/photo-card.component.ts
+++ b/client/src/app/shared/components/photo-card/photo-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, input, output, signal, untracked } from '@angular/core';
+import { Component, computed, effect, input, output, signal, untracked } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -21,7 +21,39 @@ interface AppConfig {
     show_critique?: boolean;
     show_embed_metadata?: boolean;
   };
+  badges?: Partial<BadgeVisibility>;
+  clipping?: { badge_percent?: number };
 }
+
+/** Which card badges are drawn, from `viewer.badges`. */
+export interface BadgeVisibility {
+  favorite: boolean;
+  star_rating: boolean;
+  rejected: boolean;
+  sequence_kind: boolean;
+  sequence_override_pending: boolean;
+  keeper_hint: boolean;
+  best_of_burst: boolean;
+  clipping_highlight: boolean;
+  clipping_shadow: boolean;
+}
+
+/** Every badge that predates the config block stays on, so an install that
+ *  says nothing about badges looks exactly as it did. Shadow clipping is the
+ *  one default-off badge: crushed blacks are routinely deliberate. */
+export const DEFAULT_BADGE_VISIBILITY: BadgeVisibility = {
+  favorite: true,
+  star_rating: true,
+  rejected: true,
+  sequence_kind: true,
+  sequence_override_pending: true,
+  keeper_hint: true,
+  best_of_burst: true,
+  clipping_highlight: true,
+  clipping_shadow: false,
+};
+
+const DEFAULT_CLIPPING_BADGE_PERCENT = 5;
 
 @Component({
   selector: 'app-photo-card',
@@ -85,7 +117,7 @@ interface AppConfig {
              right-9 the bar's own px-1.5 py-1 and gap-0.5 produce. They were
              6px off before, which read as the icons jumping every time the
              pointer entered or left the tile. -->
-        @if (isEditionMode() && photo().is_favorite) {
+        @if (badges().favorite && isEditionMode() && photo().is_favorite) {
           <div class="absolute bottom-1 right-1.5 w-7 h-7 z-20 pointer-events-none inline-flex items-center justify-center transition-opacity md:group-hover/img:opacity-0">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-red-400 drop-shadow-md">favorite</mat-icon>
           </div>
@@ -94,7 +126,7 @@ interface AppConfig {
         <!-- A rating the user set is a standing fact about the photo, so it
              should not take a hover to see it. Carries the same count bubble the
              control does. -->
-        @if (isEditionMode() && photo().star_rating) {
+        @if (badges().star_rating && isEditionMode() && photo().star_rating) {
           <div class="absolute bottom-1 left-1.5 w-7 h-7 z-20 pointer-events-none inline-flex items-center justify-center transition-opacity md:group-hover/img:opacity-0"
                [attr.aria-label]="'rating.rating_badge' | translate:{ stars: photo().star_rating ?? 0 }">
             <mat-icon class="!text-lg !w-[18px] !h-[18px] !leading-[18px] !text-yellow-400 drop-shadow-md"
@@ -114,7 +146,7 @@ interface AppConfig {
              because the bar replaces them with their own controls, whereas this
              one states a fact the bar never repeats, so hiding it on hover just
              loses information. Sits above the bar's gradient. -->
-        @if (collapsedSequenceKinds().includes(photo().sequence_kind ?? '')) {
+        @if (badges().sequence_kind && collapsedSequenceKinds().includes(photo().sequence_kind ?? '')) {
           <div class="absolute bottom-1 left-10 w-7 h-7 z-30 inline-flex items-center justify-center"
                [matTooltip]="photo().sequence_kind | sequenceKindLabel | translate"
                [attr.aria-label]="photo().sequence_kind | sequenceKindLabel | translate">
@@ -128,7 +160,7 @@ interface AppConfig {
              until the next run, and that miss is exactly what was corrected.
              Unconditional, unlike the badge above -- a correction is not
              collapsed behind anything, so a hide toggle says nothing about it. -->
-        @if (photo().sequence_override_pending && photo().sequence_override; as pending) {
+        @if (badges().sequence_override_pending && photo().sequence_override_pending && photo().sequence_override; as pending) {
           <div class="absolute bottom-1 left-[4.5rem] w-7 h-7 z-30 inline-flex items-center justify-center"
                [matTooltip]="(pending === 'suppressed' ? 'gallery.sequence_override.badge_suppressed' : 'gallery.sequence_override.badge') | translate"
                [attr.aria-label]="(pending === 'suppressed' ? 'gallery.sequence_override.badge_suppressed' : 'gallery.sequence_override.badge') | translate">
@@ -143,7 +175,7 @@ interface AppConfig {
              corners so they never collided, and hiding it left desaturation as
              the only signal -- which conveys nothing to a screen reader and
              nothing at all on an already-monochrome photo. -->
-        @if (isEditionMode() && photo().is_rejected) {
+        @if (badges().rejected && isEditionMode() && photo().is_rejected) {
           <div class="absolute bottom-1 right-9 w-7 h-7 z-20 pointer-events-none inline-flex items-center justify-center transition-opacity md:group-hover/img:opacity-0"
                [attr.aria-label]="'rating.rejected_badge' | translate">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-red-400 drop-shadow-md" aria-hidden="true">thumb_down</mat-icon>
@@ -151,9 +183,24 @@ interface AppConfig {
         }
 
         <!-- Keeper hint: a better shot exists in this group (learned keeper head) -->
-        @if (photo().keeper_hint?.has_better) {
+        @if (badges().keeper_hint && photo().keeper_hint?.has_better) {
           <div class="absolute top-1.5 left-3 z-20 pointer-events-none flex items-center gap-1 px-1.5 py-0.5 rounded bg-black/60 transition-opacity md:group-hover/img:opacity-0">
             <mat-icon class="!text-base !w-4 !h-4 !leading-4 !text-amber-300 drop-shadow-md" aria-hidden="true">arrow_circle_up</mat-icon>
+          </div>
+        }
+
+        <!-- Clipping: a channel ran out of range and lost its detail. Top
+             right, fading on hover so it never sits under the overlay's own
+             buttons. Highlight and shadow are separate badges because they are
+             separate decisions -- a blown sky is usually a mistake, crushed
+             blacks are routinely the point -- which is why shadow is off by
+             default. A photo whose row was never measured has no percentage at
+             all and is silent, rather than claiming to be clean. -->
+        @if (clipping(); as clip) {
+          <div class="absolute top-1.5 right-1.5 z-20 pointer-events-none flex items-center gap-1 px-1.5 py-0.5 rounded bg-black/60 transition-opacity md:group-hover/img:opacity-0"
+               [attr.aria-label]="clip.label | translate:{ percent: clip.percentText }">
+            <mat-icon class="!text-base !w-4 !h-4 !leading-4 drop-shadow-md"
+                      [class]="clip.colorClass" aria-hidden="true">{{ clip.icon }}</mat-icon>
           </div>
         }
 
@@ -163,7 +210,7 @@ interface AppConfig {
           <div class="flex justify-end items-center gap-1 p-1.5">
             @if (config()?.features?.show_similar_button) {
               <button
-                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
+                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white cursor-pointer"
                 [matMenuTriggerFor]="similarMenu"
                 [matTooltip]="'similar.find_similar' | translate"
                 [attr.aria-label]="'similar.find_similar' | translate"
@@ -187,7 +234,7 @@ interface AppConfig {
             }
             @if (config()?.features?.show_critique) {
               <button
-                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
+                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white cursor-pointer"
                 [matTooltip]="'critique.title' | translate"
                 [attr.aria-label]="'critique.title' | translate"
                 (click)="openCritiqueClicked.emit(photo()); $event.stopPropagation()">
@@ -196,7 +243,7 @@ interface AppConfig {
             }
             @if (isEditionMode() && config()?.features?.show_embed_metadata) {
               <button
-                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
+                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white cursor-pointer"
                 [matTooltip]="'photoCard.embed_to_file' | translate"
                 [attr.aria-label]="'photoCard.embed_to_file' | translate"
                 (click)="embedMetadataClicked.emit(photo()); $event.stopPropagation()">
@@ -205,7 +252,7 @@ interface AppConfig {
             }
             @if (isEditionMode() && photo().unassigned_faces > 0) {
               <button
-                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white"
+                class="w-7 h-7 rounded-full bg-black/50 inline-flex items-center justify-center hover:bg-black/80 transition-colors text-white cursor-pointer"
                 [matTooltip]="'manage_persons.assign_face' | translate"
                 [attr.aria-label]="'manage_persons.assign_face' | translate"
                 (click)="openAddPersonClicked.emit(photo()); $event.stopPropagation()">
@@ -220,7 +267,7 @@ interface AppConfig {
               <!-- Left: compact star rating -->
               @if (config()?.features?.show_rating_controls) {
                 <button
-                  class="relative w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-yellow-400"
+                  class="relative w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors text-yellow-400 cursor-pointer"
                   [matTooltip]="'rating.set_rating' | translate"
                   [attr.aria-label]="'rating.set_rating' | translate"
                   (click)="cycleStarRating(); $event.stopPropagation()"
@@ -235,7 +282,7 @@ interface AppConfig {
               <div class="flex items-center gap-0.5 ml-auto">
                 @if (!photo().star_rating) {
                   <button
-                    class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors"
+                    class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors cursor-pointer"
                     [class.text-red-400]="photo().is_rejected"
                     [class.text-white]="!photo().is_rejected"
                     [matTooltip]="(photo().is_rejected ? 'rating.unmark_rejected' : 'rating.mark_rejected') | translate"
@@ -247,7 +294,7 @@ interface AppConfig {
                   </button>
                 }
                 <button
-                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors"
+                  class="w-7 h-7 rounded-full inline-flex items-center justify-center hover:bg-white/20 transition-colors cursor-pointer"
                   [class.text-red-400]="photo().is_favorite"
                   [class.text-white]="!photo().is_favorite"
                   [matTooltip]="(photo().is_favorite ? 'rating.remove_favorite' : 'rating.add_favorite') | translate"
@@ -276,7 +323,7 @@ interface AppConfig {
           <div class="flex items-center gap-1">
             <span class="font-medium text-neutral-200 truncate">{{ photo().filename }}</span>
             <span class="ml-auto flex items-center gap-1 shrink-0">
-              @if (photo().is_best_of_burst) {
+              @if (badges().best_of_burst && burstFramesVisible() && photo().is_burst_lead) {
                 <span class="px-1 py-0.5 rounded text-[10px] font-bold bg-[var(--facet-accent-dim)] text-white">{{ 'ui.badges.best' | translate }}</span>
               }
               @if (currentSort() !== 'aggregate') {
@@ -318,7 +365,7 @@ interface AppConfig {
               @for (person of photo().persons | sortPersons:personFilterId(); track person.id) {
                 @if (isEditionMode() && personFilterId() === '' + person.id) {
                   <button
-                    class="w-8 h-8 rounded-full bg-red-900/60 inline-flex items-center justify-center hover:bg-red-800 transition-colors"
+                    class="w-8 h-8 rounded-full bg-red-900/60 inline-flex items-center justify-center hover:bg-red-800 transition-colors cursor-pointer"
                     [matTooltip]="('ui.buttons.remove' | translate) + ': ' + person.name"
                     [attr.aria-label]="('ui.buttons.remove' | translate) + ': ' + person.name"
                     (click)="personRemoveClicked.emit({photo: photo(), personId: person.id}); $event.stopPropagation()">
@@ -347,6 +394,43 @@ export class PhotoCardComponent {
   // Data
   readonly photo = input.required<Photo>();
   readonly config = input<AppConfig | null>(null);
+
+  /** Which badges this install draws, with every unset key left at its default. */
+  protected readonly badges = computed<BadgeVisibility>(
+    () => ({ ...DEFAULT_BADGE_VISIBILITY, ...(this.config()?.badges ?? {}) }));
+
+  /**
+   * The clipping badge for this photo, or null when it has not earned one.
+   *
+   * Highlights win when both directions clip: a blown highlight is
+   * unrecoverable, while a crushed black usually still reads as black.
+   * A null percentage means the photo was never measured (its stored
+   * histogram predates the per-channel format) and is treated as unknown,
+   * never as clean.
+   */
+  protected readonly clipping = computed(() => {
+    const badges = this.badges();
+    const threshold = this.config()?.clipping?.badge_percent ?? DEFAULT_CLIPPING_BADGE_PERCENT;
+    const highlight = this.photo().channel_clip_highlight_pct;
+    const shadow = this.photo().channel_clip_shadow_pct;
+    if (badges.clipping_highlight && highlight != null && highlight > threshold) {
+      return {
+        label: 'gallery.clipping.badge_highlight',
+        icon: 'flare',
+        colorClass: '!text-amber-300',
+        percentText: highlight.toFixed(1),
+      };
+    }
+    if (badges.clipping_shadow && shadow != null && shadow > threshold) {
+      return {
+        label: 'gallery.clipping.badge_shadow',
+        icon: 'brightness_low',
+        colorClass: '!text-sky-300',
+        percentText: shadow.toFixed(1),
+      };
+    }
+    return null;
+  });
 
   // Progressive loading
   readonly imageLoaded = signal(false);
@@ -380,24 +464,52 @@ export class PhotoCardComponent {
    *  toggle is on, and the badge would then be claiming a set is collapsed when
    *  every one of its frames is on screen. */
   readonly collapsedSequenceKinds = input<readonly string[]>([]);
+  /** Whether a burst's non-lead frames are on screen.
+   *
+   *  The mirror image of `collapsedSequenceKinds`: with `hide_bursts` on --
+   *  the default -- every burst photo in the grid IS its group's lead, so a
+   *  "best" badge on each would be decoration. It only carries information
+   *  once the siblings it was picked over are visible beside it. */
+  readonly burstFramesVisible = input(false);
   readonly personFilterId = input('');
   /** 'hover' (default) | 'click' | 'off' | 'panel' — drives tooltip emission strategy.
    *
-   *  'panel' feeds the gallery's docked rail, which is the one mode driven by
-   *  BOTH gestures: it was asked for as "changes with the photo selected (click)
-   *  or hovered (hover)", and since the rail is parked rather than chasing the
-   *  cursor there is no reason to make that an either/or. It also keeps the rail
-   *  usable on a touch screen, where hover never fires. */
+   *  'panel' feeds the gallery's docked rail. By default it responds to BOTH
+   *  gestures: it was asked for as "changes with the photo selected (click) or
+   *  hovered (hover)", and since the rail is parked rather than chasing the
+   *  cursor there is no reason to make that an either/or by default. It also
+   *  keeps the rail usable on a touch screen, where hover never fires.
+   *  panelActivation narrows this per-install/per-user. */
   readonly tooltipMode = input<'hover' | 'click' | 'off' | 'panel'>('hover');
+  /** Which gesture(s) retarget the docked panel when tooltipMode is 'panel'.
+   *  Irrelevant for every other mode, which already has one fixed gesture.
+   *  Default 'both' preserves the original panel behaviour exactly. */
+  readonly panelActivation = input<'hover' | 'click' | 'both'>('both');
 
-  /** Whether this mode reports hover at all (both hover and the docked rail do). */
+  /** Whether a mouse hover retargets the panel: always for 'hover', for
+   *  'panel' only when panelActivation allows hover. */
   private hoverDriven(): boolean {
-    return this.tooltipMode() === 'hover' || this.tooltipMode() === 'panel';
+    const mode = this.tooltipMode();
+    if (mode === 'hover') return true;
+    if (mode === 'panel') return this.panelActivation() !== 'click';
+    return false;
   }
 
-  /** Whether this mode reports clicks (the click tooltip and the docked rail). */
+  /** Whether a mouse click retargets the panel: always for 'click', for
+   *  'panel' only when panelActivation allows click. */
   private clickDriven(): boolean {
-    return this.tooltipMode() === 'click' || this.tooltipMode() === 'panel';
+    const mode = this.tooltipMode();
+    if (mode === 'click') return true;
+    if (mode === 'panel') return this.panelActivation() !== 'hover';
+    return false;
+  }
+
+  /** Keyboard selection always retargets 'click' and 'panel', regardless of
+   *  panelActivation -- a keyboard user has no hover to fall back on, so
+   *  narrowing this the same way as clickDriven() would strand them. */
+  private keyboardDriven(): boolean {
+    const mode = this.tooltipMode();
+    return mode === 'click' || mode === 'panel';
   }
 
   // Events
@@ -414,7 +526,7 @@ export class PhotoCardComponent {
   onKeySelect(event: Event): void {
     event.preventDefault();
     this.selectionChange.emit({ photo: this.photo(), event: event as MouseEvent });
-    if (this.clickDriven()) {
+    if (this.keyboardDriven()) {
       this.tooltipShow.emit({ photo: this.photo(), event: event as MouseEvent });
     }
   }

--- a/client/src/app/shared/components/shared-view/shared-photo-detail.component.ts
+++ b/client/src/app/shared/components/shared-view/shared-photo-detail.component.ts
@@ -132,7 +132,7 @@ import { I18N_KEYS } from '../../../core/i18n/keys';
                 @if (p.eye_sharpness !== null) {
                   <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.eye_sharpness | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.eye_sharpness | fixed:1 }}</span></div>
                 }
-                @if (p.face_confidence !== null) {
+                @if (p.face_confidence !== null && p.face_confidence !== undefined) {
                   <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.face_confidence | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.face_confidence * 100 | fixed:0 }}%</span></div>
                 }
               }
@@ -207,13 +207,13 @@ import { I18N_KEYS } from '../../../core/i18n/keys';
               @if (p.dynamic_range_stops !== null) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.dynamic_range | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.dynamic_range_stops | fixed:1 }}</span></div>
               }
-              @if (p.mean_saturation !== null) {
+              @if (p.mean_saturation !== null && p.mean_saturation !== undefined) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.saturation | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ (p.mean_saturation * 100) | fixed:0 }}%</span></div>
               }
               @if (p.noise_sigma !== null) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.noise | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.noise_sigma | fixed:1 }}</span></div>
               }
-              @if (p.mean_luminance !== null) {
+              @if (p.mean_luminance !== null && p.mean_luminance !== undefined) {
                 <div class="flex justify-between items-baseline gap-2"><span class="text-[var(--mat-sys-on-surface-variant)]">{{ I18N.tooltip.luminance | translate }}</span><span class="text-[var(--mat-sys-primary)] font-medium">{{ p.mean_luminance * 100 | fixed:0 }}%</span></div>
               }
               @if (p.histogram_spread !== null) {

--- a/client/src/app/shared/components/shared-view/shared-view.component.ts
+++ b/client/src/app/shared/components/shared-view/shared-view.component.ts
@@ -518,7 +518,7 @@ interface SharedFilters {
 
       <!-- Client proofing: pick + comment overlay buttons (shared by mosaic & grid) -->
       <ng-template #proofingButtons let-photo let-btnSize="btnSize" let-iconSize="iconSize" let-commentPos="commentPos">
-        <button class="absolute top-1 right-1 z-10 flex items-center justify-center rounded-full bg-black/40 text-white hover:bg-black/60"
+        <button class="absolute top-1 right-1 z-10 flex items-center justify-center rounded-full bg-black/40 text-white hover:bg-black/60 cursor-pointer"
                 [ngClass]="btnSize"
                 [matTooltip]="(pickedPaths().has(photo.path) ? I18N.proofing.unpick : I18N.proofing.pick) | translate"
                 [attr.aria-label]="(pickedPaths().has(photo.path) ? I18N.proofing.unpick : I18N.proofing.pick) | translate"
@@ -526,7 +526,7 @@ interface SharedFilters {
                 (click)="togglePick(photo, $event)">
           <mat-icon [ngClass]="iconSize" [class.!text-red-400]="pickedPaths().has(photo.path)">{{ pickedPaths().has(photo.path) ? 'favorite' : 'favorite_border' }}</mat-icon>
         </button>
-        <button class="absolute top-1 z-10 flex items-center justify-center rounded-full bg-black/40 text-white hover:bg-black/60"
+        <button class="absolute top-1 z-10 flex items-center justify-center rounded-full bg-black/40 text-white hover:bg-black/60 cursor-pointer"
                 [ngClass]="[btnSize, commentPos]"
                 [matTooltip]="I18N.proofing.comment | translate"
                 [attr.aria-label]="I18N.proofing.comment | translate"

--- a/client/src/app/shared/models/photo.model.ts
+++ b/client/src/app/shared/models/photo.model.ts
@@ -16,23 +16,27 @@ export interface Photo {
   tech_sharpness: number | null;
   color_score: number | null;
   exposure_score: number | null;
-  quality_score: number | null;
-  topiq_score: number | null;
-  top_picks_score: number | null;
+  // Optional below: only sent when the DB has run the migration that added
+  // the column (api/db_helpers.py PHOTO_OPTIONAL_COLS is filtered against
+  // the DB's actual column set at query time — see api/__init__.py).
+  quality_score?: number | null;
+  topiq_score?: number | null;
+  /** Computed sort alias, sent only when sorting by it (never a stored column). */
+  top_picks_score?: number | null;
   isolation_bonus: number | null;
   // Extended quality
-  aesthetic_iaa: number | null;
-  face_quality_iqa: number | null;
-  liqe_score: number | null;
+  aesthetic_iaa?: number | null;
+  face_quality_iqa?: number | null;
+  liqe_score?: number | null;
   // Extended IQA tier (config-gated; optional — absent/null unless iqa_extended is enabled)
   qrealign_score?: number | null;
   aesthetic_v25?: number | null;
   deqa_score?: number | null;
   // Subject saliency
-  subject_sharpness: number | null;
-  subject_prominence: number | null;
-  subject_placement: number | null;
-  bg_separation: number | null;
+  subject_sharpness?: number | null;
+  subject_prominence?: number | null;
+  subject_placement?: number | null;
+  bg_separation?: number | null;
   // Form facet + color harmony (optional — absent until the columns are populated)
   form_symmetry?: number | null;
   form_balance?: number | null;
@@ -44,7 +48,7 @@ export interface Photo {
   face_ratio: number;
   eye_sharpness: number | null;
   face_sharpness: number | null;
-  face_confidence: number | null;
+  face_confidence?: number | null;
   is_blink: boolean | null;
   // Camera
   camera_model: string | null;
@@ -54,24 +58,29 @@ export interface Photo {
   shutter_speed: number | null;
   focal_length: number | null;
   // Technical
-  noise_sigma: number | null;
-  contrast_score: number | null;
-  dynamic_range_stops: number | null;
-  mean_saturation: number | null;
-  mean_luminance: number | null;
-  histogram_spread: number | null;
+  noise_sigma?: number | null;
+  contrast_score?: number | null;
+  dynamic_range_stops?: number | null;
+  mean_saturation?: number | null;
+  mean_luminance?: number | null;
+  histogram_spread?: number | null;
   // Composition
-  composition_pattern: string | null;
-  power_point_score: number | null;
-  leading_lines_score: number | null;
+  composition_pattern?: string | null;
+  power_point_score?: number | null;
+  leading_lines_score?: number | null;
   // Classification
   category: string | null;
   narrative_moment?: string | null;
   narrative_moment_confidence?: number | null;
-  tags: string | null;
+  tags?: string | null;
   tags_list: string[];
-  is_monochrome: boolean | null;
-  is_silhouette: boolean | null;
+  is_monochrome?: boolean | null;
+  is_silhouette?: boolean | null;
+  /** Worst-channel share of pixels pinned to bin 0 / bin 255, as a percentage.
+   *  `null`/absent means the photo was never measured — its stored histogram
+   *  predates the per-channel format — which is NOT the same as "clean". */
+  channel_clip_shadow_pct?: number | null;
+  channel_clip_highlight_pct?: number | null;
   // Metadata
   date_taken: string | null;
   /** Pixel dimensions of the frame the scan analysed. Null when the recorded
@@ -85,21 +94,27 @@ export interface Photo {
    *  it is a fallback, never a preference. */
   image_aspect?: number | null;
   // Burst/Duplicate
-  is_best_of_burst: boolean | null;
-  burst_group_id: string | null;
-  duplicate_group_id: string | null;
-  is_duplicate_lead: boolean | null;
+  /** The frame that stands for its burst. Named for the column the API sends:
+   *  the client used to declare an `is_best_of_burst` that no backend has ever
+   *  produced, so the badge keyed on it could never fire. */
+  is_burst_lead: boolean | null;
+  burst_group_id?: string | null;
+  duplicate_group_id?: string | null;
+  is_duplicate_lead?: boolean | null;
   // Persons & Rating
   persons: { id: number; name: string }[];
   unassigned_faces: number;
-  star_rating: number | null;
-  is_favorite: boolean | null;
-  is_rejected: boolean | null;
+  star_rating?: number | null;
+  is_favorite?: boolean | null;
+  is_rejected?: boolean | null;
   keeper_hint?: KeeperHint | null;
   /** 'bracket' | 'panorama' | 'hdr_panorama' when this frame belongs to a
    *  deliberate multi-frame set. With the matching hide toggle on, the tile
    *  showing it stands for the whole set. */
   sequence_kind?: string | null;
+  /** This frame's stops from the set's base exposure. Only a bracket has one
+   *  — NULL for every other kind, which has no base frame to measure against. */
+  sequence_ev_offset?: number | null;
   /** A manual correction to what this frame's set is: 'suppressed' ("not a
    *  panorama") or the kind it was forced to. Independent of `sequence_kind`,
    *  which the detector owns — a forced set has none at all until the next run.
@@ -113,4 +128,26 @@ export interface Photo {
   caption_translated?: string;
   gps_latitude?: number;
   gps_longitude?: number;
+}
+
+/** One sibling frame within a `PhotoSet`, from `GET /api/photo/set`. */
+export interface PhotoSetMember {
+  path: string;
+  /** Stops from the set's base exposure. Only a bracket has one — NULL for
+   *  every other kind, which has no base frame to measure against. */
+  ev_offset: number | null;
+  is_lead: boolean;
+}
+
+/** The bracket/panorama/hdr_panorama/burst/duplicate set a photo belongs to,
+ *  resolved server-side from the photo's own row (never from a group id,
+ *  which the detector renumbers from 1 on every run). `kind` is null when
+ *  the photo belongs to no set at all. */
+export interface PhotoSet {
+  kind: string | null;
+  group_id: number | null;
+  count: number;
+  /** Widest exposure swing in the set, in stops. Only a bracket has one. */
+  ev_span: number | null;
+  members: PhotoSetMember[];
 }

--- a/client/src/app/shared/pipes/photo-set-kind.pipe.ts
+++ b/client/src/app/shared/pipes/photo-set-kind.pipe.ts
@@ -1,0 +1,41 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { I18N } from '../../core/i18n/keys';
+import { SEQUENCE_KIND_ICONS, SEQUENCE_KIND_LABELS } from './sequence-kind.pipe';
+
+/**
+ * Every kind of multi-frame set a photo can belong to, as resolved by
+ * `GET /api/photo/set`: the three deliberate sequence kinds plus the two
+ * derived groupings that endpoint also reports. Composes
+ * SEQUENCE_KIND_ICONS/LABELS rather than duplicating them, so a sequence-kind
+ * icon or label still changes in one place -- burst and duplicate have no
+ * `sequence_kind` counterpart to reuse, since neither is a value that column
+ * can hold.
+ */
+export const PHOTO_SET_KIND_ICONS: Record<string, string> = {
+  ...SEQUENCE_KIND_ICONS,
+  burst: 'burst_mode',
+  duplicate: 'content_copy',
+};
+
+export const PHOTO_SET_KIND_LABELS: Record<string, string> = {
+  ...SEQUENCE_KIND_LABELS,
+  burst: I18N.culling.type_burst,
+  duplicate: I18N.photo_detail.set.kind_duplicate,
+};
+
+/** Material icon for a photo-set kind, or '' when it names no known kind. */
+@Pipe({ name: 'photoSetKindIcon', standalone: true })
+export class PhotoSetKindIconPipe implements PipeTransform {
+  transform(kind: string | null | undefined): string {
+    return (kind && PHOTO_SET_KIND_ICONS[kind]) || '';
+  }
+}
+
+/** Translation key naming a photo-set kind, or '' when it names no known kind. */
+@Pipe({ name: 'photoSetKindLabel', standalone: true })
+export class PhotoSetKindLabelPipe implements PipeTransform {
+  transform(kind: string | null | undefined): string {
+    return (kind && PHOTO_SET_KIND_LABELS[kind]) || '';
+  }
+}

--- a/client/src/app/shared/utils/histogram.spec.ts
+++ b/client/src/app/shared/utils/histogram.spec.ts
@@ -1,4 +1,7 @@
-import { computeLuminanceHistogram, histogramPolygonPoints } from './histogram';
+import {
+  ClipPercents, clippedChannels, computeRgbHistogram, downsampleBins, histogramLinePoints,
+  histogramPolygonPoints, normalizeChannels, toInteriorChannels,
+} from './histogram';
 
 function rgba(pixels: number[][]): Uint8ClampedArray {
   const data = new Uint8ClampedArray(pixels.length * 4);
@@ -8,27 +11,73 @@ function rgba(pixels: number[][]): Uint8ClampedArray {
   return data;
 }
 
-describe('computeLuminanceHistogram', () => {
+describe('computeRgbHistogram', () => {
   it('all-black image spikes in the first bin', () => {
-    const hist = computeLuminanceHistogram(rgba(Array(50).fill([0, 0, 0])), 8);
-    expect(hist[0]).toBe(1);
-    expect(hist.slice(1).every(v => v === 0)).toBe(true);
+    const hist = computeRgbHistogram(rgba(Array(50).fill([0, 0, 0])), 8);
+    expect(hist.luma[0]).toBe(1);
+    expect(hist.luma.slice(1).every(v => v === 0)).toBe(true);
   });
 
   it('all-white image spikes in the last bin', () => {
-    const hist = computeLuminanceHistogram(rgba(Array(50).fill([255, 255, 255])), 8);
-    expect(hist[7]).toBe(1);
-    expect(hist.slice(0, 7).every(v => v === 0)).toBe(true);
+    const hist = computeRgbHistogram(rgba(Array(50).fill([255, 255, 255])), 8);
+    expect(hist.luma[7]).toBe(1);
+    expect(hist.luma.slice(0, 7).every(v => v === 0)).toBe(true);
   });
 
   it('uniform gray ramp fills bins roughly evenly', () => {
     const pixels = Array.from({ length: 256 }, (_, v) => [v, v, v]);
-    const hist = computeLuminanceHistogram(rgba(pixels), 8);
-    expect(hist.every(v => v > 0.9)).toBe(true);
+    const hist = computeRgbHistogram(rgba(pixels), 8);
+    expect(hist.luma.every(v => v > 0.9)).toBe(true);
   });
 
-  it('empty data yields all-zero bins', () => {
-    expect(computeLuminanceHistogram(new Uint8ClampedArray(0), 4)).toEqual([0, 0, 0, 0]);
+  it('empty data yields all-zero bins on every channel', () => {
+    const hist = computeRgbHistogram(new Uint8ClampedArray(0), 4);
+    expect(hist.luma).toEqual([0, 0, 0, 0]);
+    expect(hist.r).toEqual([0, 0, 0, 0]);
+    expect(hist.g).toEqual([0, 0, 0, 0]);
+    expect(hist.b).toEqual([0, 0, 0, 0]);
+  });
+
+  it('separates the channels of a pure-red frame', () => {
+    const hist = computeRgbHistogram(rgba(Array(50).fill([255, 0, 0])), 8);
+    expect(hist.r![7]).toBe(1);
+    expect(hist.g![0]).toBe(1);
+    expect(hist.b![0]).toBe(1);
+    // Rec. 601 luma of pure red is 76 -> bin 2 of 8.
+    expect(hist.luma[2]).toBe(1);
+  });
+
+  it('normalizes every channel by one global max, never per channel', () => {
+    // 30 red + 10 green pixels. Blue is zero for all 40, so its single bin is
+    // the tallest anywhere and sets the global max; no other channel may be
+    // stretched up to 1 by its own peak.
+    const pixels = [...Array(30).fill([255, 0, 0]), ...Array(10).fill([0, 255, 0])];
+    const hist = computeRgbHistogram(rgba(pixels), 8);
+    expect(hist.b![0]).toBeCloseTo(1, 5);
+    expect(hist.r![7]).toBeCloseTo(0.75, 5);
+    expect(hist.g![7]).toBeCloseTo(0.25, 5);
+    expect(Math.max(...hist.r!)).toBeLessThan(1);
+    expect(Math.max(...hist.g!)).toBeLessThan(1);
+    expect(Math.max(...hist.luma)).toBeLessThan(1);
+  });
+});
+
+describe('normalizeChannels', () => {
+  it('leaves null channels null', () => {
+    const out = normalizeChannels({ luma: [1, 3], r: null, g: null, b: null });
+    expect(out.luma).toEqual([1 / 3, 1]);
+    expect(out.r).toBeNull();
+  });
+
+  it('scales luminance by the RGB peak when a channel is taller', () => {
+    const out = normalizeChannels({ luma: [2, 0], r: [4, 0], g: [0, 0], b: [0, 0] });
+    expect(out.luma).toEqual([0.5, 0]);
+    expect(out.r).toEqual([1, 0]);
+  });
+
+  it('all-zero input is returned untouched', () => {
+    const zero = { luma: [0, 0], r: [0, 0], g: [0, 0], b: [0, 0] };
+    expect(normalizeChannels(zero)).toEqual(zero);
   });
 });
 
@@ -46,5 +95,104 @@ describe('histogramPolygonPoints', () => {
 
   it('empty values yield empty string', () => {
     expect(histogramPolygonPoints([], 100, 40)).toBe('');
+  });
+});
+
+describe('histogramLinePoints', () => {
+  it('omits the baseline points the polygon adds', () => {
+    const line = histogramLinePoints([0.5, 1, 0.25], 128, 40);
+    expect(line.startsWith('0,40')).toBe(false);
+    expect(histogramPolygonPoints([0.5, 1, 0.25], 128, 40)).toBe(`0,40 ${line} 128,40`);
+  });
+
+  it('empty values yield empty string', () => {
+    expect(histogramLinePoints([], 100, 40)).toBe('');
+  });
+});
+
+describe('downsampleBins', () => {
+  it('sums adjacent bins', () => {
+    expect(downsampleBins([1, 2, 3, 4, 5, 6, 7, 8], 4)).toEqual([3, 7, 11, 15]);
+  });
+
+  it('is a passthrough at full resolution', () => {
+    expect(downsampleBins([1, 2, 3], 3)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('toInteriorChannels', () => {
+  /** A readable curve at bin 100, dwarfed by a clipping spike at bin 255. */
+  function clippedCurve(): number[] {
+    const bins = new Array<number>(256).fill(0);
+    bins[255] = 10000;
+    bins[100] = 300;
+    bins[101] = 150;
+    return bins;
+  }
+
+  it('keeps the curve readable when the clip spike dominates', () => {
+    const bins = clippedCurve();
+    const out = toInteriorChannels({ luma: bins, r: null, g: null, b: null }, 256);
+    // Normalized against the spike this was 0.03 of full height — a hairline.
+    expect(out.luma[100]).toBeCloseTo(1, 5);
+    expect(out.luma[101]).toBeCloseTo(0.5, 5);
+  });
+
+  it('drops both clipping bins from the drawn curve', () => {
+    const out = toInteriorChannels(
+      { luma: clippedCurve(), r: null, g: null, b: null }, 256);
+    expect(out.luma[255]).toBe(0);
+    expect(out.luma[0]).toBe(0);
+  });
+
+  it('still scales every channel by one shared maximum', () => {
+    const spike = (at: number, height: number) => {
+      const bins = new Array<number>(256).fill(0);
+      bins[at] = height;
+      return bins;
+    };
+    const out = toInteriorChannels(
+      { luma: spike(90, 100), r: spike(90, 400), g: spike(90, 200), b: spike(90, 50) }, 256);
+    expect(Math.max(...out.r!)).toBeCloseTo(1, 5);
+    expect(Math.max(...out.g!)).toBeCloseTo(0.5, 5);
+    expect(Math.max(...out.b!)).toBeCloseTo(0.125, 5);
+    expect(Math.max(...out.luma)).toBeCloseTo(0.25, 5);
+  });
+
+  it('does not divide by zero when every pixel is clipped', () => {
+    const bins = new Array<number>(256).fill(0);
+    bins[255] = 5000;
+    const out = toInteriorChannels({ luma: bins, r: null, g: null, b: null }, 64);
+    expect(out.luma.every(v => v === 0)).toBe(true);
+  });
+});
+
+describe('clippedChannels', () => {
+  const clipped: ClipPercents = {
+    shadow: { luma: 1.73, r: 9.58, g: 2.94, b: 1.63 },
+    highlight: { luma: 0, r: 0.0035, g: 0, b: 0 },
+  };
+
+  it('returns only the channels above the threshold', () => {
+    expect(clippedChannels(clipped, 'shadow', 2, false)).toEqual(['r', 'g']);
+  });
+
+  it('finds a single-channel clip luminance would miss entirely', () => {
+    expect(clippedChannels(clipped, 'highlight', 0.001, false)).toEqual(['r']);
+    expect(clipped.highlight.luma).toBe(0);
+  });
+
+  it('returns nothing when no channel reaches the threshold', () => {
+    expect(clippedChannels(clipped, 'highlight', 1, false)).toEqual([]);
+  });
+
+  it('reports luminance alone for a monochrome photo', () => {
+    expect(clippedChannels(clipped, 'shadow', 1, true)).toEqual(['luma']);
+  });
+
+  it('treats an unmeasured photo as unknown, never as clean', () => {
+    // Threshold 0 would match every channel if null were read as zero.
+    expect(clippedChannels(null, 'highlight', 0, false)).toEqual([]);
+    expect(clippedChannels(undefined, 'shadow', 0, false)).toEqual([]);
   });
 });

--- a/client/src/app/shared/utils/histogram.ts
+++ b/client/src/app/shared/utils/histogram.ts
@@ -1,27 +1,149 @@
-/** Pure luminance-histogram math (kept canvas-free so it tests in jsdom). */
+/** Pure histogram math (kept canvas-free so it tests in jsdom). */
 
 /**
- * Bin pixel data (RGBA byte stream) into a luminance histogram.
- * Uses Rec. 601 luma weights. Returns counts normalized to [0, 1].
+ * Normalized bins in [0, 1]. `r`/`g`/`b` are null when only luminance is known —
+ * a photo whose stored histogram predates the per-channel format.
  */
-export function computeLuminanceHistogram(data: Uint8ClampedArray, bins = 64): number[] {
-  const counts = new Array<number>(bins).fill(0);
-  if (!data.length) return counts;
-  const scale = bins / 256;
-  for (let i = 0; i < data.length; i += 4) {
-    const luma = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
-    counts[Math.min(bins - 1, Math.floor(luma * scale))]++;
-  }
-  let max = 0;
-  for (const c of counts) if (c > max) max = c;
-  return max > 0 ? counts.map(c => c / max) : counts;
+export interface HistogramChannels {
+  luma: number[];
+  r: number[] | null;
+  g: number[] | null;
+  b: number[] | null;
 }
 
-/** SVG polygon points string for a normalized histogram, in a 0..width / 0..height box. */
-export function histogramPolygonPoints(values: number[], width: number, height: number): string {
+/**
+ * Scale every channel by the single largest bin found across all of them.
+ * Normalizing each channel by its own maximum would stretch a near-empty
+ * channel to full height and draw a colour cast the photo does not have.
+ */
+export function normalizeChannels(channels: HistogramChannels): HistogramChannels {
+  const series = [channels.luma, channels.r, channels.g, channels.b];
+  let max = 0;
+  for (const bins of series) {
+    if (!bins) continue;
+    for (const v of bins) if (v > max) max = v;
+  }
+  if (max <= 0) return channels;
+  const scale = (bins: number[] | null) => bins && bins.map(v => v / max);
+  return {
+    luma: channels.luma.map(v => v / max),
+    r: scale(channels.r),
+    g: scale(channels.g),
+    b: scale(channels.b),
+  };
+}
+
+/**
+ * Bin pixel data (RGBA byte stream) into luminance + R/G/B histograms.
+ * Uses Rec. 601 luma weights. All four channels share one normalization.
+ */
+export function computeRgbHistogram(data: Uint8ClampedArray, bins = 64): HistogramChannels {
+  const luma = new Array<number>(bins).fill(0);
+  const r = new Array<number>(bins).fill(0);
+  const g = new Array<number>(bins).fill(0);
+  const b = new Array<number>(bins).fill(0);
+  if (!data.length) return { luma, r, g, b };
+  const scale = bins / 256;
+  const last = bins - 1;
+  for (let i = 0; i < data.length; i += 4) {
+    const red = data[i];
+    const green = data[i + 1];
+    const blue = data[i + 2];
+    luma[Math.min(last, Math.floor((0.299 * red + 0.587 * green + 0.114 * blue) * scale))]++;
+    r[Math.min(last, Math.floor(red * scale))]++;
+    g[Math.min(last, Math.floor(green * scale))]++;
+    b[Math.min(last, Math.floor(blue * scale))]++;
+  }
+  return normalizeChannels({ luma, r, g, b });
+}
+
+/** SVG point list for a normalized histogram, in a 0..width / 0..height box. */
+export function histogramLinePoints(values: number[], width: number, height: number): string {
   if (!values.length) return '';
   const step = width / (values.length - 1 || 1);
-  const points = values.map((v, i) =>
-    `${(i * step).toFixed(1)},${(height - v * height).toFixed(1)}`);
-  return `0,${height} ${points.join(' ')} ${width},${height}`;
+  return values
+    .map((v, i) => `${(i * step).toFixed(1)},${(height - v * height).toFixed(1)}`)
+    .join(' ');
+}
+
+/** The same curve closed down to the baseline, for a filled `<polygon>`. */
+export function histogramPolygonPoints(values: number[], width: number, height: number): string {
+  const line = histogramLinePoints(values, width, height);
+  return line ? `0,${height} ${line} ${width},${height}` : '';
+}
+
+/** Draw the filled luminance curve, the three colour channels together, or one alone. */
+export type HistogramMode = 'luma' | 'rgb' | 'r' | 'g' | 'b';
+
+export const HISTOGRAM_MODES: readonly HistogramMode[] = ['luma', 'rgb', 'r', 'g', 'b'];
+
+/** Narrows a stored/configured value, so a stale localStorage entry or an
+ *  unrecognised config string degrades to the caller's fallback rather than
+ *  rendering nothing. */
+export function isHistogramMode(value: unknown): value is HistogramMode {
+  return typeof value === 'string' && (HISTOGRAM_MODES as readonly string[]).includes(value);
+}
+
+/** The channels a clipping percentage is reported for. */
+export type ClipChannel = 'luma' | 'r' | 'g' | 'b';
+
+/**
+ * Percentage of pixels sitting exactly on bin 0 / bin 255, per channel, as
+ * measured by the scan. `null` from the API means the photo was never measured
+ * — its histogram predates the per-channel format — which is NOT the same as
+ * zero and must never be drawn as "clean".
+ */
+export interface ClipPercents {
+  shadow: Record<ClipChannel, number>;
+  highlight: Record<ClipChannel, number>;
+}
+
+/** Channels whose clipping exceeds `threshold` percent, worst-first order R/G/B. */
+export function clippedChannels(
+  clipped: ClipPercents | null | undefined,
+  direction: 'shadow' | 'highlight',
+  threshold: number,
+  monochrome: boolean,
+): ClipChannel[] {
+  if (!clipped) return [];
+  // A monochrome frame has three identical channels, so three coloured markers
+  // would be one fact drawn three times; it gets a single neutral one instead.
+  const channels: ClipChannel[] = monochrome ? ['luma'] : ['r', 'g', 'b'];
+  return channels.filter(c => (clipped[direction]?.[c] ?? 0) > threshold);
+}
+
+/** Sum adjacent bins down to `bins` buckets. `bins` must divide the input length. */
+export function downsampleBins(values: number[], bins: number): number[] {
+  if (bins >= values.length) return [...values];
+  const group = values.length / bins;
+  const out = new Array<number>(bins).fill(0);
+  for (let i = 0; i < values.length; i++) out[Math.min(bins - 1, Math.floor(i / group))] += values[i];
+  return out;
+}
+
+/**
+ * Fold full-resolution channels down to `bins` for drawing, with both clipping
+ * bins excluded.
+ *
+ * A clipped frame puts a large share of its pixels in one extreme bin, and that
+ * spike becomes the global maximum — normalizing against it flattens the entire
+ * tonal curve into a hairline at the baseline, destroying the only thing the
+ * curve is for. The extremes are reported as clipping markers instead. The
+ * single shared maximum across channels is kept: per-channel maxima would
+ * stretch a near-empty channel to full height and invent a colour cast.
+ */
+export function toInteriorChannels(channels: HistogramChannels, bins: number): HistogramChannels {
+  const interior = (values: number[] | null): number[] | null => {
+    if (!values?.length) return values;
+    const trimmed = [...values];
+    trimmed[0] = 0;
+    trimmed[trimmed.length - 1] = 0;
+    return downsampleBins(trimmed, bins);
+  };
+  return normalizeChannels({
+    luma: interior(channels.luma) ?? [],
+    r: interior(channels.r),
+    g: interior(channels.g),
+    b: interior(channels.b),
+  });
 }

--- a/config/scoring_config.py
+++ b/config/scoring_config.py
@@ -465,6 +465,26 @@ class ScoringConfig:
             }
         })
 
+    def get_raw_decode_settings(self):
+        """Get RAW demosaic and embedded-preview settings.
+
+        ``bright`` is a fixed exposure gain applied to every frame, replacing
+        LibRaw's per-frame auto-brightness: the latter equalises exposure
+        across a bracket, which erases the exposure ladder the scoring engine
+        is supposed to measure.
+        """
+        defaults = {
+            'bright': 1.62,
+            'prefer_embedded_preview': True,
+            'preview_min_sensor_ratio': 0.5,
+            'viewer_concurrency': 3,
+            'faithful_bracket_render': True,
+        }
+        block = self.config.get('raw_decode', {})
+        if not isinstance(block, dict):
+            return defaults
+        return {**defaults, **block}
+
     def get_scanning_settings(self):
         """Get directory scanning settings.
 
@@ -695,9 +715,9 @@ class ScoringConfig:
                 },
                 '24gb': {
                     'aesthetic_model': 'topiq',
-                    'composition_model': 'qwen2-vl-2b',
+                    'composition_model': 'samp-net',
                     'tagging_model': 'qwen2.5-vl-7b',
-                    'description': 'TOPIQ aesthetic, Qwen2-VL composition (~18GB VRAM)'
+                    'description': 'TOPIQ aesthetic, SAMP-Net composition (~18GB VRAM)'
                 }
             },
             'qwen2_vl': {
@@ -728,14 +748,7 @@ class ScoringConfig:
     def get_samp_net_config(self):
         """Get SAMP-Net model configuration for composition scoring."""
         models_config = self.get_model_config()
-        return models_config.get('samp_net', {
-            'model_path': 'pretrained_models/samp_net.pth',
-            'download_url': 'https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth',
-            'input_size': 384,
-            'patterns': ['none', 'center', 'rule_of_thirds', 'golden_ratio', 'triangle',
-                        'horizontal', 'vertical', 'diagonal', 'symmetric',
-                        'curved', 'radial', 'vanishing_point', 'pattern', 'fill_frame']
-        })
+        return models_config.get('samp_net', {'model_path': 'pretrained_models/samp_net.pth'})
 
     def _resolved_vram_profile(self) -> str:
         """The active VRAM profile name, with 'auto' resolved to the detected one.

--- a/config/scoring_config.py
+++ b/config/scoring_config.py
@@ -35,6 +35,19 @@ UNIFIED_MEMORY_PROFILE_THRESHOLDS_GB = (
 )
 UNIFIED_MEMORY_MINIMUM_PROFILE = 'legacy'
 
+# RAW demosaic and embedded-preview defaults. ``bright`` is a fixed exposure
+# gain applied to every frame, replacing LibRaw's per-frame auto-brightness:
+# the latter equalises exposure across a bracket, which erases the exposure
+# ladder the scoring engine is supposed to measure. Authoritative copy —
+# utils/image_loading.py imports this rather than redefining it.
+RAW_DECODE_DEFAULTS = {
+    'bright': 1.62,
+    'prefer_embedded_preview': True,
+    'preview_min_sensor_ratio': 0.5,
+    'viewer_concurrency': 3,
+    'faithful_bracket_render': True,
+}
+
 
 def default_config_path():
     """Absolute path to the repo-root scoring_config.json.
@@ -466,24 +479,11 @@ class ScoringConfig:
         })
 
     def get_raw_decode_settings(self):
-        """Get RAW demosaic and embedded-preview settings.
-
-        ``bright`` is a fixed exposure gain applied to every frame, replacing
-        LibRaw's per-frame auto-brightness: the latter equalises exposure
-        across a bracket, which erases the exposure ladder the scoring engine
-        is supposed to measure.
-        """
-        defaults = {
-            'bright': 1.62,
-            'prefer_embedded_preview': True,
-            'preview_min_sensor_ratio': 0.5,
-            'viewer_concurrency': 3,
-            'faithful_bracket_render': True,
-        }
+        """Get RAW demosaic and embedded-preview settings."""
         block = self.config.get('raw_decode', {})
         if not isinstance(block, dict):
-            return defaults
-        return {**defaults, **block}
+            return dict(RAW_DECODE_DEFAULTS)
+        return {**RAW_DECODE_DEFAULTS, **block}
 
     def get_scanning_settings(self):
         """Get directory scanning settings.

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -1010,5 +1010,5 @@ def backfill_channel_clipping(db_path='photo_scores_pro.db', batch_size=2000, ve
         if legacy:
             logger.info(
                 "%d photos still hold a luminance-only histogram and stay unknown — "
-                "rescan them (or view them once) to measure the channels.", legacy)
+                "rescan them to measure the channels.", legacy)
     return updated

--- a/db/maintenance.py
+++ b/db/maintenance.py
@@ -520,7 +520,7 @@ def _incremental_update_viewer_db(source_db, output_path, thumbnail_size, verbos
     # Use intersection of src/dest columns to handle any schema skew gracefully
     src_photo_cols = [r[1] for r in dest_conn.execute("PRAGMA src.table_info(photos)").fetchall()]
     dest_photo_col_set = {r[1] for r in dest_conn.execute("PRAGMA main.table_info(photos)").fetchall()}
-    _STRIP_COLS = {'clip_embedding', 'histogram_data', 'raw_sharpness_variance', 'caption_embedding', 'thumbnail', 'path'}
+    _STRIP_COLS = {'clip_embedding', 'raw_sharpness_variance', 'caption_embedding', 'thumbnail', 'path'}
     # On-demand caches (VLM critique, caption) may be generated on the viewer
     # deployment itself, while the source scan DB keeps them NULL. COALESCE onto
     # the current destination value so a re-export never overwrites that
@@ -557,7 +557,7 @@ def _incremental_update_viewer_db(source_db, output_path, thumbnail_size, verbos
     batch_size = 200
     if new_paths:
         common_photo_cols = [c for c in src_photo_cols if c in dest_photo_col_set]
-        _BLOB_STRIP = {'clip_embedding', 'histogram_data', 'raw_sharpness_variance', 'caption_embedding', 'thumbnail'}
+        _BLOB_STRIP = {'clip_embedding', 'raw_sharpness_variance', 'caption_embedding', 'thumbnail'}
         select_exprs = ', '.join(
             f"NULL AS {c}" if c in _BLOB_STRIP else c
             for c in common_photo_cols
@@ -778,7 +778,7 @@ def export_viewer_db(source_db='photo_scores_pro.db', output_path=None, thumbnai
     """Export a lightweight database for viewer-only deployment.
 
     Creates a stripped-down copy suitable for low-memory NAS devices by:
-    - Removing unused BLOB columns (clip_embedding, histogram_data, face embeddings)
+    - Removing unused BLOB columns (clip_embedding, caption_embedding, face embeddings)
     - Downsizing photo thumbnails from 640px to the specified size
     - Running VACUUM + ANALYZE on the result
 
@@ -828,10 +828,13 @@ def export_viewer_db(source_db='photo_scores_pro.db', output_path=None, thumbnai
     if verbose:
         logger.info("  Stripping unused BLOB columns...")
 
-    # photos: clip_embedding, histogram_data, raw_sharpness_variance, caption_embedding
+    # photos: clip_embedding, raw_sharpness_variance, caption_embedding
     # (caption_embedding is the scan-side moment signal, ~4.6KB/captioned photo,
     # and is never read by the viewer — stripping it keeps the export lightweight).
-    dst_conn.execute("UPDATE photos SET clip_embedding = NULL, histogram_data = NULL, "
+    # histogram_data is NOT stripped: /api/photo/histogram serves it to the
+    # viewer's RGB histogram widget, which falls back to sampling a subsampled
+    # thumbnail when it is absent. It costs ~2KB/photo.
+    dst_conn.execute("UPDATE photos SET clip_embedding = NULL, "
                      "raw_sharpness_variance = NULL, caption_embedding = NULL")
     dst_conn.commit()
 
@@ -949,3 +952,63 @@ def export_viewer_db(source_db='photo_scores_pro.db', output_path=None, thumbnai
         logger.info("  Saved:   %.1f MB (%.1f%%)", saved / 1024 / 1024, saved / source_size * 100)
 
     return source_size, output_size
+
+
+# Rows are claimed by the current blob format, not by "the column is NULL":
+# a legacy 1024-byte blob has no per-channel data and must STAY NULL, and
+# selecting on NULL alone would re-read every one of those rows on every run.
+_CLIPPING_BACKFILL_SELECT = """
+    SELECT path, histogram_data FROM photos
+    WHERE channel_clip_highlight_pct IS NULL
+      AND length(histogram_data) = ?
+    LIMIT ?
+"""
+
+
+def backfill_channel_clipping(db_path='photo_scores_pro.db', batch_size=2000, verbose=True):
+    """Derive the per-channel clipping columns from already-stored histograms.
+
+    No image decode: the ratio of a bin to its channel's total survives the
+    uint16 packing (all four channels share one scale factor), so the numbers
+    come straight out of the BLOB. Commits per batch and re-selects only rows
+    still missing the columns, so an interrupted run resumes where it stopped.
+
+    Rows still holding a legacy luminance-only blob are never selected — they
+    have no per-channel data, so their answer is unknown and stays NULL.
+    """
+    from db.connection import get_connection
+    from utils.histogram import HISTOGRAM_BLOB_SIZE, max_clip_percents, unpack_histogram
+
+    updated = 0
+    while True:
+        with get_connection(db_path) as conn:
+            rows = conn.execute(
+                _CLIPPING_BACKFILL_SELECT, (HISTOGRAM_BLOB_SIZE, batch_size)).fetchall()
+            if not rows:
+                break
+            payload = []
+            for row in rows:
+                shadow_pct, highlight_pct = max_clip_percents(unpack_histogram(row['histogram_data']))
+                if highlight_pct is None:
+                    continue
+                payload.append((shadow_pct, highlight_pct, row['path']))
+            if not payload:
+                break
+            conn.executemany(
+                "UPDATE photos SET channel_clip_shadow_pct = ?, channel_clip_highlight_pct = ? "
+                "WHERE path = ?", payload)
+            conn.commit()
+            updated += len(payload)
+        if verbose:
+            logger.info("Derived per-channel clipping for %d photos...", updated)
+    if verbose:
+        with get_connection(db_path) as conn:
+            legacy = conn.execute(
+                "SELECT COUNT(*) FROM photos WHERE histogram_data IS NOT NULL "
+                "AND length(histogram_data) != ?", (HISTOGRAM_BLOB_SIZE,)).fetchone()[0]
+        logger.info("Per-channel clipping: %d photos updated.", updated)
+        if legacy:
+            logger.info(
+                "%d photos still hold a luminance-only histogram and stay unknown — "
+                "rescan them (or view them once) to measure the channels.", legacy)
+    return updated

--- a/db/render_version.py
+++ b/db/render_version.py
@@ -1,24 +1,47 @@
-"""The ``photos.render_version`` stamp: which display-render pipeline built a row.
+"""The ``photos.render_version`` stamp: which display render built a row's thumbnail.
 
 A stored thumbnail is a *baked* artifact. When the RAW display profile changed
 (camera-embedded preview first, faithful demosaic as fallback — see
 ``utils.image_loading.load_display_image``), every thumbnail already in the
 database stayed on the old, exposure-equalizing rendering. ``/image`` renders on
 the fly and self-corrects; the gallery grid reads ``photos.thumbnail`` and does
-not. This column says which rows are still on the old rendering, so the
+not. This column says which rows are still on the wrong rendering, so the
 migration can be reported and resumed instead of forcing a full rescan.
+
+The stamp records WHICH of the two RAW display renderings baked the thumbnail,
+not merely how old it is, because the right one depends on the row's
+``sequence_kind``: a bracketed frame renders with no correction at all, anything
+else through the camera preview. Sequence detection runs after a scan, so a scan
+can only ever bake the display rendering — a frame a later pass groups into a
+bracket therefore ends up carrying ``DISPLAY_RENDER_VERSION`` while its kind now
+demands ``FAITHFUL_RENDER_VERSION``, and comparing the stamp against the kind is
+what surfaces it to the migration instead of leaving it silently wrong.
 
 The stamp is DERIVED state, so it belongs on ``photos`` even though
 ``processing/scorer.py`` rewrites that table wholesale: a rescan regenerates the
 thumbnail with current code, and the stamp must be rewritten with it. Every
-writer of a fresh thumbnail therefore stamps ``CURRENT_RENDER_VERSION``, and a
-NULL means "written before the stamp existed", never "unknown but fine".
+writer of a fresh thumbnail therefore stamps the rendering it used, and a NULL
+means "written before the stamp existed", never "unknown but fine".
 
 Only RAW rows are ever pending: JPEG and HEIF display rendering never changed,
 so any pipeline version produces the same bytes for them.
 """
 
-CURRENT_RENDER_VERSION = 1
+# Camera-embedded preview first, configured `bright` gain on the demosaic
+# fallback: what a scan bakes and what every non-bracketed RAW should show.
+DISPLAY_RENDER_VERSION = 1
+
+# No preview and no gain: what a frame of a bracketed set should show, and what
+# only `--refresh-thumbnails` can bake, since it is the first pass that knows
+# the frame is bracketed.
+FAITHFUL_RENDER_VERSION = 2
+
+
+def render_version_for(sequence_kind):
+    """The stamp for a thumbnail just rendered for a row of this sequence kind."""
+    from utils.image_loading import renders_faithfully
+
+    return FAITHFUL_RENDER_VERSION if renders_faithfully(sequence_kind) else DISPLAY_RENDER_VERSION
 
 
 def raw_path_predicate(alias=''):
@@ -29,15 +52,33 @@ def raw_path_predicate(alias=''):
     return " OR ".join(f"{column} LIKE '%{ext}'" for ext in sorted(RAW_EXTENSIONS))
 
 
+def expected_render_version_sql(alias=''):
+    """SQL for the stamp a row's CURRENT sequence kind demands.
+
+    Built from ``renders_faithfully`` rather than from the kind list directly,
+    so turning ``raw_decode.faithful_bracket_render`` off cannot leave brackets
+    permanently pending against a rendering nothing will ever produce.
+    """
+    from utils.image_loading import BRACKETED_SEQUENCE_KINDS, renders_faithfully
+
+    faithful = sorted(kind for kind in BRACKETED_SEQUENCE_KINDS if renders_faithfully(kind))
+    if not faithful:
+        return str(DISPLAY_RENDER_VERSION)
+    column = f"{alias}.sequence_kind" if alias else "sequence_kind"
+    kinds = ', '.join(f"'{kind}'" for kind in faithful)
+    return (f"CASE WHEN {column} IN ({kinds}) THEN {FAITHFUL_RENDER_VERSION} "
+            f"ELSE {DISPLAY_RENDER_VERSION} END")
+
+
 def pending_render_predicate(alias=''):
-    """SQL predicate matching RAW rows whose thumbnail predates the current render."""
+    """SQL predicate matching RAW rows whose thumbnail is not the render they need."""
     column = f"{alias}.render_version" if alias else "render_version"
-    return (f"({column} IS NULL OR {column} < {CURRENT_RENDER_VERSION}) "
+    return (f"({column} IS NULL OR {column} <> {expected_render_version_sql(alias)}) "
             f"AND ({raw_path_predicate(alias)})")
 
 
 def count_pending_render(conn):
-    """How many RAW rows still carry a thumbnail from an older render pipeline.
+    """How many RAW rows carry a thumbnail from the wrong display render.
 
     Never call this on a request path — it reads every unstamped row's path.
     Callers go through the ``stats_cache`` entry instead (see

--- a/db/render_version.py
+++ b/db/render_version.py
@@ -1,0 +1,53 @@
+"""The ``photos.render_version`` stamp: which display-render pipeline built a row.
+
+A stored thumbnail is a *baked* artifact. When the RAW display profile changed
+(camera-embedded preview first, faithful demosaic as fallback — see
+``utils.image_loading.load_display_image``), every thumbnail already in the
+database stayed on the old, exposure-equalizing rendering. ``/image`` renders on
+the fly and self-corrects; the gallery grid reads ``photos.thumbnail`` and does
+not. This column says which rows are still on the old rendering, so the
+migration can be reported and resumed instead of forcing a full rescan.
+
+The stamp is DERIVED state, so it belongs on ``photos`` even though
+``processing/scorer.py`` rewrites that table wholesale: a rescan regenerates the
+thumbnail with current code, and the stamp must be rewritten with it. Every
+writer of a fresh thumbnail therefore stamps ``CURRENT_RENDER_VERSION``, and a
+NULL means "written before the stamp existed", never "unknown but fine".
+
+Only RAW rows are ever pending: JPEG and HEIF display rendering never changed,
+so any pipeline version produces the same bytes for them.
+"""
+
+CURRENT_RENDER_VERSION = 1
+
+
+def raw_path_predicate(alias=''):
+    """SQL predicate matching RAW paths (LIKE is case-insensitive over ASCII)."""
+    from utils.image_loading import RAW_EXTENSIONS
+
+    column = f"{alias}.path" if alias else "path"
+    return " OR ".join(f"{column} LIKE '%{ext}'" for ext in sorted(RAW_EXTENSIONS))
+
+
+def pending_render_predicate(alias=''):
+    """SQL predicate matching RAW rows whose thumbnail predates the current render."""
+    column = f"{alias}.render_version" if alias else "render_version"
+    return (f"({column} IS NULL OR {column} < {CURRENT_RENDER_VERSION}) "
+            f"AND ({raw_path_predicate(alias)})")
+
+
+def count_pending_render(conn):
+    """How many RAW rows still carry a thumbnail from an older render pipeline.
+
+    Never call this on a request path — it reads every unstamped row's path.
+    Callers go through the ``stats_cache`` entry instead (see
+    ``db.stats_cache.get_pending_render_count``).
+    """
+    import sqlite3
+
+    try:
+        return conn.execute(
+            f"SELECT COUNT(*) FROM photos WHERE {pending_render_predicate()}"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0

--- a/db/schema.py
+++ b/db/schema.py
@@ -195,12 +195,16 @@ PHOTOS_COLUMNS = [
     ('skin_tone_delta', 'REAL'),        # worst-face CIEDE2000 distance to the natural skin locus (--recompute-skin-tone)
     ('skin_tone_cast', 'TEXT'),         # 'green'|'magenta'|'blue'|'yellow' when the delta exceeds the cast threshold, else NULL
 
-    # Which display-render pipeline produced this row's stored thumbnail (and,
-    # for a RAW, its histogram). DERIVED state, which is why it lives here and
-    # not in a side table despite the INSERT-OR-REPLACE invariant: a rescan
-    # regenerates the thumbnail with current code, so the stamp SHOULD be
-    # rewritten with the row. NULL = written before the stamp existed, i.e.
-    # before the RAW exposure fix. See db/render_version.py.
+    # Which of the two RAW display renders produced this row's stored thumbnail,
+    # and nothing else: the camera preview one every scan bakes, or the
+    # uncorrected demosaic a bracketed frame needs. Says nothing about
+    # histogram_data or any other scored column — those come from the metrics
+    # demosaic, and --refresh-thumbnails never rewrites them. DERIVED state,
+    # which is why it lives here and not in a side table despite the
+    # INSERT-OR-REPLACE invariant: a rescan regenerates the thumbnail with
+    # current code, so the stamp SHOULD be rewritten with the row. Read against
+    # the row's sequence_kind, never on its own. NULL = written before the stamp
+    # existed, i.e. before the RAW exposure fix. See db/render_version.py.
     ('render_version', 'INTEGER'),
 ]
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -311,10 +311,6 @@ INDEXES = [
     ('idx_category_aggregate', 'photos', 'category, aggregate DESC'),
     ('idx_narrative_moment', 'photos', 'narrative_moment'),
     ('idx_junk_kind', 'photos', 'junk_kind'),
-    # Prunes the migration-status count once a library is stamped: a fully
-    # migrated row set answers it from the index alone instead of reading every
-    # path to test the RAW suffix.
-    ('idx_render_version', 'photos', 'render_version'),
     ('idx_sequence_group', 'photos', 'sequence_group_id'),
     ('idx_sequence_kind', 'photos', 'sequence_kind, sequence_group_id'),
     # Additional composite indexes for viewer sorting performance
@@ -1084,7 +1080,13 @@ def init_database(db_path='photo_scores_pro.db'):
         # Q-ReAlign, and the migration is additive-only, so the qalign_score
         # column itself survives on upgraded DBs (its data is still readable).
         # Dropping only its index stops a retired column from taxing every write.
-        for stale_idx in ('idx_burst_moment', 'idx_burst_learned', 'idx_qalign_score'):
+        # idx_render_version never earned its keep: the pending-render count
+        # (db.render_version.pending_render_predicate) compares the column
+        # against a per-row CASE on sequence_kind, not a constant, so no
+        # single- or multi-column shape on render_version is sargable for it —
+        # EXPLAIN QUERY PLAN shows a full `SCAN photos` with or without the
+        # index. Dropped rather than reshaped.
+        for stale_idx in ('idx_burst_moment', 'idx_burst_learned', 'idx_qalign_score', 'idx_render_version'):
             conn.execute(f'DROP INDEX IF EXISTS {stale_idx}')
 
         # Create the photos-table indexes first so the ANALYZE gate below can

--- a/db/schema.py
+++ b/db/schema.py
@@ -96,6 +96,17 @@ PHOTOS_COLUMNS = [
     # Technical metrics
     ('shadow_clipped', 'INTEGER'),
     ('highlight_clipped', 'INTEGER'),
+    # Share of pixels that reached the end of the scale, in the worst of R/G/B:
+    # exactly bin 0 and exactly bin 255 of the stored histogram, as a percentage
+    # (0-100). A DIFFERENT measurement from the two flags above, which are
+    # binary and cover the luminance bands 0-30 / 225-255.
+    #
+    # NULL means unknown, never clean: a row whose histogram_data is still a
+    # legacy 1024-byte luminance-only blob has no per-channel data to derive
+    # from, and its bins came from an auto-brightened decode anyway. Every
+    # reader treats NULL as "not measured" -- see --backfill-clipping.
+    ('channel_clip_shadow_pct', 'REAL'),
+    ('channel_clip_highlight_pct', 'REAL'),
     ('dynamic_range_stops', 'REAL'),
     ('noise_sigma', 'REAL'),
     ('contrast_score', 'REAL'),
@@ -183,6 +194,14 @@ PHOTOS_COLUMNS = [
     ('distortion_attributes', 'TEXT'),  # JSON [{attribute, confidence}] from --recompute-distortions (zero-shot ExIQA-style)
     ('skin_tone_delta', 'REAL'),        # worst-face CIEDE2000 distance to the natural skin locus (--recompute-skin-tone)
     ('skin_tone_cast', 'TEXT'),         # 'green'|'magenta'|'blue'|'yellow' when the delta exceeds the cast threshold, else NULL
+
+    # Which display-render pipeline produced this row's stored thumbnail (and,
+    # for a RAW, its histogram). DERIVED state, which is why it lives here and
+    # not in a side table despite the INSERT-OR-REPLACE invariant: a rescan
+    # regenerates the thumbnail with current code, so the stamp SHOULD be
+    # rewritten with the row. NULL = written before the stamp existed, i.e.
+    # before the RAW exposure fix. See db/render_version.py.
+    ('render_version', 'INTEGER'),
 ]
 
 FACES_COLUMNS = [
@@ -288,6 +307,10 @@ INDEXES = [
     ('idx_category_aggregate', 'photos', 'category, aggregate DESC'),
     ('idx_narrative_moment', 'photos', 'narrative_moment'),
     ('idx_junk_kind', 'photos', 'junk_kind'),
+    # Prunes the migration-status count once a library is stamped: a fully
+    # migrated row set answers it from the index alone instead of reading every
+    # path to test the RAW suffix.
+    ('idx_render_version', 'photos', 'render_version'),
     ('idx_sequence_group', 'photos', 'sequence_group_id'),
     ('idx_sequence_kind', 'photos', 'sequence_kind, sequence_group_id'),
     # Additional composite indexes for viewer sorting performance
@@ -347,6 +370,8 @@ INDEXES = [
     ('idx_dynamic_range_stops', 'photos', 'dynamic_range_stops'),
     ('idx_mean_luminance', 'photos', 'mean_luminance'),
     ('idx_histogram_spread', 'photos', 'histogram_spread'),
+    ('idx_channel_clip_shadow', 'photos', 'channel_clip_shadow_pct'),
+    ('idx_channel_clip_highlight', 'photos', 'channel_clip_highlight_pct'),
     ('idx_iso', 'photos', 'iso'),
     ('idx_f_stop', 'photos', 'f_stop'),
     ('idx_focal_length', 'photos', 'focal_length'),

--- a/db/stats_cache.py
+++ b/db/stats_cache.py
@@ -275,12 +275,12 @@ def get_pending_render_count(db_path=None, max_age_seconds=PENDING_RENDER_TTL_SE
     if is_fresh and isinstance(value, int):
         return value
     with get_connection(path) as conn:
+        count = count_pending_render(conn)
         try:
-            count = refresh_pending_render_stat(conn)
+            _cache_stat(conn, PENDING_RENDER_KEY, count, time_module.time())
             conn.commit()
         except sqlite3.OperationalError:
             logger.debug("Could not persist %s (read-only database?)", PENDING_RENDER_KEY)
-            count = count_pending_render(conn)
     return count
 
 

--- a/db/stats_cache.py
+++ b/db/stats_cache.py
@@ -11,8 +11,16 @@ import time as time_module
 
 logger = logging.getLogger("facet.stats_cache")
 
-from db.connection import get_connection
+from db.connection import DEFAULT_DB_PATH, get_connection
+from db.render_version import count_pending_render
 from db.schema import _build_create_table_sql, STATS_CACHE_COLUMNS
+
+PENDING_RENDER_KEY = 'pending_render_count'
+
+# The count only moves when a scan or a --refresh-thumbnails run writes, and the
+# banner it drives is advisory. An hour keeps the scan off every SPA startup
+# without letting a finished migration keep nagging for long.
+PENDING_RENDER_TTL_SECONDS = 3600
 
 
 def refresh_stats_cache(db_path='photo_scores_pro.db', verbose=True):
@@ -234,12 +242,46 @@ def refresh_stats_cache(db_path='photo_scores_pro.db', verbose=True):
         except sqlite3.OperationalError:
             pass
 
+        pending_render = refresh_pending_render_stat(conn)
+        stats[PENDING_RENDER_KEY] = pending_render
+        if verbose:
+            logger.info("  RAW photos awaiting a thumbnail refresh: %d", pending_render)
+
         conn.commit()
 
     if verbose:
         logger.info("Statistics cache refreshed.")
 
     return stats
+
+
+def refresh_pending_render_stat(conn):
+    """Recount RAW rows awaiting a thumbnail refresh and re-cache the total."""
+    count = count_pending_render(conn)
+    _cache_stat(conn, PENDING_RENDER_KEY, count, time_module.time())
+    return count
+
+
+def get_pending_render_count(db_path=None, max_age_seconds=PENDING_RENDER_TTL_SECONDS):
+    """Cached count of RAW rows whose thumbnail predates the current render.
+
+    Served to ``/api/config``, which the SPA calls on every startup, so the
+    underlying scan must never run per request. A stale entry is recomputed once
+    and re-cached; a miss on a read-only database still answers, it just cannot
+    persist the result.
+    """
+    path = db_path or DEFAULT_DB_PATH
+    value, is_fresh = get_cached_stat(path, PENDING_RENDER_KEY, max_age_seconds)
+    if is_fresh and isinstance(value, int):
+        return value
+    with get_connection(path) as conn:
+        try:
+            count = refresh_pending_render_stat(conn)
+            conn.commit()
+        except sqlite3.OperationalError:
+            logger.debug("Could not persist %s (read-only database?)", PENDING_RENDER_KEY)
+            count = count_pending_render(conn)
+    return count
 
 
 def _cache_stat(conn, key, value, timestamp):

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -55,7 +55,7 @@ lines (phase, current/total, ETA) which the viewer's scan API surfaces in the
 | `quality-face` | TOPIQ NR-Face | `face_quality_iqa` score (purpose-built face quality) | Shared w/ TOPIQ |
 | `quality-liqe` | LIQE | `liqe_score` + distortion diagnosis (blur, overexposure, noise) | ~2 GB |
 | `tags` | CLIP / Qwen VLM | Semantic tags from configured vocabulary | 0-16 GB |
-| `composition` | SAMP-Net | `composition_pattern` (14 patterns) + `comp_score` | ~2 GB |
+| `composition` | SAMP-Net | `composition_pattern` (8 patterns) + `comp_score` | ~2 GB |
 | `faces` | InsightFace buffalo_l | Face detection, landmarks, blink detection, recognition embeddings | ~2 GB |
 | `embeddings` | CLIP ViT-L-14 or SigLIP 2 NaFlex | `clip_embedding` BLOB for similarity/tagging | 4-5 GB |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 GB |
@@ -142,6 +142,7 @@ These commands update specific metrics, derive new data (AI captions, GPS, embed
 | `python facet.py --recompute-embeddings` | Recompute CLIP/SigLIP embeddings for all photos (required after model switch) |
 | `python facet.py --score-topiq` | Backfill TOPIQ quality scores from stored thumbnails (GPU required) |
 | `python facet.py --backfill-focal-35mm` | Backfill 35mm-equivalent focal length from EXIF for photos missing it |
+| `python facet.py --backfill-clipping` | Derive per-channel clipping percentages from stored histograms. Database-only (no image decode) and resumable; photos whose histogram predates the RGB format stay unknown (NULL) |
 | `python facet.py --compute-recommendations` | Analyze database, show scoring summary |
 | `python facet.py --compute-recommendations --verbose` | Show detailed statistics |
 | `python facet.py --compute-recommendations --apply-recommendations` | Auto-apply scoring fixes |
@@ -216,8 +217,33 @@ Embeddings power semantic tagging, duplicate detection, similar-photo search, an
 | Command | Description |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Fix rotation of stored thumbnails using EXIF orientation |
+| `python facet.py --refresh-thumbnails` | Rebuild RAW thumbnails from the camera-embedded preview |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | Same, with more parallel reads |
 
 Reads EXIF orientation from the original files and rotates the stored thumbnail bytes; for photos processed before EXIF handling existed. It reads only the EXIF header and the stored thumbnail, not the full images.
+
+`--refresh-thumbnails` re-renders the stored thumbnail of every RAW photo through the display profile (camera preview first, demosaic as fallback — see [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). It is the migration for a library scanned before that profile existed: thumbnails written by an older scan carry LibRaw's per-frame auto-brightness, which flattens the exposure differences between bracketed frames. No model is loaded and no scoring column is touched — only `photos.thumbnail` is rewritten.
+
+The command is bound by storage throughput rather than CPU, so its cost scales with library size and how fast the library's disk or network mount is, not with the machine's core count. `--refresh-thumbnails-workers` (default 8) sets how many files are read at once: raise it on a fast network mount where each read spends its time waiting, lower it on a slow local disk. It also bounds the full demosaics a preview-less RAW falls back to, so very high values cost memory.
+
+It is resumable. Each committed batch records how far it got, so a run stopped with Ctrl-C (or by a dropped mount) leaves a consistent database and the next `--refresh-thumbnails` continues where it left off. A run that completes clears the marker, so re-running it later starts over.
+
+A photo whose fresh render comes back entirely black keeps its existing thumbnail and is logged by name. That is not paranoia: a severely truncated Panasonic RW2 does not fail to decode — LibRaw zero-fills the missing data and returns a valid, full-size black frame — so without the check a corrupt file would quietly replace a good thumbnail with a black one. Such a photo stays unstamped and is retried on the next run, so repairing the file is enough to fix it.
+
+A photo belonging to an exposure bracket is re-rendered without the camera preview and without any exposure gain, so its tile shows what the sensor recorded (see [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Because bracket membership comes from sequence detection, which runs after a scan, run this command after `--detect-sequences` for those tiles to pick the rendering up.
+
+### What updates a stored thumbnail
+
+Stored thumbnails are baked at scan time, so a library scanned before the display profile existed keeps showing the old rendering in the gallery grid. `photos.render_version` records which pipeline built each row's thumbnail, and two paths bring it up to date:
+
+| Path | Covers | Cost |
+|------|--------|------|
+| A rescan (`python facet.py <dir>`) | Everything it scans, thumbnail and histogram | Full scoring run |
+| `--refresh-thumbnails` | Every RAW row's thumbnail | Storage-bound, hours on a large library |
+
+**Nothing happens on its own.** The detail view is always current because `/image` renders on the fly, but the gallery grid serves `photos.thumbnail`, and no amount of browsing rewrites it. That is what `--refresh-thumbnails` is for, and why the gallery shows a dismissible banner counting the rows still waiting.
+
+The banner's count comes from the statistics cache with a one-hour TTL, refreshed outright by `--refresh-thumbnails` and by `python database.py --refresh-stats`, so after a rescan it can trail reality by up to an hour.
 
 ## Diagnostics
 
@@ -229,6 +255,13 @@ Reads EXIF orientation from the original files and rotates the stored thumbnail 
 Reports Python version, PyTorch/CUDA build, GPU detection and driver, VRAM profile recommendation, optional dependencies, and config/database status. When PyTorch can't see the GPU but `nvidia-smi` can, it prints the `pip install` command to fix the CUDA build.
 
 `--simulate-gpu NAME` and `--simulate-vram GB` test behavior with different hardware. Both require `--doctor`; `--simulate-vram` requires `--simulate-gpu`.
+
+| Command | Description |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | Render 20 sampled RAW photos under the old and current decode settings |
+| `python facet.py --check-raw-rendering 50` | Sample 50 photos instead |
+
+Read-only: it decodes a random sample straight from disk and prints the mean luminance each rendering produces — LibRaw's per-frame auto-brightness, the fixed-gain metrics demosaic, and the camera-embedded preview the thumbnails and viewer use. Use it to check `raw_decode.bright` on your own files before committing to a scan or a `--refresh-thumbnails` run; the fixed and preview columns keep a bracket's exposure ladder, the auto-bright column collapses it.
 
 ## Model Information
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1527,7 +1527,8 @@ Web gallery display and behavior.
 | `hide_brackets` | `true` | Show only a bracket's base exposure by default |
 | `hide_panoramas` | `true` | Show only one representative frame per panorama by default |
 | `hide_details` | `true` | Hide photo details on cards by default |
-| `tooltip_mode` | `"hover"` | Tooltip trigger: `"hover"`, `"click"`, or `"off"`. Replaces the prior `hide_tooltip` boolean. |
+| `tooltip_mode` | `"hover"` | Tooltip trigger: `"hover"`, `"click"`, `"off"`, or `"panel"` (docked rail instead of a floating tooltip — see `panel_activation` below). Replaces the prior `hide_tooltip` boolean. |
+| `panel_activation` | `"both"` | Which gesture retargets the docked rail's selected photo when `tooltip_mode` is `"panel"`: `"hover"`, `"click"`, or `"both"`. No effect on the other tooltip modes. Default `"both"` preserves the original panel behaviour |
 | `hide_rejected` | `true` | Hide rejected photos by default |
 | `gallery_mode` | `"mosaic"` | Default gallery layout (`"grid"` or `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,6 +20,7 @@ All settings are in `scoring_config.json`. After modifying, run `python facet.py
 - [Models](#models)
 - [Quality Assessment Models](#quality-assessment-models)
 - [Processing](#processing)
+- [RAW Decode](#raw-decode)
 - [Burst Detection](#burst-detection)
 - [Burst Scoring](#burst-scoring)
 - [Duplicate Detection](#duplicate-detection)
@@ -447,7 +448,7 @@ Selects which models are used per VRAM profile.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Selects which models are used per VRAM profile.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Selects which models are used per VRAM profile.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Legacy pre-trained weights |
 | `clip_legacy.embedding_dim` | `768` | Legacy embedding dimensions |
 | `clip_legacy.similarity_threshold_percent` | `22` | Tag-match threshold for legacy CLIP |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | HuggingFace path (24gb composition VLM) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | HuggingFace path for the manual `composition_model: "qwen2-vl-2b"` opt-in — no profile selects it by default |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Tagging model for 16gb profile |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Images per VLM inference batch |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Tagging model for 24gb profile |
@@ -526,7 +520,6 @@ Selects which models are used per VRAM profile.
 | `saliency.resolution` | `1024` | Inference resolution |
 | `saliency.mask_threshold` | `0.3` | Sigmoid threshold for the binary subject mask |
 | `saliency.min_subject_pixels` | `50` | Minimum subject pixels to count a subject as detected |
-| `samp_net.input_size` | `384` | Composition model input size |
 
 ### VRAM Auto-Detection
 
@@ -731,6 +724,138 @@ python facet.py /path --pass saliency      # BiRefNet subject saliency
 # List available models
 python facet.py --list-models
 ```
+
+---
+
+## RAW Decode
+
+How RAW files are turned into pixels. Two profiles exist, and they are not
+interchangeable.
+
+**Metrics profile** — the demosaic every score is computed from, and the pixel
+space stored face boxes and `image_width`/`image_height` live in. It is
+deliberately faithful: no per-frame adaptation, one fixed exposure gain for the
+whole library.
+
+**Display profile** — what the stored thumbnail, the gallery and `/image` show.
+It prefers the camera-embedded preview, which already carries the model's own
+tone curve, DR modes and exposure, and falls back to the metrics demosaic when
+no usable preview exists.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `bright` | `1.62` | Fixed exposure gain applied to every demosaic (`1.0` = LibRaw's own level). The one arbitrary constant here: it matches darktable's +0.7 EV default, and nothing in the file dictates it — validate it on your own library with `--check-raw-rendering` before a large scan |
+| `prefer_embedded_preview` | `true` | Render display images from the camera preview when there is one. `false` demosaics everything, which is slower and drops the camera's tone curve |
+| `preview_min_sensor_ratio` | `0.5` | How much of the sensor a preview must cover for `/image` to serve it instead of demosaicing. Nikon, Pentax, Samsung and Canon CR3 embed a near-full-size preview (0.98-0.99); Panasonic sits at 0.52, while Olympus, Fuji, Sony and DNG embed a small one (0.29-0.49) and therefore demosaic |
+| `viewer_concurrency` | `3` | Max simultaneous RAW demosaics for the `/image` viewer path, on its own budget separate from `processing.raw_decode_concurrency` above, so a viewer request never queues behind scan or CLI decode work |
+| `faithful_bracket_render` | `true` | Render a bracketed frame with no correction at all — no camera preview, no `bright` gain. See [below](#bracketed-frames-render-uncorrected). `false` renders brackets like any other photo |
+
+### Memory tradeoff
+
+`viewer_concurrency` and `processing.raw_decode_concurrency` are independent
+budgets, each with its own semaphore, and neither borrows headroom from the
+other. Worst case, the process can therefore hold `library + viewer`
+demosaics in flight at once, each peaking at roughly 200-400MB of
+intermediates — lower `viewer_concurrency` on a memory-constrained host. In
+practice this budget is mostly idle: it is only spent when `/image` has to
+fall back to a full demosaic, which `preview_min_sensor_ratio` above already
+skips for any RAW whose embedded preview is large enough (Nikon, Pentax,
+Samsung, Canon CR3). Sony, Fuji, Olympus and DNG are the bodies that actually
+consume it.
+
+### Why there is no auto-brightness
+
+LibRaw brightens each frame until roughly 1% of *its own* pixels clip, and
+substitutes that same frame's brightest pixel for the camera white level. Both
+terms are per-frame, so a bracket comes out equalised: a measured 5-frame Canon
+set spanning -3.4 to +3.3 EV rendered at mean luminances of 54-56 for its three
+dark frames, indistinguishable from each other. With the fixed gain the same
+set spans 8.7 to 160 — an 18x ladder instead of 2.6x.
+
+Raising `bright` scales every rendering linearly; it never restores the
+per-frame behaviour. Exposure metrics move with it, so re-run
+`--recompute-average` after changing it, and re-scan to rewrite the metrics
+themselves.
+
+### Bracketed frames render uncorrected
+
+A photo whose `sequence_kind` is `bracket` or `hdr_panorama` is displayed with
+neither of the two corrections above: no camera-embedded preview, and no
+`bright` gain. Everything else keeps the display profile. A plain `panorama` is
+*not* bracketed and is excluded — only an HDR panorama, which is bracketed at
+every position, joins brackets here.
+
+The reason is that both corrections compress highlights, and highlight headroom
+is the entire point of a bracket's +EV frames. The uniform gain preserves the
+*relative* exposure between frames but clips the bright end: at `bright` 2.0 a
+measured 4.85x ladder came out as 3.67x, the difference being clipping alone.
+The camera's embedded JPEG has its own tone curve, which compresses the same
+range for the same reason. For an ordinary photo that is a better-looking
+picture; for a bracket it hides exactly what the photographer is judging.
+
+This applies to every surface that renders a bracket, so they cannot disagree:
+`/image` (the detail view, the comparison loupe and the culling loupe) renders
+it this way on the fly, `--refresh-thumbnails` bakes it into `photos.thumbnail`
+for the gallery tile and the comparison grid, and `GET /api/download` with
+`type=original` converts it the same way — a downloaded bracket frame is
+usually on its way to an HDR merge, where the clipped highlights the other
+renderings introduce are unrecoverable.
+
+Two download types are deliberately left alone: `type=raw` copies the untouched
+RAW file, and `type=darktable` is the "edited look" export, whose whole purpose
+is a tone curve. `GET /api/photo/cull_preview` is likewise unaffected — it
+renders through darktable-cli, not rawpy.
+
+It is *not* applied at scan time, because sequence detection runs after a scan
+and bracket membership is not yet known — run `--detect-sequences` first, then
+`--refresh-thumbnails`, for the tiles to follow.
+
+Scoring is unaffected. Metrics are computed from `load_image_from_path`, which
+is a separate decode at sensor dimensions and is where every stored face box
+and `image_width`/`image_height` lives; nothing here reaches it.
+
+Set `faithful_bracket_render` to `false` to render brackets like any other
+photo.
+
+### Migrating a library scanned before this profile
+
+Thumbnails and histograms are baked at scan time, so changing the profile does
+not retroactively change what a scanned row holds. `photos.render_version`
+records which pipeline produced each row's stored thumbnail: `NULL` means "from
+before the fix", and the current pipeline stamps `1`.
+
+There is nothing to configure — the stamp is bookkeeping, not a setting — but it
+is worth knowing which paths advance it:
+
+- **A rescan** rewrites the thumbnail and the histogram, and stamps the row.
+- **`--refresh-thumbnails`** rewrites RAW thumbnails and stamps them. Rows are
+  not skipped on the stamp, so re-running after a `bright` change rebuilds
+  everything.
+
+Those are the only two. Browsing the library repairs nothing: `/image` renders
+on the fly so the detail view is always current, but the gallery grid reads
+`photos.thumbnail` and only a scan or `--refresh-thumbnails` rewrites that.
+
+The gallery's dismissible banner counts the rows still on the old rendering. It
+reads a `stats_cache` entry with a one-hour TTL rather than scanning `photos` on
+every page load, so it can trail reality after a rescan; `python database.py
+--refresh-stats` recomputes it immediately.
+
+A render that comes back entirely black is refused rather than stored, and the
+row is left unstamped so a later run retries it. LibRaw zero-fills a severely
+truncated Panasonic RW2 into a valid full-size black frame instead of failing,
+and an unattended migration is the worst place for that to go unnoticed. The
+rejection is logged with the file name.
 
 ---
 
@@ -1415,6 +1540,71 @@ Web gallery display and behavior.
 | `notification_duration_ms` | `2000` | Toast duration |
 | `moment_confidence_min` | `0` | Below this stored `narrative_moment_confidence` posterior (0–1), moment labels render dimmed with an "(uncertain)" suffix in the Scenes header, the Culling scene-group header, and the gallery photo tooltip. `0` = never dim |
 
+### Card badges and clipping
+
+`viewer.badges` turns individual gallery-card badges on and off. Every badge
+that predates this block defaults to `true`, so leaving the block out changes
+nothing.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `badges.favorite` | `true` | Heart badge on a favourited photo (edition mode) |
+| `badges.star_rating` | `true` | Star + count badge on a rated photo (edition mode) |
+| `badges.rejected` | `true` | Thumb-down badge on a rejected photo (edition mode) |
+| `badges.sequence_kind` | `true` | Bracket/panorama badge, shown only while the matching hide toggle collapses the set |
+| `badges.sequence_override_pending` | `true` | Clock badge for a panorama correction awaiting the next detection run |
+| `badges.keeper_hint` | `true` | "A better shot exists in this group" arrow from the learned keeper head |
+| `badges.best_of_burst` | `true` | "Best" badge on a burst lead. Shown only when `hide_bursts` is off — with it on, every burst photo on screen is already its group's lead |
+| `badges.clipping_highlight` | `true` | Badge a photo whose highlights clip past `clipping.badge_percent` |
+| `badges.clipping_shadow` | `false` | Same for crushed shadows. Off by default: shadow clipping is frequently intentional (silhouettes, night, low-key) |
+
+`viewer.clipping` is the single definition of "clipped" shared by the card
+badge, the histogram markers and the gallery filter, so the three cannot
+disagree.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `badge_percent` | `5` | Percent of pixels, in the worst of R/G/B, above which the gallery card is badged. Measured over a 28-photo sample: worst-channel highlight clipping had a median of 0.31% and a p90 of 2.35%, so 5% fires on roughly 1 photo in 25 |
+| `indicator_percent` | `1` | Threshold for the histogram's own R/G/B end markers. Finer than the badge because you are already looking at a single photo |
+| `histogram_mode` | `"rgb"` | House default for the **detail panel's** histogram: `"luma"`, `"rgb"`, or a single channel (`"r"` / `"g"` / `"b"`). A user's own choice for this surface is stored in `localStorage` under `facet_histogram_mode` and wins over this |
+| `tooltip_histogram_mode` | `"luma"` | House default for the **hover/pinned tooltip's** histogram, same five values. Deliberately independent of `histogram_mode` and persisted under its own `localStorage` key (`facet_histogram_mode_tooltip`): the panel is for studying one photo, where per-channel detail earns its space; the tooltip is for scanning many quickly, where a plain luminance curve usually reads faster. Setting one never retunes the other, and the toggle to change it only renders while the tooltip is pinned (docked rail, or `tooltip_mode: "click"`) — in plain hover mode it shows its resolved mode read-only |
+
+**Clipping is measured per channel, at exactly bin 0 and bin 255.** It is stored
+in `photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` as the worst
+channel's percentage of pixels — a *different* measurement from the
+`shadow_clipped` / `highlight_clipped` flags, which are binary and cover the
+luminance bands 0–30 and 225–255 and feed `exposure_score`.
+
+**`NULL` means unknown, never clean.** A photo whose stored histogram predates
+the per-channel format has no channel data, so it carries no badge and matches
+neither side of the gallery filter. Run `python facet.py --backfill-clipping` to
+derive the columns for rows that already hold a full histogram — it reads only
+the database, decodes no images, and is resumable.
+
 ### Features
 
 Toggle optional features to reduce memory usage or simplify the UI:
@@ -1426,7 +1616,6 @@ Toggle optional features to reduce memory usage or simplify the UI:
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1443,7 +1632,6 @@ Toggle optional features to reduce memory usage or simplify the UI:
 | `show_similar_button` | `true` | Show "Find Similar" button on photo cards (uses numpy for CLIP similarity) |
 | `show_merge_suggestions` | `true` | Enable merge suggestions feature on manage persons page |
 | `show_rating_controls` | `true` | Show star rating and favorite controls |
-| `show_rating_badge` | `true` | Show rating badge on photo cards |
 | `show_scan_button` | `false` | Show scan trigger button for superadmin users (requires GPU on viewer host) |
 | `metrics_enabled` | `false` | Enable the public `GET /metrics` Prometheus endpoint. Off by default — it exposes photo/person/face counts, DB size, and process memory; enable only when the endpoint is reachable from the scraper network, not from the public internet. |
 | `show_semantic_search` | `true` | Show semantic search bar (text-to-image search using CLIP/SigLIP embeddings) |
@@ -2060,6 +2248,32 @@ python facet.py --recompute-text   # re-read the whole library
 
 **Cost.** A 640px thumbnail takes roughly 0.4s on CPU, so a 50k-photo library is an overnight CPU job — it is a one-time backfill, and later scans only ever add new photos. A GPU is used automatically when torch reports one.
 
+## Export and Cull Destinations
+
+Any endpoint that copies, symlinks, or moves photo files out of the library — album "basket" export (`POST /api/albums/{id}/export`, modes `copy`/`symlink`) and cull-to-folder (`POST /api/cull/apply`, actions `copy_keeps` / `move_rejects`) — writes to a `target_dir` that must resolve under an allowed root, or the request is refused before touching any file.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(key absent)* | Extra root directories a copy/symlink export or a cull-to-folder copy/move may write into, on top of the scan directories (always allowed). **Absent by default** — out of the box, the only writable export destinations are your configured scan directories |
+
+**Resolution order.** The allow-list is `allowed_target_dirs` first, then every scan directory (per-user, shared, and `path_mapping` targets) — so exporting *within* the photo tree needs no configuration, but a destination outside it needs an entry here. Both the requested `target_dir` and every allowed root are canonicalized with `os.path.realpath()` (symlinks resolved, `..` collapsed) before comparison, so a symlink that resolves outside an allowed root is rejected even when the link itself sits inside one.
+
+**Fail-closed by design.** With no roots at all — no `allowed_target_dirs` and no scan directories configured — copy/symlink/move export is refused outright rather than falling back to writing anywhere. In practice this case is rare once you have scanned a library, since the scan directories are always in the allow-list.
+
+**Troubleshooting "access denied."** This check runs before any filesystem access, so a refused destination never touches disk and produces no traceback in the server logs — a `403` here is a normal HTTP response from a deliberate check, not a server error. The web UI currently shows a generic "Access denied" toast for *any* `403` on these endpoints without naming the reason; open your browser's Network tab, find the failed `/api/cull/apply` or `/api/albums/{id}/export` request, and read its response body's `detail` field for the actual cause (either this allow-list, or an expired edition session). A genuine filesystem/permission failure looks different: the request itself succeeds (`200`), the response's `errors` count is nonzero, and the server logs a full traceback for each failed file — see [Deployment — Container Path Semantics](DEPLOYMENT.md#container-path-semantics) for the container case, where this is often mistaken for a UID mismatch.
+
+See [Web Viewer — Cull to folder](VIEWER.md#cull-to-folder) and [Web Viewer — Editor Export](VIEWER.md#editor-export).
+
 ## Social Export
 
 Saliency-aware crop presets for social aspect ratios (`GET /api/photo/social_crop`, edition-gated). Each preset crops the full-resolution original to a target aspect and frames it on the detected subject — the largest rectangle of that aspect fitting inside the image, centered on the subject and clamped at the edges. The subject box follows a fallback chain: the persisted BiRefNet subject box (`photos.subject_bbox`) → the union of detected face boxes → a plain center crop. See [Web Viewer — Download](VIEWER.md#download).
@@ -2105,7 +2319,7 @@ Export an album as a self-contained static HTML gallery a photographer can drop 
 | `max_edge` | `2048` | Long-edge cap (px) for exported originals; the request may override it (clamped 256–8000) |
 | `jpeg_quality` | `88` | JPEG quality of the exported images |
 
-The `target_dir` goes through the exact same allow-list as the copy/move export endpoints (`viewer.export.allowed_target_dirs` plus the scan directories). Gated by `viewer.features.show_portfolio_export` (default `true`). See [Web Viewer — Portfolio export](VIEWER.md#portfolio-export).
+The `target_dir` goes through the exact same allow-list as the copy/move export endpoints (`viewer.export.allowed_target_dirs` plus the scan directories — see [Export and Cull Destinations](#export-and-cull-destinations)). Gated by `viewer.features.show_portfolio_export` (default `true`). See [Web Viewer — Portfolio export](VIEWER.md#portfolio-export).
 
 ## Photo Frame / Kiosk
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,6 +56,43 @@ Multiple mappings are supported (first match wins):
 - Both UNC paths (`\\server\share`) and drive letters (`Z:\`) are supported
 - The first matching prefix wins
 
+## Container Path Semantics
+
+Anything you type into a folder field in the viewer — a "Cull to folder" target, an album's copy/symlink export destination, or `viewer.export.allowed_target_dirs` in `scoring_config.json` — is resolved by the Facet process itself. **In Docker/Podman that process runs inside the container**, so every path is the path *the container* sees: the mount point, never the host-side path.
+
+**Example.** The shipped `docker-compose.yml` mounts your photo folder at `/data/photos`:
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+To cull rejects into a `rejects` subfolder, enter `/data/photos/rejects` in the dialog — never the host path (`/home/you/Pictures`, `D:\Photos`, …), which the container cannot see at all. The same applies to `viewer.export.allowed_target_dirs`: list the container-side path.
+
+To write somewhere other than the scanned photo tree — a separate export volume, say — mount it into the container first, then add its container-side path to `viewer.export.allowed_target_dirs`:
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # extra volume for cull/export output
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+A destination that resolves outside every mounted volume is refused (`403`) — Facet's target-dir check runs `os.path.realpath()` on the request *and* on every allowed root, resolving symlinks and `..` before comparing, so a path that only looks right from outside the container (or a symlink pointing outside a mount) still fails the containment test. See [Configuration — Export and Cull Destinations](CONFIGURATION.md#export-and-cull-destinations) for the full allow-list reference.
+
+**This is not a container-user permission problem.** The `facet` user's UID inside the container commonly differs from your host account's UID, and that can cause a real, separate filesystem-permission failure on a bind mount — but that happens *after* this path check passes, when the copy/symlink/move actually runs, and it is logged server-side with the underlying OS error for the file that failed. A `403 target_dir is not an allowed export location` (or a generic "access denied" in the UI) happens *before* any file is touched and has nothing to do with UIDs.
+
 ## Building the Angular Client
 
 The FastAPI server serves the pre-built SPA from `client/dist/client/browser/`. Build it before deployment:
@@ -101,7 +138,8 @@ python database.py --export-viewer-db
 ```
 
 This creates `photo_scores_viewer.db`, which:
-- Strips CLIP embeddings, histogram data, and face embeddings
+- Strips CLIP embeddings, caption embeddings, and face embeddings
+- Keeps the per-photo histogram (~2 KB each), which the viewer's RGB histogram widget reads
 - Downsizes thumbnails from 640px to 320px
 - Typically reduces a 14GB database to ~4-5GB
 
@@ -207,9 +245,11 @@ What follows is only what differs on a NAS.
 
 **Both published images are `linux/amd64` (x86_64) only.** That covers x86 NAS hardware (Synology Plus/x86, UGREEN, UnifyDrive, and anything running Coolify, Portainer or plain Docker on an Intel/AMD CPU). There is no `arm64` image: cross-building a multi-gigabyte ML stack under QEMU costs hours per tag, and the CUDA variant is x86-only regardless. On an ARM NAS or a Raspberry Pi, build locally with `docker compose build` instead of pulling — `docker compose up` keeps `build: .` underneath the `image:` key for exactly this case.
 
-**Budget the disk.** The CPU image is ~3.3 GB and the CUDA image ~21 GB, plus the model
-weights each profile downloads at first run (~3–4 GB for `legacy`/`8gb`, ~10–11 GB for
-`16gb`, ~18 GB for `24gb` — full table in
+**Budget the disk.** Unpacked, the CPU image is approximately 3.3 GB on disk and the
+CUDA image approximately 21 GB (approximate, not reverified against the current build;
+pulling either transfers less, compressed — see [Image size](#image-size) below), plus
+the model weights each profile downloads at first run (`legacy` 4.69 GB, `8gb` 6.93 GB,
+`16gb` 14.55 GB, `24gb` 19.13 GB — full table in
 [Installation › Download sizes](INSTALLATION.md#download-sizes)). `docker compose down -v`
 deletes the model volumes and forces a re-download.
 
@@ -352,10 +392,16 @@ Neither published image contains model weights — those download at first run i
 named volumes ([per-profile totals](INSTALLATION.md#download-sizes)). Budget disk for the
 image **plus** those volumes.
 
-| Image | Measured size | Base |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3.3 GB | `python:3.12-slim` + CPU-wheel PyTorch |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 GB | CUDA PyTorch + RAPIDS cuML |
+| Image | Compressed download | On disk (approx.) | Base |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4.18 GB | ~3.3 GB | `python:3.12-slim` + CPU-wheel PyTorch |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7.33 GB | ~21 GB | CUDA PyTorch + RAPIDS cuML |
+
+"Compressed download" is what `docker pull` transfers, measured from the current
+`ghcr.io/ncoevoet/facet` registry manifests. "On disk" is the unpacked image footprint
+after decompression; those figures were not reverified against the current `:latest`
+digest for this pass, so treat them as an approximate planning number rather than a
+precise current measurement.
 
 The CPU image is dominated by the ML dependency stack (~1.9 GB) rather than PyTorch
 itself (~960 MB), plus system libs (~288 MB) and the base OS (~150 MB). In the CUDA image

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -152,8 +152,9 @@ Use [Docker](#install-with-docker). To use an NVIDIA card on Windows, follow the
 ## First run: what to expect
 
 - **A download.** The first scan fetches the AI models for your profile — roughly
-  3–4 GB for `legacy` and `8gb`, 10–11 GB for `16gb`, 18 GB for `24gb`. This happens
-  once; later runs start immediately.
+  4.7 GB for `legacy`, 6.9 GB for `8gb`, 14.6 GB for `16gb`, 19.1 GB for `24gb`
+  (full breakdown in [Download sizes](#download-sizes)). This happens once; later
+  runs start immediately.
 - **No setup.** There is nothing to configure. Facet creates its database on the first
   scan and ships with working settings.
 - **Your photos are not modified.** Scanning only reads them; results go to Facet's own
@@ -232,8 +233,10 @@ alternative: it reserves the GPU but leaves the profile to the config's own
 `vram_profile` (default `auto`).
 
 Two images are published from one `Dockerfile`: `ghcr.io/ncoevoet/facet:latest` is a
-slim CPU build (~3.3 GB), `ghcr.io/ncoevoet/facet:latest-cuda` carries CUDA and RAPIDS
-cuML (~21 GB) and is what the GPU profiles pull. Both are `linux/amd64` only — on an ARM
+slim CPU build (~3.3 GB unpacked on disk, approximate — pulling it transfers less,
+4.18 GB compressed; see [Download sizes](#download-sizes)), `ghcr.io/ncoevoet/facet:latest-cuda`
+carries CUDA and RAPIDS cuML (~21 GB unpacked on disk, approximate; 7.33 GB compressed
+to pull) and is what the GPU profiles pull. Both are `linux/amd64` only — on an ARM
 machine, build locally with `docker compose build` instead of pulling. `docker compose build`
 (or `up --build`) always builds from this repository; see the `BASE_IMAGE`, `STRIP_TORCH`
 and `INSTALL_CUML` build args in the `Dockerfile`.
@@ -391,22 +394,55 @@ direction.
 
 ## Download sizes
 
-Models download on first use into `~/.cache/` and `~/.insightface/` (or the Docker named
-volumes). No model weights are baked into the image.
+Models download on first use into `~/.cache/huggingface/` (Hugging Face models),
+`~/.cache/torch/hub/` (PyIQA weights) and `~/.insightface/` (face detection/recognition),
+or the Docker named volumes. `samp_net.pth`, `u2netp.pth`, `face_landmarker.task` and the
+CLIP-MLP aesthetic head's `aesthetic_predictor_weights.pth` (`legacy`/`8gb` only) all land
+in `pretrained_models/`, resolved against the repository root rather than the process's
+working directory — in Docker that's the mapped `facet-pretrained` volume, so none of them
+re-download on container recreation. No model weights are baked into the image.
+
+Sizes below are decimal (GB = 10⁹ bytes, MB = 10⁶ bytes), measured from the local model
+caches and the Hugging Face API.
 
 | Model | Size | Profiles |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (embeddings + tagging) | ~1.6 GB | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (embeddings) | ~4.3 GB | `16gb`/`24gb` |
-| Qwen3.5-2B (VLM tagging) | ~4.2 GB | `16gb` |
-| Qwen3.5-4B (VLM tagging) | ~8 GB | `24gb` |
-| Qwen2-VL-2B (composition) | ~4.2 GB | `24gb` |
-| InsightFace buffalo_l (faces) | ~600 MB | all |
-| SAMP-Net weights (composition) | ~175 MB | all (`24gb` uses Qwen2-VL instead) |
-| BiRefNet_dynamic (subject saliency) | ~424 MB | all |
-| U2-Net-P (saliency helper) | ~5 MB | all |
+| CLIP ViT-L-14 laion2b (embeddings + CLIP tagging + CLIP-MLP aesthetic) | 1.711 GB | `legacy`/`8gb` |
+| Aesthetic-MLP head (`sac+logos+ava1-l14-linearMSE.pth`) | 3.7 MB | `legacy`/`8gb` only |
+| SigLIP 2 NaFlex SO400M (embeddings) | 4.581 GB | `16gb`/`24gb` |
+| Qwen3.5-2B (VLM tagging) | 4.571 GB | `16gb` |
+| Qwen3.5-4B (VLM tagging) | 9.343 GB | `24gb` |
+| Qwen2-VL-2B (composition) | 4.430 GB | none by default — only if you manually set `composition_model: "qwen2-vl-2b"` **and** `processing.mode: "single-pass"` |
+| InsightFace buffalo_l (faces) | 289 MB download / 630 MB on disk (the zip is kept alongside the extracted `.onnx` files) | all |
+| SAMP-Net weights (composition) | 183 MB | all |
+| U2-Net-P (SAMP-Net's saliency sub-model) | 4.7 MB | same as SAMP-Net |
+| BiRefNet_dynamic (subject saliency) | 445 MB | all |
+| TOPIQ NR (aesthetic model) | 181 MB | `16gb`/`24gb` |
+| TOPIQ IAA (supplementary aesthetic) | 873 MB | all |
+| TOPIQ NR-Face (supplementary face quality) | 376 MB | all |
+| LIQE (supplementary quality/distortion) | 708 MB | all |
+| timm resnet50.a1_in1k (shared PyIQA backbone) | 102 MB | all |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2.235 GB | `8gb`/`16gb`/`24gb`, **on by default** (`"auto"` resolves to enabled on every profile but `legacy`) |
 
-Totals per profile: `legacy`/`8gb` ~3–4 GB · `16gb` ~10–11 GB · `24gb` ~18 GB.
+Totals per profile (download): `legacy` 4.69 GB · `8gb` 6.93 GB · `16gb` 14.55 GB ·
+`24gb` 19.32 GB · `24gb` with `composition_model: "qwen2-vl-2b"` and
+`processing.mode: "single-pass"` 23.56 GB (the manual override replaces SAMP-Net/U2-Net-P
+rather than adding to them).
+
+For reference, pulling the Docker image itself (before any model downloads) transfers
+`ghcr.io/ncoevoet/facet:latest` at 4.18 GB compressed and `:latest-cuda` at 7.33 GB
+compressed, per the current registry manifests.
+
+Opt-in models not counted in the totals above:
+
+| Model | Size | Trigger |
+|-------|------|---------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16.41 GB | off by default |
+| SigLIP so400m-patch14-384 backbone (`iqa_extended.aesthetic_v25`) | 3.515 GB | off by default, **deprecated** (AGPL-3.0, unmaintained upstream — prefer `qrealign`) |
+| Helsinki-NLP OPUS-MT, per target language (caption translation) | en→fr 303 MB · en→de 298 MB · en→es 312 MB · en→it 343 MB · en→pt 465 MB | only for the languages you enable |
+| MediaPipe `face_landmarker.task` | 3.76 MB | only when `mediapipe` is installed |
+
+`reverse_geocoder` needs no download — its data ships inside the wheel.
 
 SAMP-Net weights come from the project's
 [model-weights-v1 release](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth).
@@ -471,7 +507,6 @@ Most of Facet runs anywhere (CPU, any profile). Some features need a GPU, a high
 | SigLIP 2 embeddings | yes | `16gb`/`24gb` | — | — |
 | VLM tagging (Qwen3.5) | yes | `16gb`/`24gb` | — | — |
 | Composition pattern (SAMP-Net) | optional | any (`legacy` = CPU) | — | — |
-| Composition (Qwen2-VL) | yes | `24gb` | — | — |
 | Subject saliency (BiRefNet) | optional | any (`legacy` = CPU) | — | — |
 | AI captions (generate / view) | yes | `16gb`/`24gb` | — | — |
 | AI captions (edit) | yes | `16gb`/`24gb` | edition | — |

--- a/docs/VIEWER.md
+++ b/docs/VIEWER.md
@@ -158,10 +158,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Composition Patterns
 
-Filter by SAMP-Net detected patterns:
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Filter by SAMP-Net detected patterns (the model emits exactly these 8, from
+`models/samp_net.py`):
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Sorting
 
@@ -218,6 +218,10 @@ A **Keep top %** control in the gallery toolbar (edition mode) turns the whole f
 ### Cull to folder
 
 The bulk-action bar's **Cull to folder…** dialog (edition mode) copies keeps, or moves/trashes rejects, to a target folder in one step (OS-trash is gated behind `viewer.cull.allow_trash`, never a permanent delete). Applying is safe by construction: `POST /api/cull/apply` never trusts a client-supplied deletion list at face value — it re-derives the action's actual target set server-side from each photo's own `is_rejected` state (copy acts only on keeps, move/trash only on rejects) and reports anything outside that scope as `excluded_by_state` instead of acting on it. Every call defaults to a dry run, so a preview always runs before anything is written, and move/trash need an explicit `dry_run=false` to proceed; pulling in a rejected photo's untouched RAW or sidecar is opt-in (`include_companions`), so rejecting a derived JPEG never silently takes its RAW down with it. Several commercial photo tools have shipped delete-selection bugs that acted on the wrong photos; Facet's apply endpoint is designed so the client cannot specify a deletion set directly.
+
+**Where you can write.** With no `viewer.export.allowed_target_dirs` configured, the only folders Facet will write into are your scan directories — point the dialog at a subfolder of the photo tree (e.g. `_rejected`) and it works with no setup. To use a folder outside the scanned tree, add it to `viewer.export.allowed_target_dirs` first; anything else is refused with a `403`, regardless of filesystem permissions. See [Configuration — Export and Cull Destinations](CONFIGURATION.md#export-and-cull-destinations). Running in Docker/Podman, the path you type is resolved **inside the container**, against whatever is actually mounted there — never against the host filesystem — see [Deployment — Container Path Semantics](DEPLOYMENT.md#container-path-semantics).
+
+**"Access denied" on every action.** That's a `403` — a deliberate refusal from the target-folder check above, or an expired edition session — not a filesystem or container-user permission problem. The toast doesn't say which, so check the failed request's response body in your browser's Network tab for the `detail` field. A real filesystem/permission problem looks different: the action reports partial success with a nonzero `errors` count instead of failing outright, and the server logs the underlying OS error for each file that failed.
 
 ### Display Options
 
@@ -377,7 +381,7 @@ Each album can carry a scoring context that decides which category wins for its 
 
 ### Portfolio Export
 
-When `viewer.features.show_portfolio_export` is `true` (default) and edition is unlocked, each manual album card gains an **Export portfolio** action. It opens a small dialog (gallery title, target folder, include-captions toggle) and renders the album into a self-contained static HTML gallery — the thumbsup/sigal use case, but native, with no external tool dependency. The output directory holds `index.html` (a responsive CSS-only thumbnail grid with a built-in vanilla-JS lightbox — **zero** external/CDN references, so it works fully offline), an `assets/` folder of sequentially-named JPEGs (no library paths leaked), and a `manifest.json` recording counts and per-photo sources. Each photo prefers the on-disk **original** (downscaled to `portfolio.max_edge`, EXIF orientation applied) and falls back to the stored 640px thumbnail when the original is unreachable (offline network shares). The endpoint is `POST /api/albums/{album_id}/export-portfolio` (edition-gated); the `target_dir` is validated against the same allow-list (`viewer.export.allowed_target_dirs` plus the scan directories) as the copy/move export endpoints, and albums over `portfolio.max_photos` (default 500) are refused. Re-exporting the same album is idempotent — only the export's own files are rewritten. See [Portfolio Export configuration](CONFIGURATION.md#portfolio-export).
+When `viewer.features.show_portfolio_export` is `true` (default) and edition is unlocked, each manual album card gains an **Export portfolio** action. It opens a small dialog (gallery title, target folder, include-captions toggle) and renders the album into a self-contained static HTML gallery — the thumbsup/sigal use case, but native, with no external tool dependency. The output directory holds `index.html` (a responsive CSS-only thumbnail grid with a built-in vanilla-JS lightbox — **zero** external/CDN references, so it works fully offline), an `assets/` folder of sequentially-named JPEGs (no library paths leaked), and a `manifest.json` recording counts and per-photo sources. Each photo prefers the on-disk **original** (downscaled to `portfolio.max_edge`, EXIF orientation applied) and falls back to the stored 640px thumbnail when the original is unreachable (offline network shares). The endpoint is `POST /api/albums/{album_id}/export-portfolio` (edition-gated); the `target_dir` is validated against the same allow-list (`viewer.export.allowed_target_dirs` plus the scan directories, see [Configuration — Export and Cull Destinations](CONFIGURATION.md#export-and-cull-destinations)) as the copy/move export endpoints, and albums over `portfolio.max_photos` (default 500) are refused. Re-exporting the same album is idempotent — only the export's own files are rewritten. See [Portfolio Export configuration](CONFIGURATION.md#portfolio-export).
 
 API: see the [API Endpoints](#api-endpoints) section below.
 
@@ -570,7 +574,7 @@ Find person clusters that may be the same individual. Access via `/merge-suggest
 Write your ratings, favorites, and rejections to disk as XMP sidecars, so external editors (darktable, Lightroom) pick them up. Requires edition mode.
 
 - **From the gallery** — select photos, then **Actions → Export** writes a sidecar next to each file.
-- **From an album** ("basket") — export the whole album as sidecars, or copy/symlink the files to a target directory.
+- **From an album** ("basket") — export the whole album as sidecars, or copy/symlink the files to a target directory (same destination allow-list as [Cull to folder](#cull-to-folder)).
 - **Write metadata to file** — the photo detail "Write metadata to file" action embeds the rating/keywords directly into the original file (JPEG/HEIC/TIFF/PNG/DNG via exiftool) in addition to writing the sidecar, so the whole photo ecosystem sees them. Proprietary RAW originals are never modified. Controlled by `viewer.features.show_embed_metadata` (default: `true`).
 
 API: see the [API Endpoints](#api-endpoints) section below.
@@ -1070,6 +1074,8 @@ Interactive API documentation is available at `/api/docs` (Swagger UI) and the O
 |----------|-------------|
 | `GET /api/photos` | Paginated photo list with filters |
 | `GET /api/photo` | Single photo details |
+| `GET /api/photo/set?path=` | The bracket/panorama/hdr_panorama/burst/duplicate set a photo belongs to (sequence takes precedence over burst, burst over duplicate), keyed on `path` — never a group id, which the bracket and panorama passes each renumber from 1 on every run |
+| `GET /api/photo/histogram?path=&bins=` | Draw-ready luminance + R/G/B bins (`bins` ∈ 32/64/128/256, default 64) measured at scan time on the full-resolution image. Every channel is scaled by one global max, never its own. `r`/`g`/`b` are `null` for a row stored before the per-channel format; 404 when the row has no histogram at all, which is the widget's signal to fall back to sampling the thumbnail |
 | `GET /api/type_counts` | Photo counts per type |
 | `GET /api/similar_photos/{path}` | Similar photos (modes: `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Semantic text-to-image search (`scope=text` = OCR/caption text only) |
@@ -1318,6 +1324,8 @@ Interactive API documentation is available at `/api/docs` (Swagger UI) and the O
 - `raw` — Serve the companion RAW file as-is (not available in shared albums).
 
 The `/api/download/options` endpoint detects companion RAW files automatically and returns available options including configured darktable profiles. The viewer uses this to populate a per-photo download menu.
+
+`type=original` converts a RAW through the same rendering the viewer shows, so a bracketed frame downloads with no camera preview and no exposure gain — see [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected). `type=raw` and `type=darktable` are unaffected.
 
 **Saliency-aware social crop.** When `viewer.features.show_social_export` is `true` (default) and edition is unlocked, the photo detail download bar gains a **Social crop** menu listing the configured `social_export.presets` (square 1:1, portrait 4:5, story 9:16 out of the box). Choosing a preset downloads a full-resolution JPEG cropped to that aspect and framed on the detected subject — something Lightroom export presets cannot do. The crop window is the largest rectangle of the target aspect that fits inside the image, centered on the subject and clamped at the edges. The subject box comes from a fallback chain: the persisted BiRefNet subject box (`photos.subject_bbox`, written by the saliency pass and `--recompute-saliency`) → the union of detected face boxes → a plain center crop. The `preview` endpoint returns which source drove the crop (`saliency` / `faces` / `center`), shown in the menu tooltip. Original decoding reuses the same RAW (rawpy) and HEIC (pillow-heif) loader as the download path, with EXIF orientation applied before cropping.
 

--- a/docs/de/COMMANDS.md
+++ b/docs/de/COMMANDS.md
@@ -217,8 +217,33 @@ Embeddings treiben die semantische Verschlagwortung, Duplikaterkennung, Ähnlich
 | Befehl | Beschreibung |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Rotation gespeicherter Thumbnails anhand der EXIF-Orientierung korrigieren |
+| `python facet.py --refresh-thumbnails` | RAW-Thumbnails aus der kamerainternen Vorschau neu erstellen |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | Dasselbe, mit mehr parallelen Lesevorgängen |
 
 Liest die EXIF-Orientierung aus den Originaldateien und rotiert die gespeicherten Thumbnail-Bytes; für Fotos, die verarbeitet wurden, bevor es eine EXIF-Behandlung gab. Es liest nur den EXIF-Header und das gespeicherte Thumbnail, nicht die vollständigen Bilder.
+
+`--refresh-thumbnails` rendert das gespeicherte Thumbnail jedes RAW-Fotos neu durch das Anzeigeprofil (zuerst die Kameravorschau, als Fallback das Demosaicing — siehe [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). Es ist die Migration für eine Bibliothek, die gescannt wurde, bevor dieses Profil existierte: Von einem älteren Scan geschriebene Thumbnails tragen LibRaws automatische Aufhellung pro Aufnahme, die die Belichtungsunterschiede zwischen den Aufnahmen einer Belichtungsreihe einebnet. Es wird kein Modell geladen und keine Score-Spalte berührt — nur `photos.thumbnail` wird neu geschrieben.
+
+Der Befehl ist durch den Speicherdurchsatz begrenzt, nicht durch die CPU, daher skaliert sein Aufwand mit der Bibliotheksgröße und der Geschwindigkeit der Festplatte oder des Netzlaufwerks der Bibliothek, nicht mit der Kernzahl der Maschine. `--refresh-thumbnails-workers` (Standard 8) legt fest, wie viele Dateien gleichzeitig gelesen werden: auf einem schnellen Netzlaufwerk erhöhen, wo jeder Lesevorgang wartend verbringt, auf einer langsamen lokalen Festplatte verringern. Es begrenzt auch die vollständigen Demosaicing-Vorgänge, auf die ein RAW ohne Vorschau zurückfällt, sodass sehr hohe Werte Arbeitsspeicher kosten.
+
+Er ist fortsetzbar. Jeder committete Batch merkt sich, wie weit er gekommen ist, sodass ein mit Ctrl+C (oder durch ein getrenntes Laufwerk) gestoppter Lauf eine konsistente Datenbank hinterlässt, und der nächste `--refresh-thumbnails` dort fortsetzt, wo er aufgehört hat. Ein abgeschlossener Lauf löscht die Markierung, sodass ein späteres erneutes Ausführen von vorn beginnt.
+
+Ein Foto, dessen frisches Rendering komplett schwarz zurückkommt, behält sein bestehendes Thumbnail und wird namentlich protokolliert. Das ist keine Paranoia: Ein schwer beschädigtes Panasonic-RW2 schlägt beim Dekodieren nicht fehl — LibRaw füllt es mit Nullen zu einem gültigen, formatfüllenden schwarzen Bild auf, statt fehlzuschlagen — sodass ohne diese Prüfung eine beschädigte Datei ein gutes Thumbnail stillschweigend durch ein schwarzes ersetzen würde. Ein solches Foto bleibt ungestempelt und wird beim nächsten Lauf erneut versucht, sodass es genügt, die Datei zu reparieren.
+
+Ein Foto, das zu einer Belichtungsreihe gehört, wird ohne Kameravorschau und ohne jegliche Belichtungsverstärkung neu gerendert, sodass seine Kachel zeigt, was der Sensor aufgezeichnet hat (siehe [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Da die Zugehörigkeit zu einer Belichtungsreihe aus der Sequenzerkennung stammt, die nach einem Scan läuft, führen Sie diesen Befehl nach `--detect-sequences` aus, damit diese Kacheln das Rendering übernehmen.
+
+### Was ein gespeichertes Thumbnail aktualisiert
+
+Gespeicherte Thumbnails werden zur Scanzeit gebacken, sodass eine Bibliothek, die vor der Existenz des Anzeigeprofils gescannt wurde, im Galerie-Raster weiterhin das alte Rendering zeigt. `photos.render_version` verzeichnet, welche Pipeline das Thumbnail jeder Zeile erzeugt hat, und zwei Wege bringen es auf den aktuellen Stand:
+
+| Weg | Deckt ab | Kosten |
+|------|--------|------|
+| Ein erneuter Scan (`python facet.py <verzeichnis>`) | Alles, was er scannt, Thumbnail und Histogramm | Vollständiger Scoring-Lauf |
+| `--refresh-thumbnails` | Das Thumbnail jeder RAW-Zeile | Speicherbegrenzt, Stunden bei einer großen Bibliothek |
+
+**Nichts geschieht von allein.** Die Detailansicht ist immer aktuell, weil `/image` in Echtzeit rendert, aber das Galerie-Raster liest `photos.thumbnail`, und keine Menge an Durchsuchen schreibt es neu. Genau dafür ist `--refresh-thumbnails` da, und deshalb zeigt die Galerie ein schließbares Banner, das die noch wartenden Zeilen zählt.
+
+Die Zählung im Banner stammt aus einem `stats_cache`-Eintrag mit einer TTL von einer Stunde, direkt aktualisiert durch `--refresh-thumbnails` und durch `python database.py --refresh-stats`, sodass sie nach einem Scan hinter der Realität zurückbleiben kann.
 
 ## Diagnose
 
@@ -230,6 +255,13 @@ Liest die EXIF-Orientierung aus den Originaldateien und rotiert die gespeicherte
 Berichtet die Python-Version, den PyTorch/CUDA-Build, die GPU-Erkennung und den Treiber, die Empfehlung für das VRAM-Profil, optionale Abhängigkeiten und den Konfigurations-/Datenbankstatus. Wenn PyTorch die GPU nicht sehen kann, `nvidia-smi` aber schon, gibt es den `pip install`-Befehl zur Behebung des CUDA-Builds aus.
 
 `--simulate-gpu NAME` und `--simulate-vram GB` testen das Verhalten mit anderer Hardware. Beide erfordern `--doctor`; `--simulate-vram` erfordert `--simulate-gpu`.
+
+| Befehl | Beschreibung |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | 20 stichprobenartig ausgewählte RAW-Fotos unter den alten und aktuellen Dekodiereinstellungen rendern |
+| `python facet.py --check-raw-rendering 50` | Stattdessen 50 Fotos als Stichprobe |
+
+Nur lesend: Es dekodiert eine Zufallsstichprobe direkt von der Festplatte und gibt die mittlere Leuchtdichte aus, die jedes Rendering erzeugt — LibRaws automatische Aufhellung pro Aufnahme, das Demosaicing mit fester Verstärkung für die Metriken und die kamerainterne Vorschau, die Thumbnails und Viewer verwenden. Damit lässt sich `raw_decode.bright` an eigenen Dateien prüfen, bevor man sich auf einen Scan oder einen `--refresh-thumbnails`-Lauf festlegt; die Spalten für festen Gain und Vorschau erhalten die Belichtungsleiter einer Belichtungsreihe, die Spalte für automatische Aufhellung ebnet sie ein.
 
 ## Modellinformationen
 

--- a/docs/de/COMMANDS.md
+++ b/docs/de/COMMANDS.md
@@ -55,7 +55,7 @@ Viewers im `progress`-Feld von `/api/scan/status` und im SSE-Stream bereitstellt
 | `quality-face` | TOPIQ NR-Face | `face_quality_iqa`-Score (eigens für Gesichtsqualität entwickelt) | Geteilt mit TOPIQ |
 | `quality-liqe` | LIQE | `liqe_score` + Verzerrungsdiagnose (Unschärfe, Überbelichtung, Rauschen) | ~2 GB |
 | `tags` | CLIP / Qwen VLM | Semantische Tags aus dem konfigurierten Vokabular | 0-16 GB |
-| `composition` | SAMP-Net | `composition_pattern` (14 Muster) + `comp_score` | ~2 GB |
+| `composition` | SAMP-Net | `composition_pattern` (8 Muster) + `comp_score` | ~2 GB |
 | `faces` | InsightFace buffalo_l | Gesichtserkennung, Landmarken, Blinzelerkennung, Erkennungs-Embeddings | ~2 GB |
 | `embeddings` | CLIP ViT-L-14 oder SigLIP 2 NaFlex | `clip_embedding`-BLOB für Ähnlichkeit/Verschlagwortung | 4-5 GB |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 GB |
@@ -142,6 +142,7 @@ Diese Befehle aktualisieren bestimmte Metriken, leiten neue Daten ab (KI-Bildunt
 | `python facet.py --recompute-embeddings` | CLIP/SigLIP-Embeddings für alle Fotos neu berechnen (nach Modellwechsel erforderlich) |
 | `python facet.py --score-topiq` | TOPIQ-Qualitätsscores aus gespeicherten Thumbnails nachfüllen (GPU erforderlich) |
 | `python facet.py --backfill-focal-35mm` | 35-mm-äquivalente Brennweite aus EXIF für Fotos nachfüllen, denen sie fehlt |
+| `python facet.py --backfill-clipping` | Leitet die Beschnitt-Prozentsätze pro Kanal aus den gespeicherten Histogrammen ab. Nur Datenbank (keine Bilddekodierung) und fortsetzbar; Fotos, deren Histogramm älter als das RGB-Format ist, bleiben unbekannt (NULL) |
 | `python facet.py --compute-recommendations` | Datenbank analysieren, Bewertungszusammenfassung anzeigen |
 | `python facet.py --compute-recommendations --verbose` | Detaillierte Statistiken anzeigen |
 | `python facet.py --compute-recommendations --apply-recommendations` | Bewertungskorrekturen automatisch anwenden |

--- a/docs/de/CONFIGURATION.md
+++ b/docs/de/CONFIGURATION.md
@@ -1521,7 +1521,8 @@ Anzeige und Verhalten der Web-Galerie.
 | `hide_brackets` | `true` | Standardmäßig nur die Basisbelichtung einer Belichtungsreihe anzeigen |
 | `hide_panoramas` | `true` | Standardmäßig nur ein repräsentatives Bild je Panorama zeigen |
 | `hide_details` | `true` | Fotodetails auf Karten standardmäßig ausblenden |
-| `tooltip_mode` | `"hover"` | Tooltip-Auslöser: `"hover"`, `"click"` oder `"off"`. Ersetzt das frühere boolesche `hide_tooltip`. |
+| `tooltip_mode` | `"hover"` | Tooltip-Auslöser: `"hover"`, `"click"`, `"off"` oder `"panel"` (angedockte Leiste statt schwebendem Tooltip — siehe `panel_activation` unten). Ersetzt das frühere boolesche `hide_tooltip`. |
+| `panel_activation` | `"both"` | Geste, das das ausgewählte Foto der angedockten Leiste umschaltet, wenn `tooltip_mode` `"panel"` ist: `"hover"`, `"click"` oder `"both"`. Ohne Wirkung bei den anderen Tooltip-Modi. Der Standard `"both"` erhält das ursprüngliche Panel-Verhalten |
 | `hide_rejected` | `true` | Abgelehnte Fotos standardmäßig ausblenden |
 | `gallery_mode` | `"mosaic"` | Standard-Galerie-Layout (`"grid"` oder `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/de/CONFIGURATION.md
+++ b/docs/de/CONFIGURATION.md
@@ -20,6 +20,7 @@ Alle Einstellungen befinden sich in `scoring_config.json`. Führen Sie nach eine
 - [Modelle](#models)
 - [Modelle zur Qualitätsbewertung](#quality-assessment-models)
 - [Verarbeitung](#processing)
+- [RAW-Dekodierung](#raw-dekodierung)
 - [Serienbild-Erkennung](#burst-detection)
 - [Serienbild-Bewertung](#burst-scoring)
 - [Duplikat-Erkennung](#duplicate-detection)
@@ -447,7 +448,7 @@ Wählt aus, welche Modelle je VRAM-Profil verwendet werden.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Wählt aus, welche Modelle je VRAM-Profil verwendet werden.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Wählt aus, welche Modelle je VRAM-Profil verwendet werden.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Legacy-Pretrained-Gewichte |
 | `clip_legacy.embedding_dim` | `768` | Legacy-Embedding-Dimensionen |
 | `clip_legacy.similarity_threshold_percent` | `22` | Tag-Übereinstimmungsschwelle für Legacy-CLIP |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | HuggingFace-Pfad (Kompositions-VLM für 24gb) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | HuggingFace-Pfad für das manuelle Opt-in `composition_model: "qwen2-vl-2b"` — standardmäßig von keinem Profil gewählt |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Verschlagwortungsmodell für das Profil 16gb |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Bilder pro VLM-Inferenz-Batch |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Verschlagwortungsmodell für das Profil 24gb |
@@ -526,7 +520,6 @@ Wählt aus, welche Modelle je VRAM-Profil verwendet werden.
 | `saliency.resolution` | `1024` | Inferenzauflösung |
 | `saliency.mask_threshold` | `0.3` | Sigmoid-Schwellenwert für die binäre Subjektmaske |
 | `saliency.min_subject_pixels` | `50` | Mindestanzahl an Subjektpixeln, um ein Subjekt als erkannt zu werten |
-| `samp_net.input_size` | `384` | Eingabegröße des Kompositionsmodells |
 
 ### Automatische VRAM-Erkennung
 
@@ -723,6 +716,148 @@ python facet.py /path --pass saliency      # BiRefNet-Subjekt-Saliency
 # Verfügbare Modelle auflisten
 python facet.py --list-models
 ```
+
+---
+
+## RAW-Dekodierung
+
+Wie RAW-Dateien in Pixel umgewandelt werden. Es gibt zwei Profile, und sie sind
+nicht austauschbar.
+
+**Metrik-Profil** — das Demosaicing, aus dem jede Bewertung berechnet wird, und der
+Pixelraum, in dem gespeicherte Gesichtsboxen und `image_width`/`image_height` leben.
+Es ist bewusst originalgetreu: keine Anpassung pro Aufnahme, ein einziger fester
+Belichtungsgain für die gesamte Bibliothek.
+
+**Anzeige-Profil** — was die gespeicherte Miniaturansicht, die Galerie und `/image`
+zeigen. Es bevorzugt den kameraeigenen Vorschau-Preview, der bereits die eigene
+Tonwertkurve, DR-Modi und Belichtung des Kameramodells trägt, und fällt auf das
+Demosaicing des Metrik-Profils zurück, wenn keine brauchbare Vorschau existiert.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Einstellung | Standard | Beschreibung |
+|-------------|----------|---------------|
+| `bright` | `1.62` | Fester Belichtungsgain, der auf jedes Demosaicing angewendet wird (`1.0` = LibRaws eigenes Niveau). Die einzige willkürliche Konstante hier: Sie entspricht darktables Standard von +0,7 EV, und nichts in der Datei schreibt sie vor — validieren Sie sie an Ihrer eigenen Bibliothek mit `--check-raw-rendering`, bevor Sie einen großen Scan starten |
+| `prefer_embedded_preview` | `true` | Anzeigebilder aus der Kameravorschau rendern, wenn eine vorhanden ist. `false` führt für alles ein Demosaicing durch, was langsamer ist und die Tonwertkurve der Kamera verwirft |
+| `preview_min_sensor_ratio` | `0.5` | Wie viel vom Sensor eine Vorschau abdecken muss, damit `/image` sie ausliefert statt zu demosaicen. Nikon, Pentax, Samsung und Canon CR3 betten eine nahezu formatfüllende Vorschau ein (0,98-0,99); Panasonic liegt bei 0,52, während Olympus, Fuji, Sony und DNG eine kleine Vorschau einbetten (0,29-0,49) und daher demosaict wird |
+| `viewer_concurrency` | `3` | Maximale gleichzeitige RAW-Demosaicings für den `/image`-Viewer-Pfad, mit einem eigenen Budget getrennt von `processing.raw_decode_concurrency` oben, sodass eine Viewer-Anfrage nie hinter Scan- oder CLI-Dekodierarbeit wartet |
+| `faithful_bracket_render` | `true` | Eine Belichtungsreihen-Aufnahme ganz ohne Korrektur rendern — keine Kameravorschau, kein `bright`-Gain. Siehe [unten](#belichtungsreihen-werden-unkorrigiert-gerendert). `false` rendert Belichtungsreihen wie jedes andere Foto |
+
+### Speicher-Trade-off
+
+`viewer_concurrency` und `processing.raw_decode_concurrency` sind unabhängige
+Budgets, jedes mit eigenem Semaphor, und keines leiht sich Spielraum vom anderen.
+Im schlechtesten Fall kann der Prozess daher gleichzeitig „Bibliothek + Viewer"-
+Demosaicings offen halten, jedes mit einem Spitzenwert von etwa 200-400 MB an
+Zwischenspeicher — senken Sie `viewer_concurrency` auf einem speicherbeschränkten
+Host. In der Praxis ist dieses Budget meist ungenutzt: Es wird nur beansprucht,
+wenn `/image` auf ein vollständiges Demosaicing zurückfallen muss, was
+`preview_min_sensor_ratio` oben bereits für jedes RAW vermeidet, dessen
+eingebettete Vorschau groß genug ist (Nikon, Pentax, Samsung, Canon CR3). Sony,
+Fuji, Olympus und DNG sind die Kameras, die es tatsächlich verbrauchen.
+
+### Warum es keine automatische Aufhellung gibt
+
+LibRaw hellt jede Aufnahme auf, bis etwa 1 % ihrer *eigenen* Pixel clippen, und
+ersetzt den hellsten Pixel derselben Aufnahme durch den Kamera-Weißwert. Beide
+Größen sind pro Aufnahme, sodass eine Belichtungsreihe angeglichen herauskommt:
+Eine gemessene 5-Aufnahmen-Canon-Reihe von -3,4 bis +3,3 EV rendert bei mittleren
+Luminanzen von 54-56 für ihre drei dunklen Aufnahmen — nicht voneinander zu
+unterscheiden. Mit dem festen Gain reicht dieselbe Reihe von 8,7 bis 160 — eine
+18-fache Spreizung statt einer 2,6-fachen.
+
+Ein höherer `bright`-Wert skaliert jedes Rendering linear; er stellt nie das
+Verhalten pro Aufnahme wieder her. Belichtungsmetriken bewegen sich mit — führen
+Sie nach einer Änderung `--recompute-average` erneut aus, und scannen Sie neu, um
+die Metriken selbst neu zu schreiben.
+
+### Belichtungsreihen werden unkorrigiert gerendert
+
+Ein Foto, dessen `sequence_kind` `bracket` oder `hdr_panorama` ist, wird ohne
+beide der obigen Korrekturen angezeigt: keine kameraeigene Vorschau und kein
+`bright`-Gain. Alles andere behält das Anzeige-Profil. Ein einfaches `panorama`
+ist *keine* Belichtungsreihe und ist ausgeschlossen — nur ein HDR-Panorama, das an
+jeder Position eine Belichtungsreihe ist, zählt hier zu den Belichtungsreihen.
+
+Der Grund ist, dass beide Korrekturen Lichter komprimieren, und Lichterspielraum
+ist der ganze Zweck der +EV-Aufnahmen einer Belichtungsreihe. Der einheitliche
+Gain bewahrt die *relative* Belichtung zwischen den Aufnahmen, beschneidet aber
+das obere Ende: Bei `bright` 2.0 kam eine gemessene 4,85-fache Spreizung als
+3,67-fache heraus — der Unterschied ist reine Clipping. Das eingebettete JPEG der
+Kamera hat seine eigene Tonwertkurve, die aus demselben Grund denselben Bereich
+komprimiert. Für ein gewöhnliches Foto ist das ein besser aussehendes Bild; für
+eine Belichtungsreihe verbirgt es genau das, was der Fotograf beurteilt.
+
+Das gilt für jede Oberfläche, die eine Belichtungsreihe rendert, damit sie nicht
+widersprüchlich sein können: `/image` (die Detailansicht, die Vergleichslupe und
+die Culling-Lupe) rendert sie so in Echtzeit, `--refresh-thumbnails` bäckt es in
+`photos.thumbnail` für die Galerie-Kachel und das Vergleichsraster ein, und
+`GET /api/download` mit `type=original` konvertiert sie auf dieselbe Weise — eine
+heruntergeladene Belichtungsreihen-Aufnahme ist meist auf dem Weg zu einer
+HDR-Fusion, bei der die von den anderen Renderings eingeführten beschnittenen
+Lichter unwiederbringlich wären.
+
+Zwei Download-Typen werden absichtlich unangetastet gelassen: `type=raw` kopiert
+die unveränderte RAW-Datei, und `type=darktable` ist der Export im „bearbeiteten
+Look", dessen ganzer Zweck eine Tonwertkurve ist. `GET /api/photo/cull_preview`
+ist ebenfalls nicht betroffen — es rendert über darktable-cli, nicht über rawpy.
+
+Es wird *nicht* zur Scanzeit angewendet, weil die Sequenzerkennung nach einem Scan
+läuft und die Zugehörigkeit zu einer Belichtungsreihe noch nicht bekannt ist —
+führen Sie zuerst `--detect-sequences` aus, dann `--refresh-thumbnails`, damit die
+Kacheln folgen.
+
+Die Bewertung ist nicht betroffen. Metriken werden aus `load_image_from_path`
+berechnet, was ein separates Dekodieren in Sensor-Dimensionen ist und wo jede
+gespeicherte Gesichtsbox und `image_width`/`image_height` leben; nichts hier
+erreicht das.
+
+Setzen Sie `faithful_bracket_render` auf `false`, um Belichtungsreihen wie jedes
+andere Foto zu rendern.
+
+### Migration einer vor diesem Profil gescannten Bibliothek
+
+Miniaturansichten und Histogramme werden zur Scanzeit gebacken, daher ändert ein
+Profilwechsel nicht rückwirkend, was eine bereits gescannte Zeile enthält.
+`photos.render_version` verzeichnet, welche Pipeline die gespeicherte
+Miniaturansicht jeder Zeile erzeugt hat: `NULL` bedeutet „von vor dem Fix", und
+die aktuelle Pipeline stempelt `1`.
+
+Es gibt nichts zu konfigurieren — der Stempel ist Buchhaltung, keine Einstellung —
+aber es lohnt sich zu wissen, welche Pfade ihn voranbringen:
+
+- **Ein erneuter Scan** schreibt Miniaturansicht und Histogramm neu und stempelt
+  die Zeile.
+- **`--refresh-thumbnails`** schreibt RAW-Miniaturansichten neu und stempelt sie.
+  Zeilen werden nicht anhand des Stempels übersprungen, sodass ein erneuter Lauf
+  nach einer `bright`-Änderung alles neu aufbaut.
+
+Das sind die einzigen beiden. Das Durchsuchen der Bibliothek repariert nichts:
+`/image` rendert in Echtzeit, sodass die Detailansicht immer aktuell ist, aber das
+Galerie-Raster liest `photos.thumbnail`, und nur ein Scan oder
+`--refresh-thumbnails` schreiben das neu.
+
+Das schließbare Banner der Galerie zählt die Zeilen, die noch auf dem alten
+Rendering sind. Es liest einen `stats_cache`-Eintrag mit einer TTL von einer
+Stunde, statt bei jedem Seitenaufruf `photos` zu durchsuchen, kann also nach einem
+erneuten Scan hinter der Realität zurückbleiben; `python database.py
+--refresh-stats` berechnet es sofort neu.
+
+Ein Rendering, das komplett schwarz zurückkommt, wird verweigert statt
+gespeichert, und die Zeile bleibt ungestempelt, damit ein späterer Lauf es erneut
+versucht. LibRaw füllt ein schwer beschädigtes Panasonic-RW2 mit Nullen zu einem
+gültigen, formatfüllenden schwarzen Bild auf, statt fehlzuschlagen, und eine
+unbeaufsichtigte Migration ist der schlechteste Ort, an dem das unbemerkt bleiben
+kann. Die Ablehnung wird mit dem Dateinamen protokolliert.
 
 ---
 
@@ -1399,6 +1534,71 @@ Anzeige und Verhalten der Web-Galerie.
 | `notification_duration_ms` | `2000` | Dauer der Toast-Benachrichtigung |
 | `moment_confidence_min` | `0` | Unterhalb dieser gespeicherten `narrative_moment_confidence`-Posteriori (0–1) werden Moment-Labels abgeblendet und mit dem Suffix „(uncertain)“ im Szenen-Header, im Culling-Szenengruppen-Header und im Galerie-Foto-Tooltip dargestellt. `0` = nie abblenden |
 
+### Karten-Badges und Beschnitt
+
+`viewer.badges` schaltet einzelne Badges der Galeriekarte ein und aus. Jedes
+Badge, das es vor diesem Block gab, ist standardmäßig `true` — der Block kann
+also weggelassen werden, ohne dass sich etwas ändert.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Schlüssel | Standard | Beschreibung |
+|-----------|----------|--------------|
+| `badges.favorite` | `true` | Herz-Badge auf einem Favoriten (Bearbeitungsmodus) |
+| `badges.star_rating` | `true` | Stern- und Zähler-Badge auf einem bewerteten Foto (Bearbeitungsmodus) |
+| `badges.rejected` | `true` | Daumen-runter-Badge auf einem abgelehnten Foto (Bearbeitungsmodus) |
+| `badges.sequence_kind` | `true` | Belichtungsreihen-/Panorama-Badge, nur sichtbar solange die Ausblendoption die Serie zusammenklappt |
+| `badges.sequence_override_pending` | `true` | Uhr-Badge für eine Panorama-Korrektur, die auf den nächsten Erkennungslauf wartet |
+| `badges.keeper_hint` | `true` | Pfeil „in dieser Gruppe gibt es eine bessere Aufnahme" aus dem gelernten Keeper-Modell |
+| `badges.best_of_burst` | `true` | „Beste"-Badge auf dem Leitbild einer Serie. Nur sichtbar, wenn `hide_bursts` aus ist — sonst ist jedes sichtbare Serienfoto ohnehin schon das Leitbild |
+| `badges.clipping_highlight` | `true` | Badge für ein Foto, dessen Lichter `clipping.badge_percent` überschreiten |
+| `badges.clipping_shadow` | `false` | Dasselbe für abgesoffene Schatten. Standardmäßig aus: Schattenbeschnitt ist häufig gewollt (Silhouetten, Nacht, Low-Key) |
+
+`viewer.clipping` ist die einzige Definition von „beschnitten", die sich
+Karten-Badge, Histogramm-Marker und Galerie-Filter teilen, damit die drei nicht
+auseinanderlaufen können.
+
+| Schlüssel | Standard | Beschreibung |
+|-----------|----------|--------------|
+| `badge_percent` | `5` | Prozent der Pixel im schlechtesten R/G/B-Kanal, ab dem die Karte ein Badge erhält. Über 28 Stichprobenfotos gemessen: der Median lag bei 0,31 %, das p90 bei 2,35 % — 5 % trifft also etwa 1 von 25 Fotos |
+| `indicator_percent` | `1` | Schwelle für die R/G/B-Marker des Histogramms. Feiner als das Badge, weil bereits ein einzelnes Foto betrachtet wird |
+| `histogram_mode` | `"rgb"` | Hausstandard für das Histogramm des **Detailbereichs**: `"luma"`, `"rgb"`, oder ein einzelner Kanal (`"r"` / `"g"` / `"b"`). Die eigene Wahl der Nutzerin für diese Ansicht liegt in `localStorage` unter `facet_histogram_mode` und hat Vorrang vor diesem Wert |
+| `tooltip_histogram_mode` | `"luma"` | Hausstandard für das Histogramm des **Hover-/angehefteten Tooltips**, dieselben fünf Werte. Bewusst unabhängig von `histogram_mode` und unter einem eigenen `localStorage`-Schlüssel gespeichert (`facet_histogram_mode_tooltip`): Der Detailbereich dient dem Studium eines einzelnen Fotos, wo Detail pro Kanal seinen Platz verdient; das Tooltip dient dem schnellen Durchsehen vieler Fotos, wo eine einfache Luminanzkurve meist schneller lesbar ist. Das Einstellen des einen stellt das andere nie um, und der Umschalter dafür wird nur angezeigt, solange das Tooltip angeheftet ist (angedockte Leiste oder `tooltip_mode: "click"`) — im reinen Hover-Modus zeigt es nur seinen aufgelösten Modus schreibgeschützt an |
+
+**Beschnitt wird pro Kanal gemessen, exakt bei Bin 0 und Bin 255.** Er steht in
+`photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` als Prozentsatz des
+schlechtesten Kanals — eine *andere* Messung als die Flags `shadow_clipped` /
+`highlight_clipped`, die binär sind, die Luminanzbänder 0–30 und 225–255 abdecken
+und in `exposure_score` einfließen.
+
+**`NULL` bedeutet unbekannt, niemals sauber.** Ein Foto, dessen gespeichertes
+Histogramm älter als das Kanalformat ist, hat keine Kanaldaten: Es erhält kein
+Badge und passt auf keine Seite des Filters. `python facet.py --backfill-clipping`
+leitet die Spalten für Zeilen ab, die bereits ein vollständiges Histogramm haben —
+rein datenbankseitig, ohne Bilddekodierung, und fortsetzbar.
+
 ### Features
 
 Schalten Sie optionale Features um, um den Speicherverbrauch zu senken oder die UI zu vereinfachen:
@@ -1410,7 +1610,6 @@ Schalten Sie optionale Features um, um den Speicherverbrauch zu senken oder die 
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1427,7 +1626,6 @@ Schalten Sie optionale Features um, um den Speicherverbrauch zu senken oder die 
 | `show_similar_button` | `true` | Schaltfläche „Find Similar“ auf Fotokarten anzeigen (nutzt numpy für CLIP-Ähnlichkeit) |
 | `show_merge_suggestions` | `true` | Funktion für Zusammenführungsvorschläge auf der Personenverwaltungsseite aktivieren |
 | `show_rating_controls` | `true` | Steuerelemente für Sternebewertung und Favorit anzeigen |
-| `show_rating_badge` | `true` | Bewertungs-Badge auf Fotokarten anzeigen |
 | `show_scan_button` | `false` | Scan-Auslöser-Schaltfläche für Superadmin-Benutzer anzeigen (erfordert GPU auf dem Viewer-Host) |
 | `metrics_enabled` | `false` | Den öffentlichen Prometheus-Endpunkt `GET /metrics` aktivieren. Standardmäßig aus — er legt Foto-/Personen-/Gesichtszählungen, DB-Größe und Prozessspeicher offen; nur aktivieren, wenn der Endpunkt aus dem Scraper-Netz erreichbar ist, nicht aus dem öffentlichen Internet. |
 | `show_semantic_search` | `true` | Semantische Suchleiste anzeigen (Text-zu-Bild-Suche mit CLIP/SigLIP-Embeddings) |
@@ -2036,6 +2234,32 @@ python facet.py --recompute-text   # liest die gesamte Bibliothek neu
 
 **Kosten.** Ein 640px-Thumbnail dauert auf der CPU rund 0,4s, sodass eine Bibliothek mit 50.000 Fotos ein CPU-Job über Nacht ist — es ist ein einmaliger Backfill, und spätere Scans fügen danach nur noch neue Fotos hinzu. Eine GPU wird automatisch verwendet, wenn torch eine meldet.
 
+## Ziele für Export und Aussortierung
+
+Jeder Endpunkt, der Fotodateien aus der Bibliothek kopiert, verlinkt oder verschiebt — Album-„Korb"-Export (`POST /api/albums/{id}/export`, Modi `copy`/`symlink`) und In-Ordner-aussortieren (`POST /api/cull/apply`, Aktionen `copy_keeps` / `move_rejects`) — schreibt in ein `target_dir`, das unter einer erlaubten Wurzel liegen muss, sonst wird die Anfrage abgelehnt, bevor irgendeine Datei berührt wird.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Einstellung | Standard | Beschreibung |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(Schlüssel fehlt)* | Zusätzliche Wurzelverzeichnisse, in die ein Kopier-/Symlink-Export oder ein In-Ordner-aussortieren-Kopieren/Verschieben schreiben darf, zusätzlich zu den Scan-Verzeichnissen (immer erlaubt). **Standardmäßig nicht vorhanden** — ohne weitere Einrichtung sind die einzigen beschreibbaren Exportziele Ihre konfigurierten Scan-Verzeichnisse |
+
+**Auflösungsreihenfolge.** Die Allowlist besteht zuerst aus `allowed_target_dirs`, dann aus jedem Scan-Verzeichnis (pro Benutzer, gemeinsam, und `path_mapping`-Ziele) — Exportieren *innerhalb* des Fotobaums benötigt also keine Konfiguration, aber ein Ziel außerhalb davon braucht einen Eintrag hier. Sowohl das angeforderte `target_dir` als auch jede erlaubte Wurzel werden vor dem Vergleich mit `os.path.realpath()` kanonisiert (Symlinks aufgelöst, `..` zusammengefasst), sodass ein Symlink, der außerhalb einer erlaubten Wurzel aufgelöst wird, abgelehnt wird, selbst wenn der Link selbst innerhalb einer solchen liegt.
+
+**Standardmäßig geschlossen (fail-closed).** Gibt es überhaupt keine Wurzeln — weder `allowed_target_dirs` noch konfigurierte Scan-Verzeichnisse —, wird Kopier-/Symlink-/Verschiebe-Export vollständig verweigert, statt irgendwohin zu schreiben. In der Praxis ist dieser Fall selten, sobald Sie eine Bibliothek gescannt haben, da die Scan-Verzeichnisse immer in der Allowlist stehen.
+
+**Fehlersuche bei „Zugriff verweigert".** Diese Prüfung läuft vor jedem Dateisystemzugriff, sodass ein abgelehntes Ziel nie die Festplatte berührt und keinen Traceback in den Server-Logs erzeugt — ein `403` ist hier eine normale HTTP-Antwort einer bewussten Prüfung, kein Serverfehler. Die Web-Oberfläche zeigt derzeit für *jeden* `403` an diesen Endpunkten einen allgemeinen „Zugriff verweigert"-Hinweis, ohne den Grund zu nennen; öffnen Sie den Netzwerk-Tab Ihres Browsers, suchen Sie die fehlgeschlagene Anfrage an `/api/cull/apply` oder `/api/albums/{id}/export`, und lesen Sie das Feld `detail` im Antwortkörper für den tatsächlichen Grund (entweder diese Allowlist oder eine abgelaufene Bearbeitungssitzung). Ein echtes Dateisystem-/Rechteproblem sieht anders aus: Die Anfrage selbst gelingt (`200`), die `errors`-Anzahl in der Antwort ist ungleich null, und der Server protokolliert für jede fehlgeschlagene Datei einen vollständigen Traceback — siehe [Deployment — Pfadsemantik im Container](DEPLOYMENT.md#pfadsemantik-im-container) für den Container-Fall, wo dies oft mit einer UID-Diskrepanz verwechselt wird.
+
+Siehe [Web-Viewer — In Ordner aussortieren](VIEWER.md#in-ordner-aussortieren) und [Web-Viewer — Editor-Export](VIEWER.md#editor-export).
+
 ## Social-Export
 
 Zuschneide-Vorlagen für Social-Media-Seitenverhältnisse mit Motiverkennung (`GET /api/photo/social_crop`, editionsbeschränkt). Jede Vorlage schneidet das Original in voller Auflösung auf ein Zielseitenverhältnis und rahmt es um das erkannte Motiv — das größte Rechteck dieses Seitenverhältnisses, das ins Bild passt, zentriert auf dem Motiv und an den Rändern begrenzt. Die Motivbox folgt einer Fallback-Kette: die gespeicherte BiRefNet-Motivbox (`photos.subject_bbox`) → die Vereinigung der erkannten Gesichtsboxen → ein einfacher zentrierter Zuschnitt. Siehe [Web-Viewer — Download](VIEWER.md#download).
@@ -2081,7 +2305,7 @@ Exportieren Sie ein Album als eigenständige statische HTML-Galerie, die eine Fo
 | `max_edge` | `2048` | Obergrenze der langen Kante (px) für exportierte Originale; die Anfrage kann sie überschreiben (auf 256–8000 begrenzt) |
 | `jpeg_quality` | `88` | JPEG-Qualität der exportierten Bilder |
 
-Das `target_dir` durchläuft dieselbe Allowlist wie die Kopier-/Verschiebe-Export-Endpunkte (`viewer.export.allowed_target_dirs` plus die Scan-Verzeichnisse). Gesteuert durch `viewer.features.show_portfolio_export` (Standard `true`).
+Das `target_dir` durchläuft dieselbe Allowlist wie die Kopier-/Verschiebe-Export-Endpunkte (`viewer.export.allowed_target_dirs` plus die Scan-Verzeichnisse — siehe [Ziele für Export und Aussortierung](#ziele-für-export-und-aussortierung)). Gesteuert durch `viewer.features.show_portfolio_export` (Standard `true`).
 
 ## Bilderrahmen / Kiosk
 

--- a/docs/de/DEPLOYMENT.md
+++ b/docs/de/DEPLOYMENT.md
@@ -57,6 +57,43 @@ Mehrere Zuordnungen werden unterstützt (die erste Übereinstimmung gewinnt):
 - Sowohl UNC-Pfade (`\\server\share`) als auch Laufwerksbuchstaben (`Z:\`) werden unterstützt
 - Das erste übereinstimmende Präfix gewinnt
 
+## Pfadsemantik im Container
+
+Alles, was Sie in ein Ordnerfeld im Viewer eingeben — ein Ziel für „In Ordner aussortieren", das Kopier-/Symlink-Exportziel eines Albums, oder `viewer.export.allowed_target_dirs` in `scoring_config.json` — wird vom Facet-Prozess selbst aufgelöst. **Unter Docker/Podman läuft dieser Prozess innerhalb des Containers**, sodass jeder Pfad der Pfad ist, den *der Container* sieht: der Einhängepunkt, niemals der host-seitige Pfad.
+
+**Beispiel.** Die mitgelieferte `docker-compose.yml` hängt Ihren Fotoordner unter `/data/photos` ein:
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+Um Abgelehnte in einen Unterordner `rejects` auszusortieren, geben Sie im Dialog `/data/photos/rejects` ein — niemals den Host-Pfad (`/home/sie/Bilder`, `D:\Fotos`, …), den der Container überhaupt nicht sehen kann. Dasselbe gilt für `viewer.export.allowed_target_dirs`: Geben Sie den containerseitigen Pfad an.
+
+Um an einen anderen Ort als den gescannten Fotobaum zu schreiben — etwa ein separates Export-Volume —, hängen Sie es zuerst in den Container ein und fügen Sie dann seinen containerseitigen Pfad zu `viewer.export.allowed_target_dirs` hinzu:
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # zusätzliches Volume für Cull-/Export-Ausgabe
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+Ein Ziel, das außerhalb jedes eingehängten Volumes liegt, wird abgelehnt (`403`) — Facets Ziel-Verzeichnis-Prüfung führt `os.path.realpath()` sowohl auf die Anfrage *als auch* auf jede erlaubte Wurzel aus, löst dabei Symlinks und `..` auf, bevor sie vergleicht — ein Pfad, der nur von außerhalb des Containers richtig aussieht (oder ein Symlink, der aus einem Mount hinausweist), besteht die Containment-Prüfung trotzdem nicht. Siehe [Konfiguration — Ziele für Export und Aussortierung](CONFIGURATION.md#ziele-für-export-und-aussortierung) für die vollständige Allowlist-Referenz.
+
+**Das ist kein Rechteproblem des Container-Benutzers.** Die UID des `facet`-Benutzers im Container unterscheidet sich häufig von der Ihres Host-Kontos, und das kann auf einem Bind-Mount ein echtes, separates Dateisystem-Rechteproblem verursachen — aber das geschieht *nachdem* diese Pfadprüfung bestanden wurde, wenn das Kopieren/Verlinken/Verschieben tatsächlich läuft, und es wird serverseitig mit dem zugrunde liegenden Betriebssystemfehler für die fehlgeschlagene Datei protokolliert. Ein `403 target_dir is not an allowed export location` (oder ein allgemeines „Zugriff verweigert" in der Oberfläche) geschieht *bevor* irgendeine Datei berührt wird und hat nichts mit UIDs zu tun.
+
 ## Erstellen des Angular-Clients
 
 Der FastAPI-Server stellt die vorab erstellte SPA aus `client/dist/client/browser/` bereit. Erstellen Sie sie vor der Bereitstellung:
@@ -102,7 +139,8 @@ python database.py --export-viewer-db
 ```
 
 Dies erstellt `photo_scores_viewer.db`, die:
-- CLIP-Embeddings, Histogrammdaten und Gesichts-Embeddings entfernt
+- CLIP-Embeddings, Bildunterschrift-Embeddings und Gesichts-Embeddings entfernt
+- Das Histogramm pro Foto (~2 KB) behält, das das RGB-Histogramm-Widget der Galerie liest
 - Vorschaubilder von 640px auf 320px verkleinert
 - Eine 14-GB-Datenbank typischerweise auf ~4-5 GB reduziert
 
@@ -214,11 +252,14 @@ dokumentiert. Was folgt, ist nur das, was sich auf einem NAS unterscheidet.
 
 **Beide veröffentlichten Images sind ausschließlich `linux/amd64` (x86_64).** Das deckt x86-NAS-Hardware ab (Synology Plus/x86, UGREEN, UnifyDrive und alles, was Coolify, Portainer oder ein gewöhnliches Docker auf einer Intel-/AMD-CPU betreibt). Es gibt kein `arm64`-Image: Das Cross-Compilieren eines mehrere Gigabyte großen ML-Stacks unter QEMU kostet Stunden pro Tag, und die CUDA-Variante ist ohnehin nur für x86 verfügbar. Bauen Sie es auf einem ARM-NAS oder einem Raspberry Pi stattdessen lokal mit `docker compose build`, statt es zu ziehen – `docker compose up` behält `build: .` unterhalb des Schlüssels `image:` genau für diesen Fall bei.
 
-**Planen Sie den Speicherplatz.** Das CPU-Image ist ~3,3 GB groß und das CUDA-Image
-~21 GB, dazu kommen die Modellgewichte, die jedes Profil beim ersten Lauf herunterlädt
-(~3–4 GB für `legacy`/`8gb`, ~10–11 GB für `16gb`, ~18 GB für `24gb` — vollständige
-Tabelle unter [Installation › Downloadgrößen](INSTALLATION.md#downloadgrößen)).
-`docker compose down -v` löscht die Modell-Volumes und erzwingt einen erneuten Download.
+**Planen Sie den Speicherplatz.** Entpackt ist das CPU-Image etwa 3,3 GB groß und das
+CUDA-Image etwa 21 GB (ungefähre Werte, nicht gegen den aktuellen Build reverifiziert;
+der Download selbst überträgt weniger, komprimiert — siehe [Image-Größe](#image-größe)
+weiter unten), dazu kommen die Modellgewichte, die jedes Profil beim ersten Lauf
+herunterlädt (`legacy` 4,69 GB, `8gb` 6,93 GB, `16gb` 14,55 GB, `24gb` 19,13 GB —
+vollständige Tabelle unter
+[Installation › Downloadgrößen](INSTALLATION.md#downloadgrößen)). `docker compose down -v`
+löscht die Modell-Volumes und erzwingt einen erneuten Download.
 
 **Versionierte Tags.** `:latest` und `:latest-cuda` bewegen sich bei jedem Release; pinnen Sie eine Version (`:1.7.2`, `:1.7`, `:1.7.2-cuda`, …) auf einem NAS, das sich nicht unter Ihnen ändern soll. Beide Varianten werden aus demselben `Dockerfile` über die Build-Argumente `BASE_IMAGE`, `STRIP_TORCH` und `INSTALL_CUML` gebaut, pro Variante gesetzt in `.github/workflows/docker-publish.yml`. Dieser Workflow akzeptiert auch einen manuellen `workflow_dispatch`-Lauf, der `latest`/`latest-cuda` ausgehend von `master` erneut veröffentlicht, ohne dass dafür ein Release geschnitten oder ein versionierter Tag geprägt werden muss.
 
@@ -334,10 +375,16 @@ Keines der veröffentlichten Images enthält Modellgewichte — diese werden bei
 Start in die benannten Volumes heruntergeladen ([Summen pro Profil](INSTALLATION.md#downloadgrößen)).
 Planen Sie Speicherplatz für das Image **plus** diese Volumes ein.
 
-| Image | Gemessene Größe | Basis |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3,3 GB | `python:3.12-slim` + CPU-Wheel-PyTorch |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 GB | CUDA-PyTorch + RAPIDS cuML |
+| Image | Komprimierter Download | Auf der Platte (ca.) | Basis |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4,18 GB | ~3,3 GB | `python:3.12-slim` + CPU-Wheel-PyTorch |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7,33 GB | ~21 GB | CUDA-PyTorch + RAPIDS cuML |
+
+„Komprimierter Download" ist das, was `docker pull` überträgt, gemessen anhand der
+aktuellen `ghcr.io/ncoevoet/facet`-Registry-Manifeste. „Auf der Platte" ist der
+entpackte Image-Fußabdruck nach der Dekomprimierung; diese Werte wurden für diesen
+Durchgang nicht gegen den aktuellen `:latest`-Digest reverifiziert — behandeln Sie sie
+als ungefähre Planungsgröße, nicht als präzise aktuelle Messung.
 
 Das CPU-Image wird vom ML-Abhängigkeits-Stack dominiert (~1,9 GB) und nicht von
 PyTorch selbst (~960 MB), dazu kommen System-Bibliotheken (~288 MB) und das Basis-OS

--- a/docs/de/INSTALLATION.md
+++ b/docs/de/INSTALLATION.md
@@ -155,7 +155,8 @@ nutzen, folgen Sie der [WSL2-Anleitung](DEPLOYMENT.md#windows-wsl2-mit-einer-nvi
 ## Erster Start: was Sie erwartet
 
 - **Ein Download.** Der erste Scan lädt die KI-Modelle für Ihr Profil herunter — etwa
-  3–4 GB für `legacy` und `8gb`, 10–11 GB für `16gb`, 18 GB für `24gb`. Das geschieht
+  4,7 GB für `legacy`, 6,9 GB für `8gb`, 14,6 GB für `16gb`, 19,1 GB für `24gb`
+  (vollständige Aufschlüsselung unter [Downloadgrößen](#downloadgrößen)). Das geschieht
   einmalig; spätere Läufe starten sofort.
 - **Keine Einrichtung.** Es gibt nichts zu konfigurieren. Facet erstellt seine Datenbank
   beim ersten Scan und liefert funktionierende Einstellungen mit.
@@ -238,8 +239,11 @@ Die profilspezifischen Dateien (`docker-compose.legacy.yml`, `docker-compose.8gb
 `auto`).
 
 Zwei Images werden aus einem `Dockerfile` veröffentlicht: `ghcr.io/ncoevoet/facet:latest`
-ist ein schlanker CPU-Build (~3,3 GB), `ghcr.io/ncoevoet/facet:latest-cuda` bringt CUDA
-und RAPIDS cuML mit (~21 GB) und ist das, was die GPU-Profile ziehen. Beide sind
+ist ein schlanker CPU-Build (~3,3 GB entpackt auf der Platte, ungefährer Wert — der
+Download selbst überträgt weniger, 4,18 GB komprimiert; siehe
+[Downloadgrößen](#downloadgrößen)), `ghcr.io/ncoevoet/facet:latest-cuda` bringt CUDA und
+RAPIDS cuML mit (~21 GB entpackt auf der Platte, ungefähr; 7,33 GB komprimiert zum
+Herunterladen) und ist das, was die GPU-Profile ziehen. Beide sind
 ausschließlich `linux/amd64` — bauen Sie auf einem ARM-Rechner lokal mit
 `docker compose build`, statt zu ziehen. `docker compose build` (oder `up --build`)
 baut immer aus diesem Repository; siehe die Build-Argumente `BASE_IMAGE`,
@@ -401,23 +405,56 @@ es konfiguriert ist — setzen Sie eines, um diese Schwellen in beide Richtungen
 
 ## Downloadgrößen
 
-Modelle werden bei der ersten Verwendung nach `~/.cache/` und `~/.insightface/`
-heruntergeladen (oder in die benannten Docker-Volumes). Keine Modellgewichte sind ins
-Image eingebacken.
+Modelle werden bei der ersten Verwendung nach `~/.cache/huggingface/` (Hugging-Face-Modelle),
+`~/.cache/torch/hub/` (PyIQA-Gewichte) und `~/.insightface/` (Gesichtserkennung)
+heruntergeladen, oder in die benannten Docker-Volumes. `samp_net.pth`, `u2netp.pth`,
+`face_landmarker.task` und das `aesthetic_predictor_weights.pth` des CLIP-MLP-Ästhetik-Kopfs
+(nur `legacy`/`8gb`) landen alle in `pretrained_models/`, aufgelöst relativ zur
+Repository-Wurzel statt zum Arbeitsverzeichnis des Prozesses — unter Docker ist das das
+gemountete Volume `facet-pretrained`, sodass keines davon bei einer Container-Neuerstellung
+erneut heruntergeladen wird. Keine Modellgewichte sind ins Image eingebacken.
+
+Die folgenden Größen sind dezimal (GB = 10⁹ Byte, MB = 10⁶ Byte), gemessen anhand der
+lokalen Modell-Caches und der Hugging-Face-API.
 
 | Modell | Größe | Profile |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (Embeddings + Tagging) | ~1,6 GB | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (Embeddings) | ~4,3 GB | `16gb`/`24gb` |
-| Qwen3.5-2B (VLM-Tagging) | ~4,2 GB | `16gb` |
-| Qwen3.5-4B (VLM-Tagging) | ~8 GB | `24gb` |
-| Qwen2-VL-2B (Komposition) | ~4,2 GB | `24gb` |
-| InsightFace buffalo_l (Gesichter) | ~600 MB | alle |
-| SAMP-Net-Gewichte (Komposition) | ~175 MB | alle (`24gb` verwendet stattdessen Qwen2-VL) |
-| BiRefNet_dynamic (Motiverkennung) | ~424 MB | alle |
-| U2-Net-P (Salienz-Hilfsmodell) | ~5 MB | alle |
+| CLIP ViT-L-14 laion2b (Embeddings + CLIP-Tagging + CLIP-MLP-Ästhetik) | 1,711 GB | `legacy`/`8gb` |
+| Ästhetik-MLP-Kopf (`sac+logos+ava1-l14-linearMSE.pth`) | 3,7 MB | nur `legacy`/`8gb` |
+| SigLIP 2 NaFlex SO400M (Embeddings) | 4,581 GB | `16gb`/`24gb` |
+| Qwen3.5-2B (VLM-Tagging) | 4,571 GB | `16gb` |
+| Qwen3.5-4B (VLM-Tagging) | 9,343 GB | `24gb` |
+| Qwen2-VL-2B (Komposition) | 4,430 GB | standardmäßig kein Profil — nur wenn Sie manuell `composition_model: "qwen2-vl-2b"` **und** `processing.mode: "single-pass"` setzen |
+| InsightFace buffalo_l (Gesichter) | 289 MB Download / 630 MB auf der Platte (das Zip bleibt neben den extrahierten `.onnx`-Dateien erhalten) | alle |
+| SAMP-Net-Gewichte (Komposition) | 183 MB | alle |
+| U2-Net-P (Salienz-Untermodell von SAMP-Net) | 4,7 MB | dieselben Profile wie SAMP-Net |
+| BiRefNet_dynamic (Motiverkennung) | 445 MB | alle |
+| TOPIQ NR (Ästhetikmodell) | 181 MB | `16gb`/`24gb` |
+| TOPIQ IAA (ergänzende Ästhetik) | 873 MB | alle |
+| TOPIQ NR-Face (ergänzende Gesichtsqualität) | 376 MB | alle |
+| LIQE (ergänzende Qualität/Verzerrung) | 708 MB | alle |
+| timm resnet50.a1_in1k (gemeinsames PyIQA-Backbone) | 102 MB | alle |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2,235 GB | `8gb`/`16gb`/`24gb`, **standardmäßig aktiv** (`"auto"` löst sich auf jedem Profil außer `legacy` als aktiv auf) |
 
-Summen pro Profil: `legacy`/`8gb` ~3–4 GB · `16gb` ~10–11 GB · `24gb` ~18 GB.
+Summen pro Profil (Download): `legacy` 4,69 GB · `8gb` 6,93 GB · `16gb` 14,55 GB ·
+`24gb` 19,32 GB · `24gb` mit `composition_model: "qwen2-vl-2b"` und
+`processing.mode: "single-pass"` 23,56 GB (die manuelle Überschreibung ersetzt
+SAMP-Net/U2-Net-P, statt sie zu ergänzen).
+
+Zum Vergleich: Der Download des Docker-Images selbst (vor jedem Modell-Download)
+überträgt `ghcr.io/ncoevoet/facet:latest` mit 4,18 GB komprimiert und `:latest-cuda`
+mit 7,33 GB komprimiert, laut den aktuellen Registry-Manifesten.
+
+Optionale Modelle, die in den obigen Summen nicht enthalten sind:
+
+| Modell | Größe | Auslöser |
+|-------|------|----------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16,41 GB | standardmäßig aus |
+| SigLIP-so400m-patch14-384-Backbone (`iqa_extended.aesthetic_v25`) | 3,515 GB | standardmäßig aus, **veraltet** (AGPL-3.0, upstream unmaintained — `qrealign` vorziehen) |
+| Helsinki-NLP OPUS-MT, pro Zielsprache (Untertitel-Übersetzung) | en→fr 303 MB · en→de 298 MB · en→es 312 MB · en→it 343 MB · en→pt 465 MB | nur für aktivierte Sprachen |
+| MediaPipe `face_landmarker.task` | 3,76 MB | nur wenn `mediapipe` installiert ist |
+
+`reverse_geocoder` braucht keinen Download — seine Daten sind im Wheel enthalten.
 
 Die SAMP-Net-Gewichte stammen aus dem
 [model-weights-v1-Release](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth)

--- a/docs/de/VIEWER.md
+++ b/docs/de/VIEWER.md
@@ -1028,6 +1028,7 @@ Eine interaktive API-Dokumentation ist unter `/api/docs` (Swagger UI) verfügbar
 |----------|-------------|
 | `GET /api/photos` | Paginierte Fotoliste mit Filtern |
 | `GET /api/photo` | Details zu einem einzelnen Foto |
+| `GET /api/photo/set?path=` | Die Belichtungsreihen-/Panorama-/HDR-Panorama-/Serienbild-/Duplikat-Menge, zu der ein Foto gehört (Sequenz hat Vorrang vor Serienbild, Serienbild vor Duplikat), referenziert über `path` — niemals eine Gruppen-ID, welche die Belichtungsreihen- und Panorama-Durchläufe bei jedem Lauf jeweils neu ab 1 durchnummerieren |
 | `GET /api/photo/histogram?path=&bins=` | Zeichenfertige Luminanz- + R/G/B-Bins (`bins` ∈ 32/64/128/256, Standard 64), beim Scan am Bild in voller Auflösung gemessen. Jeder Kanal wird mit einem einzigen globalen Maximum skaliert, nie mit seinem eigenen. `r`/`g`/`b` sind `null` für eine Zeile, die vor dem Kanalformat gespeichert wurde; 404, wenn die Zeile überhaupt kein Histogramm hat — das Signal für das Widget, auf das Abtasten des Vorschaubilds zurückzufallen |
 | `GET /api/type_counts` | Fotoanzahlen pro Typ |
 | `GET /api/similar_photos/{path}` | Ähnliche Fotos (Modi: `visual`, `color`, `person`) |

--- a/docs/de/VIEWER.md
+++ b/docs/de/VIEWER.md
@@ -155,10 +155,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Kompositionsmuster
 
-Nach von SAMP-Net erkannten Mustern filtern:
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Nach von SAMP-Net erkannten Mustern filtern (das Modell liefert genau diese 8, aus
+`models/samp_net.py`):
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Sortierung
 
@@ -215,6 +215,10 @@ Ein **Top % behalten**-Steuerelement in der Symbolleiste der Galerie (Bearbeitun
 ### In Ordner aussortieren
 
 Der Dialog **In Ordner aussortieren…** in der Sammelaktionsleiste (Bearbeitungsmodus) kopiert Behaltene oder verschiebt/entsorgt Abgelehnte in einem Schritt in einen Zielordner (der Systempapierkorb ist über `viewer.cull.allow_trash` gesperrt, niemals ein endgültiges Löschen). Das Anwenden ist von Grund auf sicher: `POST /api/cull/apply` vertraut niemals blind einer vom Client übermittelten Löschliste — er leitet die tatsächliche Zielmenge der Aktion serverseitig aus dem eigenen `is_rejected`-Status jedes Fotos ab (Kopieren wirkt nur auf Behaltene, Verschieben/Papierkorb nur auf Abgelehnte) und meldet alles außerhalb dieses Bereichs als `excluded_by_state`, statt darauf zu wirken. Jeder Aufruf ist standardmäßig ein Trockenlauf (dry run) — eine Vorschau läuft immer vor jedem Schreibvorgang — und Verschieben/Papierkorb benötigen ein explizites `dry_run=false`, um auszuführen; das Einbeziehen des unberührten RAW oder Sidecars eines abgelehnten Fotos ist optional (`include_companions`), damit das Ablehnen eines abgeleiteten JPEGs niemals stillschweigend sein RAW mitreißt. Mehrere kommerzielle Fototools hatten Fehler bei der Löschauswahl, die die falschen Fotos betrafen; der Anwenden-Endpunkt von Facet ist so gestaltet, dass der Client niemals direkt eine Löschmenge angeben kann.
+
+**Wohin Sie schreiben können.** Ohne konfiguriertes `viewer.export.allowed_target_dirs` kann Facet nur in Ihre Scan-Verzeichnisse schreiben — richten Sie den Dialog auf einen Unterordner des Fotobaums (z. B. `_rejected`), dann funktioniert es ohne weitere Einrichtung. Um einen Ordner außerhalb des gescannten Baums zu verwenden, fügen Sie ihn zuerst zu `viewer.export.allowed_target_dirs` hinzu; alles andere wird mit `403` abgelehnt, unabhängig von den Dateisystemrechten. Siehe [Konfiguration — Ziele für Export und Aussortierung](CONFIGURATION.md#ziele-für-export-und-aussortierung). Unter Docker/Podman wird der eingegebene Pfad **innerhalb des Containers** aufgelöst, gegen das, was dort tatsächlich eingehängt ist — niemals gegen das Host-Dateisystem — siehe [Deployment — Pfadsemantik im Container](DEPLOYMENT.md#pfadsemantik-im-container).
+
+**„Zugriff verweigert" bei jeder Aktion.** Das ist ein `403` — eine bewusste Ablehnung durch die obige Zielordner-Prüfung, oder eine abgelaufene Bearbeitungssitzung — kein Dateisystem- oder Container-Benutzer-Rechteproblem. Der Hinweis unterscheidet nicht, welcher Fall vorliegt; prüfen Sie im Netzwerk-Tab Ihres Browsers den Antwortkörper der fehlgeschlagenen Anfrage auf das Feld `detail`. Ein echtes Dateisystem-/Rechteproblem sieht anders aus: Die Aktion meldet Teilerfolg mit einer von null verschiedenen `errors`-Anzahl, und der Server protokolliert den zugrunde liegenden Betriebssystemfehler für jede fehlgeschlagene Datei.
 
 ### Anzeigeoptionen
 
@@ -318,7 +322,7 @@ Jedes Album kann einen Bewertungskontext tragen, der bestimmt, welche Kategorie 
 
 ### Portfolio-Export
 
-Wenn `viewer.features.show_portfolio_export` auf `true` steht (Standard) und der Bearbeitungsmodus freigeschaltet ist, erhält jede manuelle Albumkarte eine Aktion **Portfolio exportieren**. Sie öffnet einen kleinen Dialog (Galerietitel, Zielordner, Schalter zum Einschließen von Bildunterschriften) und rendert das Album als eigenständige statische HTML-Galerie — der thumbsup/sigal-Anwendungsfall, aber nativ, ohne Abhängigkeit von einem externen Werkzeug. Das Ausgabeverzeichnis enthält `index.html` (ein responsives, rein per CSS umgesetztes Miniaturraster mit eingebauter Vanilla-JS-Lightbox — **null** externe/CDN-Verweise, sodass es vollständig offline funktioniert), einen Ordner `assets/` mit fortlaufend benannten JPEGs (kein Bibliothekspfad wird preisgegeben) und eine `manifest.json`, die Anzahlen und Quellen pro Foto festhält. Jedes Foto bevorzugt das **Original** auf der Festplatte (auf `portfolio.max_edge` verkleinert, EXIF-Ausrichtung angewendet) und greift auf das gespeicherte 640-px-Thumbnail zurück, wenn das Original nicht erreichbar ist (offline Netzlaufwerke). Der Endpunkt ist `POST /api/albums/{album_id}/export-portfolio` (editionsbeschränkt); das `target_dir` wird gegen dieselbe Allowlist geprüft (`viewer.export.allowed_target_dirs` plus die Scan-Verzeichnisse) wie die Kopier-/Verschiebe-Export-Endpunkte, und Alben über `portfolio.max_photos` (Standard 500) werden abgelehnt. Ein erneuter Export desselben Albums ist idempotent — nur die eigenen Dateien des Exports werden neu geschrieben. Siehe [Portfolio-Export-Konfiguration](CONFIGURATION.md#portfolio-export).
+Wenn `viewer.features.show_portfolio_export` auf `true` steht (Standard) und der Bearbeitungsmodus freigeschaltet ist, erhält jede manuelle Albumkarte eine Aktion **Portfolio exportieren**. Sie öffnet einen kleinen Dialog (Galerietitel, Zielordner, Schalter zum Einschließen von Bildunterschriften) und rendert das Album als eigenständige statische HTML-Galerie — der thumbsup/sigal-Anwendungsfall, aber nativ, ohne Abhängigkeit von einem externen Werkzeug. Das Ausgabeverzeichnis enthält `index.html` (ein responsives, rein per CSS umgesetztes Miniaturraster mit eingebauter Vanilla-JS-Lightbox — **null** externe/CDN-Verweise, sodass es vollständig offline funktioniert), einen Ordner `assets/` mit fortlaufend benannten JPEGs (kein Bibliothekspfad wird preisgegeben) und eine `manifest.json`, die Anzahlen und Quellen pro Foto festhält. Jedes Foto bevorzugt das **Original** auf der Festplatte (auf `portfolio.max_edge` verkleinert, EXIF-Ausrichtung angewendet) und greift auf das gespeicherte 640-px-Thumbnail zurück, wenn das Original nicht erreichbar ist (offline Netzlaufwerke). Der Endpunkt ist `POST /api/albums/{album_id}/export-portfolio` (editionsbeschränkt); das `target_dir` wird gegen dieselbe Allowlist geprüft (`viewer.export.allowed_target_dirs` plus die Scan-Verzeichnisse, siehe [Konfiguration — Ziele für Export und Aussortierung](CONFIGURATION.md#ziele-für-export-und-aussortierung)) wie die Kopier-/Verschiebe-Export-Endpunkte, und Alben über `portfolio.max_photos` (Standard 500) werden abgelehnt. Ein erneuter Export desselben Albums ist idempotent — nur die eigenen Dateien des Exports werden neu geschrieben. Siehe [Portfolio-Export-Konfiguration](CONFIGURATION.md#portfolio-export).
 
 API: siehe den Abschnitt [API-Endpunkte](#api-endpunkte) weiter unten.
 
@@ -528,7 +532,7 @@ Finden Sie Personencluster, die dieselbe Person sein könnten. Zugriff über `/m
 Schreiben Sie Ihre Bewertungen, Favoriten und Ablehnungen als XMP-Sidecars auf die Festplatte, damit externe Editoren (darktable, Lightroom) sie übernehmen. Erfordert den Bearbeitungsmodus.
 
 - **Aus der Galerie** — Fotos auswählen, dann schreibt **Aktionen → Exportieren** ein Sidecar neben jede Datei.
-- **Aus einem Album** („Korb") — das gesamte Album als Sidecars exportieren oder die Dateien in ein Zielverzeichnis kopieren/verlinken.
+- **Aus einem Album** („Korb") — das gesamte Album als Sidecars exportieren oder die Dateien in ein Zielverzeichnis kopieren/verlinken (dieselbe Ziel-Allowlist wie [In Ordner aussortieren](#in-ordner-aussortieren)).
 - **Metadaten in Datei schreiben** — die Aktion „Metadaten in Datei schreiben" in der Fotodetailansicht bettet die Bewertung/Schlüsselwörter zusätzlich zum Sidecar direkt in die Originaldatei ein (JPEG/HEIC/TIFF/PNG/DNG über exiftool), sodass das gesamte Foto-Ökosystem sie sieht. Proprietäre RAW-Originale werden niemals verändert. Gesteuert über `viewer.features.show_embed_metadata` (Standard: `true`).
 
 API: siehe den Abschnitt [API-Endpunkte](#api-endpunkte) weiter unten.
@@ -1024,6 +1028,7 @@ Eine interaktive API-Dokumentation ist unter `/api/docs` (Swagger UI) verfügbar
 |----------|-------------|
 | `GET /api/photos` | Paginierte Fotoliste mit Filtern |
 | `GET /api/photo` | Details zu einem einzelnen Foto |
+| `GET /api/photo/histogram?path=&bins=` | Zeichenfertige Luminanz- + R/G/B-Bins (`bins` ∈ 32/64/128/256, Standard 64), beim Scan am Bild in voller Auflösung gemessen. Jeder Kanal wird mit einem einzigen globalen Maximum skaliert, nie mit seinem eigenen. `r`/`g`/`b` sind `null` für eine Zeile, die vor dem Kanalformat gespeichert wurde; 404, wenn die Zeile überhaupt kein Histogramm hat — das Signal für das Widget, auf das Abtasten des Vorschaubilds zurückzufallen |
 | `GET /api/type_counts` | Fotoanzahlen pro Typ |
 | `GET /api/similar_photos/{path}` | Ähnliche Fotos (Modi: `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Semantische Text-zu-Bild-Suche (`scope=text` = nur OCR-/Beschreibungstext) |

--- a/docs/es/COMMANDS.md
+++ b/docs/es/COMMANDS.md
@@ -55,7 +55,7 @@ visor expone en el campo `progress` de `/api/scan/status` y del flujo SSE.
 | `quality-face` | TOPIQ NR-Face | puntuación `face_quality_iqa` (calidad facial específica) | Compartida con TOPIQ |
 | `quality-liqe` | LIQE | `liqe_score` + diagnóstico de distorsión (desenfoque, sobreexposición, ruido) | ~2 GB |
 | `tags` | CLIP / Qwen VLM | Etiquetas semánticas del vocabulario configurado | 0-16 GB |
-| `composition` | SAMP-Net | `composition_pattern` (14 patrones) + `comp_score` | ~2 GB |
+| `composition` | SAMP-Net | `composition_pattern` (8 patrones) + `comp_score` | ~2 GB |
 | `faces` | InsightFace buffalo_l | Detección facial, puntos de referencia, detección de parpadeo, embeddings de reconocimiento | ~2 GB |
 | `embeddings` | CLIP ViT-L-14 o SigLIP 2 NaFlex | BLOB `clip_embedding` para similitud/etiquetado | 4-5 GB |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 GB |
@@ -142,6 +142,7 @@ Estos comandos actualizan métricas específicas, derivan datos nuevos (leyendas
 | `python facet.py --recompute-embeddings` | Recalcula los embeddings CLIP/SigLIP para todas las fotos (necesario tras cambiar de modelo) |
 | `python facet.py --score-topiq` | Rellena las puntuaciones de calidad TOPIQ a partir de las miniaturas almacenadas (requiere GPU) |
 | `python facet.py --backfill-focal-35mm` | Rellena la distancia focal equivalente a 35 mm desde el EXIF para las fotos que la tengan ausente |
+| `python facet.py --backfill-clipping` | Deriva los porcentajes de recorte por canal a partir de los histogramas almacenados. Solo base de datos (sin descodificar imágenes) y reanudable; las fotos cuyo histograma es anterior al formato RGB quedan como desconocidas (NULL) |
 | `python facet.py --compute-recommendations` | Analiza la base de datos y muestra un resumen de puntuación |
 | `python facet.py --compute-recommendations --verbose` | Muestra estadísticas detalladas |
 | `python facet.py --compute-recommendations --apply-recommendations` | Aplica automáticamente las correcciones de puntuación |

--- a/docs/es/COMMANDS.md
+++ b/docs/es/COMMANDS.md
@@ -217,8 +217,33 @@ Los embeddings impulsan el etiquetado semántico, la detección de duplicados, l
 | Comando | Descripción |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Corrige la rotación de las miniaturas almacenadas usando la orientación EXIF |
+| `python facet.py --refresh-thumbnails` | Reconstruye las miniaturas RAW a partir de la vista previa incorporada de la cámara |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | Lo mismo, con más lecturas en paralelo |
 
 Lee la orientación EXIF de los archivos originales y rota los bytes de la miniatura almacenada; para fotos procesadas antes de que existiera el manejo del EXIF. Solo lee la cabecera EXIF y la miniatura almacenada, no las imágenes completas.
+
+`--refresh-thumbnails` vuelve a renderizar la miniatura almacenada de cada foto RAW a través del perfil de visualización (primero la vista previa de la cámara, con el demosaicado como respaldo — consulta [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). Es la migración para una biblioteca escaneada antes de que existiera ese perfil: las miniaturas escritas por un escaneo anterior llevan el brillo automático por toma de LibRaw, que aplana las diferencias de exposición entre las tomas de un bracketing. No se carga ningún modelo y no se toca ninguna columna de puntuación — solo se reescribe `photos.thumbnail`.
+
+El comando está limitado por el rendimiento de almacenamiento más que por la CPU, así que su coste depende del tamaño de la biblioteca y de la velocidad del disco o del punto de montaje de red de la biblioteca, no del número de núcleos de la máquina. `--refresh-thumbnails-workers` (8 por defecto) define cuántos archivos se leen a la vez: auméntalo en un punto de montaje de red rápido donde cada lectura pasa el tiempo esperando, redúcelo en un disco local lento. También limita los demosaicados completos a los que recurre un RAW sin vista previa, así que valores muy altos cuestan memoria.
+
+Es reanudable. Cada lote confirmado registra hasta dónde llegó, de modo que una ejecución detenida con Ctrl+C (o por un punto de montaje caído) deja una base de datos coherente, y el siguiente `--refresh-thumbnails` continúa donde lo dejó. Una ejecución que se completa borra el marcador, así que volver a ejecutarlo más tarde empieza de nuevo.
+
+Una foto cuyo nuevo renderizado sale completamente negro conserva su miniatura existente y queda registrada por su nombre. No es paranoia: un RW2 de Panasonic gravemente truncado no falla al decodificar — LibRaw lo rellena de ceros hasta convertirlo en una toma negra válida a tamaño completo en lugar de fallar — así que sin esta comprobación, un archivo corrupto reemplazaría silenciosamente una buena miniatura por una negra. Esa foto queda sin marcar y se reintenta en la siguiente ejecución, así que basta con reparar el archivo para solucionarlo.
+
+Una foto perteneciente a un bracketing se vuelve a renderizar sin la vista previa de la cámara y sin ninguna ganancia de exposición, de modo que su miniatura muestra lo que registró el sensor (consulta [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Como la pertenencia a un bracketing proviene de la detección de secuencias, que se ejecuta después de un escaneo, ejecuta este comando después de `--detect-sequences` para que esas miniaturas reciban el renderizado.
+
+### Qué actualiza una miniatura almacenada
+
+Las miniaturas almacenadas se generan en el momento del escaneo, así que una biblioteca escaneada antes de que existiera el perfil de visualización sigue mostrando el renderizado antiguo en la cuadrícula de galería. `photos.render_version` registra qué pipeline generó la miniatura de cada fila, y dos caminos la ponen al día:
+
+| Camino | Cubre | Coste |
+|------|--------|------|
+| Un nuevo escaneo (`python facet.py <directorio>`) | Todo lo que escanea, miniatura e histograma | Escaneo completo |
+| `--refresh-thumbnails` | La miniatura de cada fila RAW | Limitado por el almacenamiento, horas en una biblioteca grande |
+
+**Nada ocurre por sí solo.** La vista de detalle siempre está al día porque `/image` se renderiza al vuelo, pero la cuadrícula de galería lee `photos.thumbnail`, y ninguna cantidad de navegación lo reescribe. Para eso está `--refresh-thumbnails`, y por eso la galería muestra un banner descartable que cuenta las filas que aún están pendientes.
+
+El recuento del banner proviene de una entrada de `stats_cache` con un TTL de una hora, actualizada directamente por `--refresh-thumbnails` y por `python database.py --refresh-stats`, así que tras un escaneo puede quedar por detrás de la realidad hasta una hora.
 
 ## Diagnóstico
 
@@ -230,6 +255,13 @@ Lee la orientación EXIF de los archivos originales y rota los bytes de la minia
 Informa de la versión de Python, la compilación de PyTorch/CUDA, la detección de GPU y el controlador, la recomendación de perfil de VRAM, las dependencias opcionales y el estado de la configuración/base de datos. Cuando PyTorch no puede ver la GPU pero `nvidia-smi` sí, imprime el comando `pip install` para corregir la compilación de CUDA.
 
 `--simulate-gpu NAME` y `--simulate-vram GB` prueban el comportamiento con hardware diferente. Ambos requieren `--doctor`; `--simulate-vram` requiere `--simulate-gpu`.
+
+| Comando | Descripción |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | Renderiza 20 fotos RAW muestreadas con los ajustes de decodificación antiguos y actuales |
+| `python facet.py --check-raw-rendering 50` | Muestrea 50 fotos en su lugar |
+
+Solo lectura: decodifica una muestra aleatoria directamente desde el disco e imprime la luminancia media que produce cada renderizado — el brillo automático por toma de LibRaw, el demosaicado de ganancia fija para las métricas y la vista previa incorporada de la cámara que usan las miniaturas y el visor. Úsalo para comprobar `raw_decode.bright` en tus propios archivos antes de lanzar un escaneo o una ejecución de `--refresh-thumbnails`; las columnas fija y vista previa conservan la escalera de exposición de un bracketing, la columna de brillo automático la aplana.
 
 ## Información de modelos
 

--- a/docs/es/CONFIGURATION.md
+++ b/docs/es/CONFIGURATION.md
@@ -20,6 +20,7 @@ Todos los ajustes están en `scoring_config.json`. Tras modificarlos, ejecuta `p
 - [Modelos](#modelos)
 - [Modelos de evaluación de calidad](#modelos-de-evaluación-de-calidad)
 - [Procesamiento](#procesamiento)
+- [Decodificación RAW](#decodificación-raw)
 - [Detección de ráfagas](#detección-de-ráfagas)
 - [Puntuación de ráfagas](#puntuación-de-ráfagas)
 - [Detección de duplicados](#detección-de-duplicados)
@@ -447,7 +448,7 @@ Selecciona qué modelos se usan por cada perfil de VRAM.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Selecciona qué modelos se usan por cada perfil de VRAM.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Selecciona qué modelos se usan por cada perfil de VRAM.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Pesos preentrenados heredados |
 | `clip_legacy.embedding_dim` | `768` | Dimensiones del embedding heredado |
 | `clip_legacy.similarity_threshold_percent` | `22` | Umbral de coincidencia de etiqueta para CLIP heredado |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Ruta de HuggingFace (VLM de composición 24gb) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Ruta de Hugging Face para la opción manual `composition_model: "qwen2-vl-2b"` — ningún perfil la selecciona por defecto |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Modelo de etiquetado para el perfil 16gb |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Imágenes por lote de inferencia VLM |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Modelo de etiquetado para el perfil 24gb |
@@ -526,7 +520,6 @@ Selecciona qué modelos se usan por cada perfil de VRAM.
 | `saliency.resolution` | `1024` | Resolución de inferencia |
 | `saliency.mask_threshold` | `0.3` | Umbral sigmoide para la máscara binaria del sujeto |
 | `saliency.min_subject_pixels` | `50` | Píxeles mínimos del sujeto para contar un sujeto como detectado |
-| `samp_net.input_size` | `384` | Tamaño de entrada del modelo de composición |
 
 ### Detección automática de VRAM
 
@@ -723,6 +716,152 @@ python facet.py /path --pass saliency      # Saliencia del sujeto BiRefNet
 # Listar los modelos disponibles
 python facet.py --list-models
 ```
+
+---
+
+## Decodificación RAW
+
+Cómo se convierten los archivos RAW en píxeles. Existen dos perfiles, y no son
+intercambiables.
+
+**Perfil de métricas** — el demosaicado a partir del cual se calcula cada
+puntuación, y el espacio de píxeles en el que viven los cuadros de rostro
+almacenados y `image_width`/`image_height`. Es deliberadamente fiel: sin
+adaptación por toma, una sola ganancia de exposición fija para toda la
+biblioteca.
+
+**Perfil de visualización** — lo que muestran la miniatura almacenada, la
+galería y `/image`. Prefiere la vista previa incorporada por la cámara, que ya
+lleva la curva tonal, los modos de rango dinámico y la exposición propios del
+modelo, y recae en el demosaicado del perfil de métricas cuando no existe una
+vista previa utilizable.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Ajuste | Predeterminado | Descripción |
+|--------|-----------------|-------------|
+| `bright` | `1.62` | Ganancia de exposición fija aplicada a cada demosaicado (`1.0` = el nivel propio de LibRaw). La única constante arbitraria aquí: coincide con el +0,7 EV predeterminado de darktable, y nada en el archivo lo impone — valídala en tu propia biblioteca con `--check-raw-rendering` antes de un escaneo grande |
+| `prefer_embedded_preview` | `true` | Genera las imágenes de visualización a partir de la vista previa de la cámara cuando existe una. `false` demosaica todo, lo cual es más lento y descarta la curva tonal de la cámara |
+| `preview_min_sensor_ratio` | `0.5` | Cuánto del sensor debe cubrir una vista previa para que `/image` la sirva en lugar de demosaicar. Nikon, Pentax, Samsung y Canon CR3 incorporan una vista previa casi a tamaño completo (0,98-0,99); Panasonic se sitúa en 0,52, mientras que Olympus, Fuji, Sony y DNG incorporan una vista previa pequeña (0,29-0,49) y por tanto se demosaican |
+| `viewer_concurrency` | `3` | Máximo de demosaicados RAW simultáneos para la ruta del visor `/image`, con un presupuesto propio separado de `processing.raw_decode_concurrency` de arriba, de modo que una petición del visor nunca hace cola detrás del trabajo de escaneo o de decodificación por CLI |
+| `faithful_bracket_render` | `true` | Renderiza una toma de horquillado sin corrección alguna: sin vista previa de la cámara, sin ganancia `bright`. Ver [más abajo](#las-tomas-de-un-horquillado-se-representan-sin-corrección). `false` renderiza los horquillados como cualquier otra foto |
+
+### Compromiso de memoria
+
+`viewer_concurrency` y `processing.raw_decode_concurrency` son presupuestos
+independientes, cada uno con su propio semáforo, y ninguno toma margen prestado
+del otro. En el peor de los casos, el proceso puede por tanto tener en curso a
+la vez demosaicados de "biblioteca + visor", cada uno con un pico de unos
+200-400 MB de datos intermedios — reduce `viewer_concurrency` en un host con
+memoria limitada. En la práctica este presupuesto está mayormente inactivo:
+solo se gasta cuando `/image` tiene que recaer en un demosaicado completo, algo
+que `preview_min_sensor_ratio` de arriba ya evita para cualquier RAW cuya vista
+previa incorporada sea suficientemente grande (Nikon, Pentax, Samsung, Canon
+CR3). Sony, Fuji, Olympus y DNG son las cámaras que realmente lo consumen.
+
+### Por qué no hay brillo automático
+
+LibRaw aclara cada toma hasta que aproximadamente el 1% de sus *propios*
+píxeles se recorta, y sustituye el píxel más brillante de esa misma toma por el
+nivel de blanco de la cámara. Ambos términos son por toma, así que un
+horquillado sale igualado: una serie Canon de 5 tomas medida, que abarca de
+-3,4 a +3,3 EV, dio luminancias medias de 54-56 para sus tres tomas oscuras,
+indistinguibles entre sí. Con la ganancia fija, la misma serie va de 8,7 a 160
+— una escala de 18x en lugar de 2,6x.
+
+Aumentar `bright` escala linealmente cada renderizado; nunca restaura el
+comportamiento por toma. Las métricas de exposición se mueven con él, así que
+vuelve a ejecutar `--recompute-average` después de cambiarlo, y vuelve a
+escanear para reescribir las métricas mismas.
+
+### Las tomas de un horquillado se representan sin corrección
+
+Una foto cuyo `sequence_kind` es `bracket` o `hdr_panorama` se muestra sin
+ninguna de las dos correcciones anteriores: sin vista previa incorporada por la
+cámara, y sin ganancia `bright`. Todo lo demás conserva el perfil de
+visualización. Un `panorama` corriente *no* es un horquillado y queda excluido
+— solo un panorama HDR, que está en horquillado en cada posición, se une aquí
+a los horquillados.
+
+La razón es que ambas correcciones comprimen las altas luces, y el margen de
+altas luces es todo el sentido de las tomas a +EV de un horquillado. La
+ganancia uniforme conserva la exposición *relativa* entre las tomas pero
+recorta el extremo brillante: a `bright` 2.0, una escala medida de 4,85x salió
+como 3,67x, siendo la diferencia solo el recorte. El JPEG incorporado de la
+cámara tiene su propia curva tonal, que comprime el mismo rango por el mismo
+motivo. Para una foto corriente eso es una imagen más favorecedora; para un
+horquillado oculta exactamente lo que el fotógrafo está juzgando.
+
+Esto se aplica a toda superficie que representa un horquillado, para que no
+puedan contradecirse: `/image` (la vista de detalle, la lupa de comparación y
+la lupa de descarte) lo renderiza así al vuelo, `--refresh-thumbnails` lo
+incorpora en `photos.thumbnail` para la tarjeta de galería y la cuadrícula de
+comparación, y `GET /api/download` con `type=original` lo convierte de la
+misma forma — una toma de horquillado descargada suele ir camino de una fusión
+HDR, donde las altas luces recortadas que introducen las demás
+representaciones serían irrecuperables.
+
+Dos tipos de descarga se dejan deliberadamente intactos: `type=raw` copia el
+archivo RAW sin tocar, y `type=darktable` es la exportación de "aspecto
+editado", cuyo propósito entero es una curva tonal. `GET
+/api/photo/cull_preview` tampoco se ve afectado — se renderiza mediante
+darktable-cli, no rawpy.
+
+*No* se aplica en el momento del escaneo, porque la detección de secuencias se
+ejecuta después de un escaneo y la pertenencia a un horquillado aún no se
+conoce — ejecuta primero `--detect-sequences`, luego `--refresh-thumbnails`,
+para que las tarjetas lo reflejen.
+
+La puntuación no se ve afectada. Las métricas se calculan a partir de
+`load_image_from_path`, que es una decodificación separada a las dimensiones
+del sensor y es donde vive cada cuadro de rostro almacenado y
+`image_width`/`image_height`; nada de esto llega a alcanzarla.
+
+Pon `faithful_bracket_render` en `false` para renderizar los horquillados como
+cualquier otra foto.
+
+### Migrar una biblioteca escaneada antes de este perfil
+
+Las miniaturas y los histogramas se generan en el momento del escaneo, así que
+cambiar el perfil no modifica retroactivamente lo que contiene una fila ya
+escaneada. `photos.render_version` registra qué pipeline produjo la miniatura
+almacenada de cada fila: `NULL` significa "de antes de la corrección", y el
+pipeline actual marca `1`.
+
+No hay nada que configurar — la marca es contabilidad, no un ajuste — pero
+conviene saber qué rutas la hacen avanzar:
+
+- **Un nuevo escaneo** reescribe la miniatura y el histograma, y marca la
+  fila.
+- **`--refresh-thumbnails`** reescribe las miniaturas RAW y las marca. Las
+  filas no se omiten según la marca, así que volver a ejecutarlo tras un
+  cambio de `bright` reconstruye todo.
+
+Esas son las únicas dos. Navegar por la biblioteca no repara nada: `/image` se
+renderiza al vuelo, así que la vista de detalle siempre está al día, pero la
+cuadrícula de galería lee `photos.thumbnail`, y solo un escaneo o
+`--refresh-thumbnails` la reescriben.
+
+El banner descartable de la galería cuenta las filas que siguen en el
+renderizado antiguo. Lee una entrada de `stats_cache` con un TTL de una hora
+en lugar de recorrer `photos` en cada carga de página, así que puede quedar
+por detrás de la realidad tras un nuevo escaneo; `python database.py
+--refresh-stats` lo recalcula de inmediato.
+
+Un renderizado que resulta completamente negro se rechaza en lugar de
+almacenarse, y la fila queda sin marcar para que una ejecución posterior lo
+reintente. LibRaw rellena de ceros un RW2 Panasonic gravemente truncado hasta
+convertirlo en una toma negra válida a tamaño completo en lugar de fallar, y
+una migración desatendida es el peor lugar para que eso pase desapercibido. El
+rechazo se registra con el nombre del archivo.
 
 ---
 
@@ -1395,6 +1534,72 @@ Visualización y comportamiento de la galería web.
 | `notification_duration_ms` | `2000` | Duración del aviso emergente |
 | `moment_confidence_min` | `0` | Por debajo de este posterior `narrative_moment_confidence` almacenado (0-1), las etiquetas de momento se muestran atenuadas con un sufijo "(incierto)" en la cabecera de Escenas, la cabecera de grupo de escena del Descarte y el tooltip de foto de la galería. `0` = nunca atenuar |
 
+### Insignias de tarjeta y recorte
+
+`viewer.badges` activa o desactiva cada insignia de la tarjeta de galería. Todas
+las insignias anteriores a este bloque valen `true` por defecto, así que omitirlo
+no cambia nada.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Clave | Predeterminado | Descripción |
+|-------|----------------|-------------|
+| `badges.favorite` | `true` | Insignia de corazón en una foto favorita (modo edición) |
+| `badges.star_rating` | `true` | Insignia de estrella y contador en una foto valorada (modo edición) |
+| `badges.rejected` | `true` | Insignia de pulgar abajo en una foto rechazada (modo edición) |
+| `badges.sequence_kind` | `true` | Insignia de horquillado/panorama, visible solo mientras la opción de ocultar contrae la serie |
+| `badges.sequence_override_pending` | `true` | Insignia de reloj para una corrección de panorama pendiente de la próxima detección |
+| `badges.keeper_hint` | `true` | Flecha «existe una toma mejor en este grupo» del modelo de selección aprendido |
+| `badges.best_of_burst` | `true` | Insignia «Mejor» en la foto principal de una ráfaga. Solo se muestra con `hide_bursts` desactivado: de lo contrario toda foto de ráfaga en pantalla ya es la principal |
+| `badges.clipping_highlight` | `true` | Insignia para una foto cuyas altas luces superan `clipping.badge_percent` |
+| `badges.clipping_shadow` | `false` | Lo mismo para sombras empastadas. Desactivada por defecto: el recorte de sombras suele ser intencionado (siluetas, noche, clave baja) |
+
+`viewer.clipping` es la definición única de «recortado» que comparten la insignia
+de la tarjeta, los marcadores del histograma y el filtro de galería, de modo que
+los tres no puedan discrepar.
+
+| Clave | Predeterminado | Descripción |
+|-------|----------------|-------------|
+| `badge_percent` | `5` | Porcentaje de píxeles, en el peor canal R/G/B, por encima del cual se marca la tarjeta. Medido sobre 28 fotos de muestra: la mediana fue 0,31 % y el p90 2,35 %, así que 5 % se activa en 1 de cada 25 fotos aproximadamente |
+| `indicator_percent` | `1` | Umbral de los marcadores R/G/B del histograma. Más fino que la insignia porque ya se está mirando una sola foto |
+| `histogram_mode` | `"rgb"` | Valor predeterminado del histograma del **panel de detalle**: `"luma"`, `"rgb"`, o un solo canal (`"r"` / `"g"` / `"b"`). La elección propia del usuario para esta superficie se guarda en `localStorage` bajo `facet_histogram_mode` y prevalece sobre este valor |
+| `tooltip_histogram_mode` | `"luma"` | Valor predeterminado del histograma del **tooltip al pasar el cursor/fijado**, los mismos cinco valores. Deliberadamente independiente de `histogram_mode` y persistido bajo su propia clave de `localStorage` (`facet_histogram_mode_tooltip`): el panel de detalle sirve para estudiar una sola foto, donde el detalle por canal se justifica; el tooltip sirve para recorrer muchas fotos rápido, donde una curva de luminancia simple suele leerse más rápido. Ajustar uno nunca reajusta el otro, y el interruptor para cambiarlo solo se muestra mientras el tooltip está fijado (panel acoplado, o `tooltip_mode: "click"`) — en modo de simple paso del cursor muestra solo su modo resuelto de solo lectura |
+
+**El recorte se mide por canal, exactamente en los bins 0 y 255.** Se almacena en
+`photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` como el porcentaje
+de píxeles del peor canal — una medida *distinta* de los indicadores
+`shadow_clipped` / `highlight_clipped`, que son binarios, cubren las bandas de
+luminancia 0–30 y 225–255 y alimentan `exposure_score`.
+
+**`NULL` significa desconocido, nunca limpio.** Una foto cuyo histograma
+almacenado es anterior al formato por canal no tiene datos de canal: no lleva
+insignia y no coincide con ningún lado del filtro. Ejecuta
+`python facet.py --backfill-clipping` para derivar las columnas de las filas que ya
+tienen un histograma completo — solo lee la base de datos, no descodifica imágenes
+y es reanudable.
+
 ### Funciones
 
 Activa o desactiva funciones opcionales para reducir el uso de memoria o simplificar la UI:
@@ -1406,7 +1611,6 @@ Activa o desactiva funciones opcionales para reducir el uso de memoria o simplif
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1423,7 +1627,6 @@ Activa o desactiva funciones opcionales para reducir el uso de memoria o simplif
 | `show_similar_button` | `true` | Mostrar el botón "Buscar similares" en las tarjetas de foto (usa numpy para la similitud CLIP) |
 | `show_merge_suggestions` | `true` | Activar la función de sugerencias de fusión en la página de gestión de personas |
 | `show_rating_controls` | `true` | Mostrar los controles de valoración por estrellas y favoritos |
-| `show_rating_badge` | `true` | Mostrar la insignia de valoración en las tarjetas de foto |
 | `show_scan_button` | `false` | Mostrar el botón de iniciar escaneo para los usuarios superadmin (requiere GPU en el host del visor) |
 | `metrics_enabled` | `false` | Activar el endpoint público de Prometheus `GET /metrics`. Desactivado por defecto: expone recuentos de fotos/personas/rostros, tamaño de la BD y memoria del proceso; actívalo solo cuando el endpoint sea accesible desde la red del scraper, no desde internet público. |
 | `show_semantic_search` | `true` | Mostrar la barra de búsqueda semántica (búsqueda de texto a imagen usando embeddings CLIP/SigLIP) |
@@ -2032,6 +2235,32 @@ python facet.py --recompute-text   # vuelve a leer toda la biblioteca
 
 **Coste.** Una miniatura de 640px tarda aproximadamente 0,4s en CPU, así que una biblioteca de 50.000 fotos es un trabajo de CPU de toda una noche — es un relleno retroactivo puntual, y los escaneos posteriores solo añaden fotos nuevas. Se usa una GPU automáticamente cuando torch informa de una.
 
+## Destinos de exportación y descarte
+
+Cualquier endpoint que copie, enlace simbólicamente o mueva archivos de fotos fuera de la biblioteca — la exportación "cesta" de un álbum (`POST /api/albums/{id}/export`, modos `copy`/`symlink`) y el descarte a carpeta (`POST /api/cull/apply`, acciones `copy_keeps` / `move_rejects`) — escribe en un `target_dir` que debe resolverse bajo una raíz permitida, o la solicitud se rechaza antes de tocar ningún archivo.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Ajuste | Predeterminado | Descripción |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(clave ausente)* | Directorios raíz adicionales en los que puede escribir una exportación copiar/symlink o un descarte-a-carpeta copiar/mover, además de los directorios de escaneo (siempre permitidos). **Ausente por defecto** — de fábrica, los únicos destinos de exportación escribibles son tus directorios de escaneo configurados |
+
+**Orden de resolución.** La lista de permitidos es primero `allowed_target_dirs`, luego cada directorio de escaneo (por usuario, compartidos y destinos de `path_mapping`) — así que exportar *dentro* del árbol de fotos no necesita configuración, pero un destino fuera de él necesita una entrada aquí. Tanto el `target_dir` solicitado como cada raíz permitida se canonicalizan con `os.path.realpath()` (enlaces simbólicos resueltos, `..` colapsados) antes de la comparación, así que un enlace simbólico que se resuelve fuera de una raíz permitida se rechaza aunque el propio enlace esté dentro de una de ellas.
+
+**Cerrado por defecto (fail-closed).** Sin ninguna raíz en absoluto — ni `allowed_target_dirs` ni directorios de escaneo configurados —, la exportación copiar/symlink/mover se rechaza por completo en lugar de recurrir a escribir en cualquier sitio. En la práctica este caso es poco frecuente una vez que has escaneado una biblioteca, ya que los directorios de escaneo siempre están en la lista de permitidos.
+
+**Solución de problemas de "acceso denegado".** Esta comprobación se ejecuta antes de cualquier acceso al sistema de archivos, así que un destino rechazado nunca toca el disco y no produce ningún traceback en los registros del servidor — un `403` aquí es una respuesta HTTP normal de una comprobación deliberada, no un error del servidor. La interfaz web actualmente muestra un aviso genérico de "Acceso denegado" para *cualquier* `403` en estos endpoints, sin indicar el motivo; abre la pestaña Red de tu navegador, busca la solicitud fallida a `/api/cull/apply` o `/api/albums/{id}/export`, y lee el campo `detail` del cuerpo de la respuesta para conocer la causa real (esta lista de permitidos, o una sesión de edición caducada). Un problema real de permisos del sistema de archivos se ve diferente: la propia solicitud tiene éxito (`200`), el recuento `errors` de la respuesta es distinto de cero, y el servidor registra un traceback completo por cada archivo fallido — consulta [Despliegue — Semántica de rutas en contenedores](DEPLOYMENT.md#semántica-de-rutas-en-contenedores) para el caso del contenedor, donde esto a menudo se confunde con una discrepancia de UID.
+
+Consulta [Visor web — Descartar a carpeta](VIEWER.md#descartar-a-carpeta) y [Visor web — Exportación al editor](VIEWER.md#exportación-al-editor).
+
 ## Exportación social
 
 Recortes con reconocimiento del sujeto para relaciones de aspecto de redes sociales (`GET /api/photo/social_crop`, restringido a edición). Cada preajuste recorta el original a resolución completa a una relación de aspecto objetivo y lo encuadra en el sujeto detectado — el mayor rectángulo de esa relación de aspecto que cabe dentro de la imagen, centrado en el sujeto y ajustado a los bordes. La caja del sujeto sigue una cadena de reserva: la caja de sujeto BiRefNet persistida (`photos.subject_bbox`) → la unión de las cajas de caras detectadas → un recorte centrado simple. Consulta [Visor web — Descarga](VIEWER.md#download).
@@ -2077,7 +2306,7 @@ Exporta un álbum como una galería HTML estática y autónoma que un fotógrafo
 | `max_edge` | `2048` | Límite del lado largo (px) para los originales exportados; la solicitud puede anularlo (acotado 256–8000) |
 | `jpeg_quality` | `88` | Calidad JPEG de las imágenes exportadas |
 
-El `target_dir` pasa por la misma lista de permitidos que los endpoints de exportación copiar/mover (`viewer.export.allowed_target_dirs` más los directorios de escaneo). Controlado por `viewer.features.show_portfolio_export` (predeterminado `true`).
+El `target_dir` pasa por la misma lista de permitidos que los endpoints de exportación copiar/mover (`viewer.export.allowed_target_dirs` más los directorios de escaneo — consulta [Destinos de exportación y descarte](#destinos-de-exportación-y-descarte)). Controlado por `viewer.features.show_portfolio_export` (predeterminado `true`).
 
 ## Marco de fotos / Quiosco
 

--- a/docs/es/CONFIGURATION.md
+++ b/docs/es/CONFIGURATION.md
@@ -1521,7 +1521,8 @@ Visualización y comportamiento de la galería web.
 | `hide_brackets` | `true` | Mostrar solo la exposición base de cada horquillado por defecto |
 | `hide_panoramas` | `true` | Mostrar solo un fotograma representativo por panorámica por defecto |
 | `hide_details` | `true` | Ocultar los detalles de la foto en las tarjetas por defecto |
-| `tooltip_mode` | `"hover"` | Activación del tooltip: `"hover"`, `"click"` u `"off"`. Sustituye al booleano `hide_tooltip` anterior. |
+| `tooltip_mode` | `"hover"` | Activación del tooltip: `"hover"`, `"click"`, `"off"` o `"panel"` (panel acoplado en lugar de un tooltip flotante — consulta `panel_activation` más abajo). Sustituye al booleano `hide_tooltip` anterior. |
+| `panel_activation` | `"both"` | Gesto que actualiza la foto seleccionada del panel acoplado cuando `tooltip_mode` es `"panel"`: `"hover"`, `"click"` o `"both"`. Sin efecto en los demás modos de tooltip. El valor predeterminado `"both"` conserva el comportamiento original del panel |
 | `hide_rejected` | `true` | Ocultar las fotos rechazadas por defecto |
 | `gallery_mode` | `"mosaic"` | Disposición de la galería por defecto (`"grid"` o `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/es/DEPLOYMENT.md
+++ b/docs/es/DEPLOYMENT.md
@@ -56,6 +56,43 @@ Se admiten varios mapeos (gana la primera coincidencia):
 - Se admiten tanto las rutas UNC (`\\server\share`) como las letras de unidad (`Z:\`)
 - Gana el primer prefijo coincidente
 
+## Semántica de rutas en contenedores
+
+Todo lo que escribas en un campo de carpeta del visor — un destino de "Descartar a carpeta", el destino de exportación copiar/symlink de un álbum, o `viewer.export.allowed_target_dirs` en `scoring_config.json` — lo resuelve el propio proceso de Facet. **En Docker/Podman ese proceso se ejecuta dentro del contenedor**, así que cada ruta es la ruta que *el contenedor* ve: el punto de montaje, nunca la ruta del lado del host.
+
+**Ejemplo.** El `docker-compose.yml` incluido monta tu carpeta de fotos en `/data/photos`:
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+Para descartar los rechazados a una subcarpeta `rejects`, escribe `/data/photos/rejects` en el diálogo — nunca la ruta del host (`/home/tu/Fotos`, `D:\Fotos`, …), que el contenedor no puede ver en absoluto. Lo mismo aplica a `viewer.export.allowed_target_dirs`: indica la ruta del lado del contenedor.
+
+Para escribir en un sitio distinto del árbol de fotos escaneado — un volumen de exportación separado, por ejemplo —, móntalo primero en el contenedor y luego añade su ruta del lado del contenedor a `viewer.export.allowed_target_dirs`:
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # volumen adicional para la salida de cull/export
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+Un destino que se resuelve fuera de todo volumen montado se rechaza (`403`) — la comprobación de target-dir de Facet ejecuta `os.path.realpath()` tanto en la solicitud *como* en cada raíz permitida, resolviendo enlaces simbólicos y `..` antes de comparar, así que una ruta que solo parece correcta desde fuera del contenedor (o un enlace simbólico que apunta fuera de un montaje) sigue fallando la prueba de contención. Consulta [Configuración — Destinos de exportación y descarte](CONFIGURATION.md#destinos-de-exportación-y-descarte) para la referencia completa de la lista de permitidos.
+
+**Esto no es un problema de permisos del usuario del contenedor.** El UID del usuario `facet` dentro del contenedor suele diferir del de tu cuenta del host, y eso puede causar un problema real y separado de permisos del sistema de archivos en un montaje bind — pero eso ocurre *después* de que esta comprobación de ruta se supera, cuando la copia/symlink/movimiento se ejecuta realmente, y se registra en el servidor con el error del sistema operativo subyacente para el archivo fallido. Un `403 target_dir is not an allowed export location` (o un "acceso denegado" genérico en la interfaz) ocurre *antes* de que se toque ningún archivo y no tiene nada que ver con los UID.
+
 ## Compilar el cliente Angular
 
 El servidor FastAPI sirve la SPA precompilada desde `client/dist/client/browser/`. Compílala antes del despliegue:
@@ -101,7 +138,8 @@ python database.py --export-viewer-db
 ```
 
 Esto crea `photo_scores_viewer.db`, que:
-- Elimina los embeddings de CLIP, los datos de histograma y los embeddings faciales
+- Elimina los embeddings de CLIP, los embeddings de subtítulos y los embeddings faciales
+- Conserva el histograma por foto (~2 KB cada uno), que lee el widget de histograma RGB de la galería
 - Reduce las miniaturas de 640px a 320px
 - Normalmente reduce una base de datos de 14 GB a ~4-5 GB
 
@@ -220,9 +258,12 @@ Raspberry Pi, compílala localmente con `docker compose build` en lugar de desca
 `docker compose up` mantiene `build: .` bajo la clave `image:` precisamente para este
 caso.
 
-**Presupuesta el disco.** La imagen CPU pesa ~3,3 GB y la imagen CUDA ~21 GB, más los
-pesos de los modelos que cada perfil descarga en el primer arranque (~3–4 GB para
-`legacy`/`8gb`, ~10–11 GB para `16gb`, ~18 GB para `24gb` — tabla completa en
+**Presupuesta el disco.** Ya descomprimida, la imagen CPU pesa aproximadamente 3,3 GB
+en disco y la imagen CUDA aproximadamente 21 GB (cifras aproximadas, no reverificadas
+contra la build actual; la propia descarga transfiere menos, comprimida — ver
+[Tamaño de la imagen](#tamaño-de-la-imagen) más abajo), más los pesos de los modelos que
+cada perfil descarga en el primer arranque (`legacy` 4,69 GB, `8gb` 6,93 GB, `16gb`
+14,55 GB, `24gb` 19,13 GB — tabla completa en
 [Instalación › Tamaños de descarga](INSTALLATION.md#tamaños-de-descarga)). `docker
 compose down -v` elimina los volúmenes de modelos y fuerza una nueva descarga.
 
@@ -347,10 +388,16 @@ descargan en el primer arranque en los volúmenes con nombre
 ([totales por perfil](INSTALLATION.md#tamaños-de-descarga)). Presupuesta espacio en disco
 para la imagen **más** esos volúmenes.
 
-| Imagen | Tamaño medido | Base |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3,3 GB | `python:3.12-slim` + PyTorch en wheels de CPU |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+| Imagen | Descarga comprimida | En disco (aprox.) | Base |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4,18 GB | ~3,3 GB | `python:3.12-slim` + PyTorch en wheels de CPU |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7,33 GB | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+
+La "descarga comprimida" es lo que transfiere `docker pull`, medida a partir de los
+manifiestos actuales del registro `ghcr.io/ncoevoet/facet`. El valor "en disco" es el
+tamaño de la imagen ya descomprimida; esas cifras no se han reverificado contra el
+digest `:latest` actual en esta pasada, así que trátalas como una cifra aproximada de
+planificación y no como una medición actual precisa.
 
 En la imagen CPU predomina la pila de dependencias ML (~1,9 GB) más que PyTorch en sí
 (~960 MB), más las bibliotecas del sistema (~288 MB) y el SO base (~150 MB). En la imagen

--- a/docs/es/INSTALLATION.md
+++ b/docs/es/INSTALLATION.md
@@ -154,7 +154,8 @@ Usa [Docker](#instalar-con-docker). Para usar una tarjeta NVIDIA en Windows, sig
 ## Primera ejecución: qué esperar
 
 - **Una descarga.** El primer escaneo obtiene los modelos de IA de tu perfil —
-  aproximadamente 3–4 GB para `legacy` y `8gb`, 10–11 GB para `16gb`, 18 GB para `24gb`.
+  aproximadamente 4,7 GB para `legacy`, 6,9 GB para `8gb`, 14,6 GB para `16gb`, 19,1 GB
+  para `24gb` (desglose completo en [Tamaños de descarga](#tamaños-de-descarga)).
   Esto ocurre una sola vez; las siguientes ejecuciones arrancan de inmediato.
 - **Sin configuración.** No hay nada que configurar. Facet crea su base de datos en el
   primer escaneo y viene con ajustes que funcionan de fábrica.
@@ -236,8 +237,11 @@ Los archivos por perfil (`docker-compose.legacy.yml`, `docker-compose.8gb.yml`,
 al `vram_profile` propio de la configuración (predeterminado `auto`).
 
 Se publican dos imágenes desde un único `Dockerfile`: `ghcr.io/ncoevoet/facet:latest` es
-una compilación ligera para CPU (~3,3 GB), `ghcr.io/ncoevoet/facet:latest-cuda` incluye
-CUDA y RAPIDS cuML (~21 GB) y es la que descargan los perfiles de GPU. Ambas son
+una compilación ligera para CPU (~3,3 GB descomprimidos en disco, valor aproximado —
+descargarla transfiere menos, 4,18 GB comprimidos; ver
+[Tamaños de descarga](#tamaños-de-descarga)), `ghcr.io/ncoevoet/facet:latest-cuda`
+incluye CUDA y RAPIDS cuML (~21 GB descomprimidos en disco, aproximado; 7,33 GB
+comprimidos para descargar) y es la que descargan los perfiles de GPU. Ambas son
 únicamente `linux/amd64` — en una máquina ARM, compila en local con `docker compose
 build` en lugar de descargar. `docker compose build` (o `up --build`) siempre compila
 desde este repositorio; consulta los argumentos de compilación `BASE_IMAGE`,
@@ -399,22 +403,56 @@ cual, así que define uno para anular estos umbrales en cualquiera de los dos se
 
 ## Tamaños de descarga
 
-Los modelos se descargan en el primer uso a `~/.cache/` y `~/.insightface/` (o a los
-volúmenes con nombre de Docker). Ningún peso de modelo viene integrado en la imagen.
+Los modelos se descargan en el primer uso a `~/.cache/huggingface/` (modelos Hugging
+Face), `~/.cache/torch/hub/` (pesos de PyIQA) y `~/.insightface/` (detección/reconocimiento
+facial), o a los volúmenes con nombre de Docker. `samp_net.pth`, `u2netp.pth`,
+`face_landmarker.task` y el `aesthetic_predictor_weights.pth` de la cabeza estética CLIP-MLP
+(solo `legacy`/`8gb`) van todos a `pretrained_models/`, resuelto respecto a la raíz del
+repositorio y no al directorio de trabajo del proceso — en Docker eso es el volumen montado
+`facet-pretrained`, así que ninguno de ellos se vuelve a descargar al recrear el
+contenedor. Ningún peso de modelo viene integrado en la imagen.
+
+Los tamaños siguientes son decimales (GB = 10⁹ bytes, MB = 10⁶ bytes), medidos a partir
+de las cachés de modelos locales y de la API de Hugging Face.
 
 | Modelo | Tamaño | Perfiles |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (embeddings + etiquetado) | ~1,6 GB | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (embeddings) | ~4,3 GB | `16gb`/`24gb` |
-| Qwen3.5-2B (etiquetado VLM) | ~4,2 GB | `16gb` |
-| Qwen3.5-4B (etiquetado VLM) | ~8 GB | `24gb` |
-| Qwen2-VL-2B (composición) | ~4,2 GB | `24gb` |
-| InsightFace buffalo_l (rostros) | ~600 MB | todos |
-| Pesos de SAMP-Net (composición) | ~175 MB | todos (`24gb` usa Qwen2-VL en su lugar) |
-| BiRefNet_dynamic (saliencia del sujeto) | ~424 MB | todos |
-| U2-Net-P (ayuda de saliencia) | ~5 MB | todos |
+| CLIP ViT-L-14 laion2b (embeddings + etiquetado CLIP + estética CLIP-MLP) | 1,711 GB | `legacy`/`8gb` |
+| Cabeza estética MLP (`sac+logos+ava1-l14-linearMSE.pth`) | 3,7 MB | solo `legacy`/`8gb` |
+| SigLIP 2 NaFlex SO400M (embeddings) | 4,581 GB | `16gb`/`24gb` |
+| Qwen3.5-2B (etiquetado VLM) | 4,571 GB | `16gb` |
+| Qwen3.5-4B (etiquetado VLM) | 9,343 GB | `24gb` |
+| Qwen2-VL-2B (composición) | 4,430 GB | ninguno por defecto — solo si estableces manualmente `composition_model: "qwen2-vl-2b"` **y** `processing.mode: "single-pass"` |
+| InsightFace buffalo_l (rostros) | 289 MB de descarga / 630 MB en disco (el zip se conserva junto a los archivos `.onnx` extraídos) | todos |
+| Pesos de SAMP-Net (composición) | 183 MB | todos |
+| U2-Net-P (submodelo de saliencia de SAMP-Net) | 4,7 MB | los mismos perfiles que SAMP-Net |
+| BiRefNet_dynamic (saliencia del sujeto) | 445 MB | todos |
+| TOPIQ NR (modelo estético) | 181 MB | `16gb`/`24gb` |
+| TOPIQ IAA (estética complementaria) | 873 MB | todos |
+| TOPIQ NR-Face (calidad facial complementaria) | 376 MB | todos |
+| LIQE (calidad/distorsión complementaria) | 708 MB | todos |
+| timm resnet50.a1_in1k (backbone PyIQA compartido) | 102 MB | todos |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2,235 GB | `8gb`/`16gb`/`24gb`, **activado por defecto** (`"auto"` se resuelve como activado en todos los perfiles salvo `legacy`) |
 
-Totales por perfil: `legacy`/`8gb` ~3–4 GB · `16gb` ~10–11 GB · `24gb` ~18 GB.
+Totales por perfil (descarga): `legacy` 4,69 GB · `8gb` 6,93 GB · `16gb` 14,55 GB ·
+`24gb` 19,32 GB · `24gb` con `composition_model: "qwen2-vl-2b"` y
+`processing.mode: "single-pass"` 23,56 GB (la sustitución manual reemplaza a
+SAMP-Net/U2-Net-P en lugar de sumarse a ellos).
+
+Como referencia, descargar la propia imagen de Docker (antes de cualquier descarga de
+modelos) transfiere `ghcr.io/ncoevoet/facet:latest` con 4,18 GB comprimidos y
+`:latest-cuda` con 7,33 GB comprimidos, según los manifiestos actuales del registro.
+
+Modelos opcionales no incluidos en los totales anteriores:
+
+| Modelo | Tamaño | Activación |
+|-------|------|----------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16,41 GB | desactivado por defecto |
+| Backbone SigLIP so400m-patch14-384 (`iqa_extended.aesthetic_v25`) | 3,515 GB | desactivado por defecto, **obsoleto** (AGPL-3.0, sin mantenimiento upstream — se prefiere `qrealign`) |
+| Helsinki-NLP OPUS-MT, por idioma de destino (traducción de leyendas) | en→fr 303 MB · en→de 298 MB · en→es 312 MB · en→it 343 MB · en→pt 465 MB | solo para los idiomas activados |
+| MediaPipe `face_landmarker.task` | 3,76 MB | solo si `mediapipe` está instalado |
+
+`reverse_geocoder` no necesita ninguna descarga: sus datos van incluidos en el wheel.
 
 Los pesos de SAMP-Net provienen de la
 [versión model-weights-v1](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth)

--- a/docs/es/VIEWER.md
+++ b/docs/es/VIEWER.md
@@ -155,10 +155,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Patrones de composición
 
-Filtra por los patrones detectados por SAMP-Net:
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Filtra por los patrones detectados por SAMP-Net (el modelo emite exactamente estos
+8, en `models/samp_net.py`):
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Ordenación
 
@@ -215,6 +215,10 @@ Un control **Conservar % superior** en la barra de herramientas de la galería (
 ### Descartar a carpeta
 
 El diálogo **Descartar a carpeta…** de la barra de acciones masivas (modo edición) copia los conservados, o mueve/envía a la papelera los descartados, a una carpeta de destino en un solo paso (la papelera del sistema está condicionada por `viewer.cull.allow_trash`, nunca un borrado permanente). Aplicar es seguro por construcción: `POST /api/cull/apply` nunca confía a ciegas en una lista de eliminación proporcionada por el cliente — vuelve a derivar en el servidor el conjunto real de la acción a partir del estado `is_rejected` propio de cada foto (copiar actúa solo sobre los conservados, mover/papelera solo sobre los descartados) y reporta todo lo que quede fuera de ese alcance como `excluded_by_state` en lugar de actuar sobre ello. Cada llamada usa por defecto una simulación (dry run) — siempre se ejecuta una vista previa antes de escribir nada — y mover/papelera requieren un `dry_run=false` explícito para proceder; incluir el RAW o el sidecar intacto de una foto descartada es opcional (`include_companions`), de modo que descartar un JPEG derivado nunca arrastra silenciosamente su RAW. Varias herramientas fotográficas comerciales han tenido errores de selección de eliminación que afectaron a las fotos equivocadas; el endpoint de aplicación de Facet está diseñado para que el cliente nunca pueda especificar directamente un conjunto a eliminar.
+
+**Dónde puedes escribir.** Sin `viewer.export.allowed_target_dirs` configurado, las únicas carpetas en las que Facet puede escribir son tus directorios de escaneo — apunta el diálogo a una subcarpeta del árbol de fotos (por ejemplo, `_rejected`) y funciona sin configuración. Para usar una carpeta fuera del árbol escaneado, añádela primero a `viewer.export.allowed_target_dirs`; cualquier otra cosa se rechaza con un `403`, independientemente de los permisos del sistema de archivos. Consulta [Configuración — Destinos de exportación y descarte](CONFIGURATION.md#destinos-de-exportación-y-descarte). Al ejecutarse en Docker/Podman, la ruta que escribes se resuelve **dentro del contenedor**, contra lo que realmente está montado allí — nunca contra el sistema de archivos del host — consulta [Despliegue — Semántica de rutas en contenedores](DEPLOYMENT.md#semántica-de-rutas-en-contenedores).
+
+**"Acceso denegado" en cada acción.** Eso es un `403` — un rechazo deliberado de la comprobación de carpeta de destino anterior, o una sesión de edición caducada — no un problema de permisos del sistema de archivos o del usuario del contenedor. El aviso no indica cuál de los dos es; comprueba el cuerpo de la respuesta de la solicitud fallida en la pestaña Red de tu navegador para ver el campo `detail`. Un problema real de permisos del sistema de archivos se ve diferente: la acción reporta un éxito parcial con un recuento `errors` distinto de cero, y el servidor registra el error del sistema operativo subyacente para cada archivo fallido.
 
 ### Opciones de visualización
 
@@ -317,7 +321,7 @@ Cada álbum puede llevar un contexto de puntuación que decide qué categoría g
 
 ### Exportación de portafolio
 
-Cuando `viewer.features.show_portfolio_export` es `true` (predeterminado) y la edición está desbloqueada, cada tarjeta de álbum manual obtiene una acción **Exportar portafolio**. Abre un pequeño diálogo (título de la galería, carpeta de destino, interruptor de inclusión de subtítulos) y renderiza el álbum como una galería HTML estática autónoma — el caso de uso de thumbsup/sigal, pero nativo, sin dependencia de herramientas externas. El directorio de salida contiene `index.html` (una cuadrícula de miniaturas responsiva solo con CSS con una lightbox vanilla-JS integrada — **cero** referencias externas/CDN, por lo que funciona completamente sin conexión), una carpeta `assets/` con JPEG nombrados secuencialmente (no se filtra ninguna ruta de la biblioteca) y un `manifest.json` que registra los recuentos y las fuentes por foto. Cada foto prefiere el **original** en disco (reducido a `portfolio.max_edge`, con la orientación EXIF aplicada) y recurre a la miniatura de 640 px almacenada cuando el original es inaccesible (recursos de red sin conexión). El endpoint es `POST /api/albums/{album_id}/export-portfolio` (solo edición); el `target_dir` se valida contra la misma lista de permitidos (`viewer.export.allowed_target_dirs` más los directorios de escaneo) que los endpoints de exportación copiar/mover, y los álbumes que superan `portfolio.max_photos` (predeterminado 500) se rechazan. Reexportar el mismo álbum es idempotente — solo se reescriben los propios archivos de la exportación. Consulta [Configuración de la exportación de portafolio](CONFIGURATION.md#exportación-de-portafolio).
+Cuando `viewer.features.show_portfolio_export` es `true` (predeterminado) y la edición está desbloqueada, cada tarjeta de álbum manual obtiene una acción **Exportar portafolio**. Abre un pequeño diálogo (título de la galería, carpeta de destino, interruptor de inclusión de subtítulos) y renderiza el álbum como una galería HTML estática autónoma — el caso de uso de thumbsup/sigal, pero nativo, sin dependencia de herramientas externas. El directorio de salida contiene `index.html` (una cuadrícula de miniaturas responsiva solo con CSS con una lightbox vanilla-JS integrada — **cero** referencias externas/CDN, por lo que funciona completamente sin conexión), una carpeta `assets/` con JPEG nombrados secuencialmente (no se filtra ninguna ruta de la biblioteca) y un `manifest.json` que registra los recuentos y las fuentes por foto. Cada foto prefiere el **original** en disco (reducido a `portfolio.max_edge`, con la orientación EXIF aplicada) y recurre a la miniatura de 640 px almacenada cuando el original es inaccesible (recursos de red sin conexión). El endpoint es `POST /api/albums/{album_id}/export-portfolio` (solo edición); el `target_dir` se valida contra la misma lista de permitidos (`viewer.export.allowed_target_dirs` más los directorios de escaneo, consulta [Configuración — Destinos de exportación y descarte](CONFIGURATION.md#destinos-de-exportación-y-descarte)) que los endpoints de exportación copiar/mover, y los álbumes que superan `portfolio.max_photos` (predeterminado 500) se rechazan. Reexportar el mismo álbum es idempotente — solo se reescriben los propios archivos de la exportación. Consulta [Configuración de la exportación de portafolio](CONFIGURATION.md#exportación-de-portafolio).
 
 API: consulta la sección [Endpoints de la API](#endpoints-de-la-api) más abajo.
 
@@ -527,7 +531,7 @@ Encuentra grupos de personas que podrían ser el mismo individuo. Accede mediant
 Escribe tus valoraciones, favoritos y descartes en el disco como sidecars XMP, para que los editores externos (darktable, Lightroom) los recojan. Requiere el modo de edición.
 
 - **Desde la galería** — selecciona fotos, y luego **Acciones → Exportar** escribe un sidecar junto a cada archivo.
-- **Desde un álbum** ("cesta") — exporta todo el álbum como sidecars, o copia/enlaza simbólicamente los archivos a un directorio de destino.
+- **Desde un álbum** ("cesta") — exporta todo el álbum como sidecars, o copia/enlaza simbólicamente los archivos a un directorio de destino (misma lista de destinos permitidos que [Descartar a carpeta](#descartar-a-carpeta)).
 - **Escribir metadatos en el archivo** — la acción "Escribir metadatos en el archivo" del detalle de la foto incrusta la valoración/palabras clave directamente en el archivo original (JPEG/HEIC/TIFF/PNG/DNG mediante exiftool) además de escribir el sidecar, para que todo el ecosistema fotográfico las vea. Los originales RAW propietarios nunca se modifican. Controlado por `viewer.features.show_embed_metadata` (predeterminado: `true`).
 
 API: consulta la sección [Endpoints de la API](#endpoints-de-la-api) más abajo.
@@ -1022,6 +1026,7 @@ La documentación interactiva de la API está disponible en `/api/docs` (Swagger
 |----------|-------------|
 | `GET /api/photos` | Lista paginada de fotos con filtros |
 | `GET /api/photo` | Detalles de una sola foto |
+| `GET /api/photo/histogram?path=&bins=` | Bins de luminancia + R/G/B listos para dibujar (`bins` ∈ 32/64/128/256, 64 por defecto), medidos durante el análisis sobre la imagen a resolución completa. Cada canal se escala por un único máximo global, nunca por el suyo. `r`/`g`/`b` son `null` para una fila guardada antes del formato por canal; 404 cuando la fila no tiene histograma alguno, la señal para que el widget recurra al muestreo de la miniatura |
 | `GET /api/type_counts` | Recuentos de fotos por tipo |
 | `GET /api/similar_photos/{path}` | Fotos similares (modos: `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Búsqueda semántica de texto a imagen (`scope=text` = solo texto de OCR/subtítulos) |

--- a/docs/es/VIEWER.md
+++ b/docs/es/VIEWER.md
@@ -1026,6 +1026,7 @@ La documentación interactiva de la API está disponible en `/api/docs` (Swagger
 |----------|-------------|
 | `GET /api/photos` | Lista paginada de fotos con filtros |
 | `GET /api/photo` | Detalles de una sola foto |
+| `GET /api/photo/set?path=` | El conjunto horquillado/panorama/hdr_panorama/ráfaga/duplicada al que pertenece una foto (la secuencia tiene prioridad sobre la ráfaga, la ráfaga sobre la duplicada), indexado por `path` — nunca un id de grupo, que los pases de horquillado y panorama renumeran cada uno desde 1 en cada ejecución |
 | `GET /api/photo/histogram?path=&bins=` | Bins de luminancia + R/G/B listos para dibujar (`bins` ∈ 32/64/128/256, 64 por defecto), medidos durante el análisis sobre la imagen a resolución completa. Cada canal se escala por un único máximo global, nunca por el suyo. `r`/`g`/`b` son `null` para una fila guardada antes del formato por canal; 404 cuando la fila no tiene histograma alguno, la señal para que el widget recurra al muestreo de la miniatura |
 | `GET /api/type_counts` | Recuentos de fotos por tipo |
 | `GET /api/similar_photos/{path}` | Fotos similares (modos: `visual`, `color`, `person`) |

--- a/docs/fr/COMMANDS.md
+++ b/docs/fr/COMMANDS.md
@@ -217,8 +217,33 @@ Les embeddings alimentent l'étiquetage sémantique, la détection de doublons, 
 | Commande | Description |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Corrige la rotation des miniatures stockées en utilisant l'orientation EXIF |
+| `python facet.py --refresh-thumbnails` | Reconstruit les miniatures RAW à partir de l'aperçu intégré par le boîtier |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | Idem, avec plus de lectures en parallèle |
 
 Lit l'orientation EXIF des fichiers originaux et fait pivoter les octets de la miniature stockée ; pour les photos traitées avant l'existence de la gestion EXIF. Ne lit que l'en-tête EXIF et la miniature stockée, pas les images complètes.
+
+`--refresh-thumbnails` régénère la miniature stockée de chaque photo RAW à travers le profil d'affichage (aperçu du boîtier en priorité, démosaïçage en repli — voir [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). C'est la migration pour une bibliothèque scannée avant l'existence de ce profil : les miniatures écrites par un scan plus ancien portent la luminosité automatique par vue de LibRaw, qui aplatit les écarts d'exposition entre les vues d'un bracketing. Aucun modèle n'est chargé et aucune colonne de score n'est modifiée — seul `photos.thumbnail` est réécrit.
+
+La commande est limitée par le débit de stockage plutôt que par le CPU, donc son coût dépend de la taille de la bibliothèque et de la vitesse du disque ou du montage réseau de la bibliothèque, pas du nombre de cœurs de la machine. `--refresh-thumbnails-workers` (8 par défaut) définit le nombre de fichiers lus en parallèle : augmentez-le sur un montage réseau rapide où chaque lecture passe son temps à attendre, réduisez-le sur un disque local lent. Cela borne aussi les démosaïçages complets vers lesquels bascule un RAW sans aperçu, donc des valeurs très élevées coûtent en mémoire.
+
+Elle est reprenable. Chaque lot validé enregistre jusqu'où il est allé, si bien qu'une exécution interrompue par Ctrl+C (ou par un montage perdu) laisse une base de données cohérente, et le `--refresh-thumbnails` suivant reprend où il s'était arrêté. Une exécution qui se termine efface le marqueur, donc la relancer plus tard repart de zéro.
+
+Une photo dont le nouveau rendu revient entièrement noir conserve sa miniature existante et est journalisée par son nom. Ce n'est pas de la paranoïa : un RW2 Panasonic sévèrement tronqué n'échoue pas au décodage — LibRaw le remplit de zéros pour en faire une vue noire pleine taille valide au lieu d'échouer — donc sans cette vérification, un fichier corrompu remplacerait silencieusement une bonne miniature par une noire. Une telle photo reste sans marqueur et est retentée à l'exécution suivante, donc réparer le fichier suffit à corriger le problème.
+
+Une photo appartenant à un bracketing est rendue à nouveau sans l'aperçu du boîtier et sans aucun gain d'exposition, si bien que sa vignette montre ce que le capteur a enregistré (voir [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Comme l'appartenance à un bracketing provient de la détection de séquences, qui s'exécute après un scan, lancez cette commande après `--detect-sequences` pour que ces vignettes récupèrent le rendu.
+
+### Ce qui met à jour une miniature stockée
+
+Les miniatures stockées sont figées au moment du scan, donc une bibliothèque scannée avant l'existence du profil d'affichage continue d'afficher l'ancien rendu dans la grille de galerie. `photos.render_version` enregistre quel pipeline a produit la miniature de chaque ligne, et deux chemins la mettent à jour :
+
+| Chemin | Couvre | Coût |
+|------|--------|------|
+| Un rescan (`python facet.py <répertoire>`) | Tout ce qu'il scanne, miniature et histogramme | Analyse complète |
+| `--refresh-thumbnails` | La miniature de chaque ligne RAW | Limité par le stockage, des heures sur une grande bibliothèque |
+
+**Rien ne se passe tout seul.** La vue détail est toujours à jour car `/image` s'affiche à la volée, mais la grille de galerie sert `photos.thumbnail`, et aucune navigation ne le réécrit. C'est à cela que sert `--refresh-thumbnails`, et c'est pourquoi la galerie affiche une bannière rejetable comptant les lignes encore en attente.
+
+Le compte de la bannière provient du cache de statistiques avec un TTL d'une heure, actualisé directement par `--refresh-thumbnails` et par `python database.py --refresh-stats`, donc après un scan il peut retarder par rapport à la réalité jusqu'à une heure.
 
 ## Diagnostics
 
@@ -230,6 +255,13 @@ Lit l'orientation EXIF des fichiers originaux et fait pivoter les octets de la m
 Rapporte la version de Python, la build PyTorch/CUDA, la détection du GPU et du pilote, la recommandation de profil VRAM, les dépendances optionnelles et l'état de la config/base de données. Lorsque PyTorch ne voit pas le GPU mais que `nvidia-smi` le voit, il affiche la commande `pip install` pour corriger la build CUDA.
 
 `--simulate-gpu NAME` et `--simulate-vram GB` testent le comportement avec différents matériels. Les deux nécessitent `--doctor` ; `--simulate-vram` nécessite `--simulate-gpu`.
+
+| Commande | Description |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | Rend 20 photos RAW échantillonnées avec les anciens et les nouveaux réglages de décodage |
+| `python facet.py --check-raw-rendering 50` | Échantillonne 50 photos à la place |
+
+Lecture seule : elle décode un échantillon aléatoire directement depuis le disque et affiche la luminance moyenne produite par chaque rendu — la luminosité automatique par vue de LibRaw, le démosaïçage à gain fixe des métriques, et l'aperçu intégré par le boîtier utilisé par les miniatures et la visionneuse. Utilisez-la pour vérifier `raw_decode.bright` sur vos propres fichiers avant de lancer un scan ou une exécution de `--refresh-thumbnails` ; les colonnes fixe et aperçu conservent l'échelle d'exposition d'un bracketing, la colonne luminosité automatique l'aplatit.
 
 ## Informations sur les modèles
 

--- a/docs/fr/COMMANDS.md
+++ b/docs/fr/COMMANDS.md
@@ -55,7 +55,7 @@ visionneuse expose dans le champ `progress` de `/api/scan/status` et du flux SSE
 | `quality-face` | TOPIQ NR-Face | Score `face_quality_iqa` (qualité de visage dédiée) | Partagé avec TOPIQ |
 | `quality-liqe` | LIQE | Score `liqe_score` + diagnostic de distorsion (flou, surexposition, bruit) | ~2 Go |
 | `tags` | CLIP / Qwen VLM | Étiquettes sémantiques depuis le vocabulaire configuré | 0-16 Go |
-| `composition` | SAMP-Net | `composition_pattern` (14 motifs) + `comp_score` | ~2 Go |
+| `composition` | SAMP-Net | `composition_pattern` (8 motifs) + `comp_score` | ~2 Go |
 | `faces` | InsightFace buffalo_l | Détection de visages, points de repère, détection de clignement, embeddings de reconnaissance | ~2 Go |
 | `embeddings` | CLIP ViT-L-14 ou SigLIP 2 NaFlex | BLOB `clip_embedding` pour similarité/étiquetage | 4-5 Go |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 Go |
@@ -142,6 +142,7 @@ Ces commandes mettent à jour des métriques spécifiques, dérivent de nouvelle
 | `python facet.py --recompute-embeddings` | Recalcule les embeddings CLIP/SigLIP pour toutes les photos (requis après un changement de modèle) |
 | `python facet.py --score-topiq` | Remplit les scores de qualité TOPIQ à partir des miniatures stockées (GPU requis) |
 | `python facet.py --backfill-focal-35mm` | Remplit la focale équivalente 35 mm depuis l'EXIF pour les photos qui en manquent |
+| `python facet.py --backfill-clipping` | Dérive les pourcentages d'écrêtage par canal depuis les histogrammes stockés. Base de données uniquement (aucun décodage d'image) et reprenable ; les photos dont l'histogramme précède le format RVB restent inconnues (NULL) |
 | `python facet.py --compute-recommendations` | Analyse la base de données, affiche un résumé de notation |
 | `python facet.py --compute-recommendations --verbose` | Affiche des statistiques détaillées |
 | `python facet.py --compute-recommendations --apply-recommendations` | Applique automatiquement les correctifs de notation |

--- a/docs/fr/CONFIGURATION.md
+++ b/docs/fr/CONFIGURATION.md
@@ -1517,7 +1517,8 @@ Affichage et comportement de la galerie web.
 | `hide_brackets` | `true` | Afficher uniquement l'exposition de base de chaque bracketing par défaut |
 | `hide_panoramas` | `true` | N'afficher qu'une image représentative par panorama par défaut |
 | `hide_details` | `true` | Masquer les détails des photos sur les cartes par défaut |
-| `tooltip_mode` | `"hover"` | Déclencheur d'infobulle : `"hover"`, `"click"` ou `"off"`. Remplace l'ancien booléen `hide_tooltip`. |
+| `tooltip_mode` | `"hover"` | Déclencheur d'infobulle : `"hover"`, `"click"`, `"off"` ou `"panel"` (rail ancré au lieu d'une infobulle flottante — voir `panel_activation` ci-dessous). Remplace l'ancien booléen `hide_tooltip`. |
+| `panel_activation` | `"both"` | Geste qui redirige la photo sélectionnée du rail ancré quand `tooltip_mode` vaut `"panel"` : `"hover"`, `"click"` ou `"both"`. Sans effet sur les autres modes d'infobulle. La valeur par défaut `"both"` préserve le comportement d'origine du panneau |
 | `hide_rejected` | `true` | Masquer les photos rejetées par défaut |
 | `gallery_mode` | `"mosaic"` | Disposition de galerie par défaut (`"grid"` ou `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/fr/CONFIGURATION.md
+++ b/docs/fr/CONFIGURATION.md
@@ -20,6 +20,7 @@ Tous les réglages se trouvent dans `scoring_config.json`. Après modification, 
 - [Modèles](#models)
 - [Modèles d'évaluation de la qualité](#quality-assessment-models)
 - [Traitement](#processing)
+- [Décodage RAW](#décodage-raw)
 - [Détection de rafales](#burst-detection)
 - [Notation des rafales](#burst-scoring)
 - [Détection de doublons](#duplicate-detection)
@@ -447,7 +448,7 @@ Sélectionne les modèles utilisés selon le profil VRAM.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Sélectionne les modèles utilisés selon le profil VRAM.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Sélectionne les modèles utilisés selon le profil VRAM.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Poids pré-entraînés historiques |
 | `clip_legacy.embedding_dim` | `768` | Dimensions de l'embedding historique |
 | `clip_legacy.similarity_threshold_percent` | `22` | Seuil de correspondance d'étiquette pour le CLIP historique |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Chemin HuggingFace (VLM de composition 24gb) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Chemin HuggingFace pour l'option manuelle `composition_model: "qwen2-vl-2b"` — aucun profil ne la sélectionne par défaut |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Modèle d'étiquetage pour le profil 16gb |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Images par lot d'inférence VLM |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Modèle d'étiquetage pour le profil 24gb |
@@ -526,7 +520,6 @@ Sélectionne les modèles utilisés selon le profil VRAM.
 | `saliency.resolution` | `1024` | Résolution d'inférence |
 | `saliency.mask_threshold` | `0.3` | Seuil sigmoïde pour le masque binaire du sujet |
 | `saliency.min_subject_pixels` | `50` | Nombre minimal de pixels de sujet pour considérer qu'un sujet est détecté |
-| `samp_net.input_size` | `384` | Taille d'entrée du modèle de composition |
 
 ### Détection automatique de la VRAM
 
@@ -723,6 +716,144 @@ python facet.py /path --pass saliency      # Saillance du sujet BiRefNet
 # Lister les modèles disponibles
 python facet.py --list-models
 ```
+
+---
+
+## Décodage RAW
+
+Comment les fichiers RAW sont transformés en pixels. Deux profils existent, et ils ne
+sont pas interchangeables.
+
+**Profil métriques** — le démosaïçage à partir duquel chaque score est calculé, et
+l'espace de pixels dans lequel vivent les cadres de visage stockés et
+`image_width`/`image_height`. Il est délibérément fidèle : aucune adaptation par vue,
+un seul gain d'exposition fixe pour toute la bibliothèque.
+
+**Profil d'affichage** — ce que montrent la miniature stockée, la galerie et `/image`.
+Il privilégie l'aperçu intégré par le boîtier, qui porte déjà la courbe de tons, les
+modes de plage dynamique et l'exposition propres au modèle, et retombe sur le
+démosaïçage du profil métriques quand aucun aperçu exploitable n'existe.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Réglage | Défaut | Description |
+|---------|--------|-------------|
+| `bright` | `1.62` | Gain d'exposition fixe appliqué à chaque démosaïçage (`1.0` = le niveau propre de LibRaw). La seule constante arbitraire ici : elle correspond au +0,7 IL par défaut de darktable, et rien dans le fichier ne l'impose — validez-la sur votre propre bibliothèque avec `--check-raw-rendering` avant un grand scan |
+| `prefer_embedded_preview` | `true` | Générer les images d'affichage à partir de l'aperçu du boîtier quand il y en a un. `false` démosaïque tout, ce qui est plus lent et perd la courbe de tons du boîtier |
+| `preview_min_sensor_ratio` | `0.5` | Quelle part du capteur un aperçu doit couvrir pour que `/image` le serve au lieu de démosaïquer. Nikon, Pentax, Samsung et Canon CR3 intègrent un aperçu quasi plein format (0,98-0,99) ; le Panasonic se situe à 0,52, tandis qu'Olympus, Fuji, Sony et DNG intègrent un petit aperçu (0,29-0,49) et démosaïquent donc |
+| `viewer_concurrency` | `3` | Nombre maximal de démosaïçages RAW simultanés pour le chemin de la visionneuse `/image`, sur son propre budget séparé de `processing.raw_decode_concurrency` ci-dessus, si bien qu'une requête de la visionneuse ne fait jamais la queue derrière un scan ou un décodage en ligne de commande |
+| `faithful_bracket_render` | `true` | Afficher une vue d'un bracketing sans aucune correction : ni aperçu du boîtier, ni gain `bright`. Voir [plus bas](#les-vues-dun-bracketing-saffichent-sans-correction). `false` affiche les bracketings comme n'importe quelle autre photo |
+
+### Compromis mémoire
+
+`viewer_concurrency` et `processing.raw_decode_concurrency` sont des budgets
+indépendants, chacun avec son propre sémaphore, et ni l'un ni l'autre n'emprunte de
+marge à l'autre. Dans le pire des cas, le processus peut donc tenir en vol des
+démosaïçages « bibliothèque + visionneuse » à la fois, chacun culminant à environ
+200-400 Mo d'intermédiaires — abaissez `viewer_concurrency` sur un hôte contraint en
+mémoire. En pratique ce budget est le plus souvent inactif : il n'est dépensé que
+lorsque `/image` doit retomber sur un démosaïçage complet, ce que
+`preview_min_sensor_ratio` ci-dessus évite déjà pour tout RAW dont l'aperçu intégré est
+assez grand (Nikon, Pentax, Samsung, Canon CR3). Sony, Fuji, Olympus et DNG sont les
+boîtiers qui le consomment réellement.
+
+### Pourquoi il n'y a pas de luminosité automatique
+
+LibRaw éclaircit chaque vue jusqu'à ce qu'environ 1 % de ses propres pixels soit
+écrêté, et substitue le pixel le plus clair de cette même vue au niveau de blanc du
+boîtier. Les deux termes sont propres à chaque vue, si bien qu'un bracketing ressort
+égalisé : un ensemble Canon de 5 vues mesuré, couvrant -3,4 à +3,3 IL, a rendu des
+luminances moyennes de 54 à 56 pour ses trois vues sombres, indiscernables les unes des
+autres. Avec le gain fixe, le même ensemble s'étend de 8,7 à 160 — une échelle de 18x
+au lieu de 2,6x.
+
+Augmenter `bright` étire linéairement chaque rendu ; cela ne restaure jamais le
+comportement par vue. Les métriques d'exposition en dépendent, donc relancez
+`--recompute-average` après l'avoir modifié, et rescannez pour réécrire les métriques
+elles-mêmes.
+
+### Les vues d'un bracketing s'affichent sans correction
+
+Une photo dont le `sequence_kind` est `bracket` ou `hdr_panorama` s'affiche sans
+aucune des deux corrections ci-dessus : ni aperçu intégré par le boîtier, ni gain
+`bright`. Tout le reste conserve le profil d'affichage. Un `panorama` ordinaire n'est
+*pas* un bracketing et en est exclu — seul un panorama HDR, qui est en bracketing à
+chaque position, rejoint les bracketings ici.
+
+La raison est que les deux corrections compressent les hautes lumières, et la marge
+de hautes lumières est tout l'intérêt des vues en +IL d'un bracketing. Le gain
+uniforme préserve l'exposition *relative* entre les vues mais écrête le haut de
+l'échelle : à `bright` 2.0, une échelle mesurée de 4,85x est ressortie à 3,67x, l'écart
+tenant uniquement à l'écrêtage. Le JPEG intégré du boîtier a sa propre courbe de
+tons, qui compresse la même plage pour la même raison. Pour une photo ordinaire,
+c'est une image plus flatteuse ; pour un bracketing, cela cache exactement ce que le
+photographe est en train de juger.
+
+Cela s'applique à toute surface qui affiche un bracketing, afin qu'elles ne puissent
+pas se contredire : `/image` (la vue détail, la loupe de comparaison et la loupe de
+tri) le rend ainsi à la volée, `--refresh-thumbnails` le fige dans
+`photos.thumbnail` pour la vignette de galerie et la grille de comparaison, et
+`GET /api/download` avec `type=original` le convertit de la même façon — une vue de
+bracketing téléchargée est généralement en route vers une fusion HDR, où les hautes
+lumières écrêtées que les autres rendus introduisent seraient irrécupérables.
+
+Deux types de téléchargement sont délibérément laissés de côté : `type=raw` copie
+le fichier RAW intact, et `type=darktable` est l'export « rendu retouché », dont le
+but même est une courbe de tons. `GET /api/photo/cull_preview` n'est pas affecté non
+plus — il s'affiche via darktable-cli, pas via rawpy.
+
+Ce n'est *pas* appliqué au moment du scan, car la détection de séquence tourne après
+un scan et l'appartenance à un bracketing n'est pas encore connue — lancez
+`--detect-sequences` d'abord, puis `--refresh-thumbnails`, pour que les vignettes
+suivent.
+
+La notation n'est pas affectée. Les métriques sont calculées à partir de
+`load_image_from_path`, qui est un décodage séparé aux dimensions du capteur et où
+vivent chaque cadre de visage stocké et `image_width`/`image_height` ; rien ici ne
+les atteint.
+
+Réglez `faithful_bracket_render` sur `false` pour afficher les bracketings comme
+n'importe quelle autre photo.
+
+### Migration d'une bibliothèque scannée avant ce profil
+
+Les miniatures et les histogrammes sont figés au moment du scan, donc changer de
+profil ne modifie pas rétroactivement ce que contient une ligne déjà scannée.
+`photos.render_version` enregistre quel pipeline a produit la miniature stockée de
+chaque ligne : `NULL` signifie « d'avant le correctif », et le pipeline actuel
+marque `1`.
+
+Il n'y a rien à configurer — le marqueur est une écriture comptable, pas un réglage —
+mais il vaut la peine de savoir quels chemins le font avancer :
+
+- **Un rescan** réécrit la miniature et l'histogramme, et marque la ligne.
+- **`--refresh-thumbnails`** réécrit les miniatures RAW et les marque. Les lignes ne
+  sont pas ignorées sur la base du marqueur, donc relancer la commande après un
+  changement de `bright` reconstruit tout.
+
+Ce sont les deux seuls. Parcourir la bibliothèque ne répare rien : `/image` s'affiche
+à la volée, donc la vue détail est toujours à jour, mais la grille de galerie lit
+`photos.thumbnail` et seuls un scan ou `--refresh-thumbnails` la réécrivent.
+
+La bannière rejetable de la galerie compte les lignes encore sur l'ancien rendu.
+Elle lit une entrée `stats_cache` avec un TTL d'une heure plutôt que de parcourir
+`photos` à chaque chargement de page, donc elle peut retarder par rapport à la
+réalité après un rescan ; `python database.py --refresh-stats` la recalcule
+immédiatement.
+
+Un rendu qui revient entièrement noir est refusé plutôt que stocké, et la ligne
+reste sans marqueur pour qu'une exécution ultérieure la retente. LibRaw remplit de
+zéros un RW2 Panasonic sévèrement tronqué pour en faire une vue noire pleine taille
+valide au lieu d'échouer, et une migration sans supervision est le pire endroit pour
+que cela passe inaperçu. Le rejet est journalisé avec le nom du fichier.
 
 ---
 
@@ -1399,6 +1530,72 @@ Affichage et comportement de la galerie web.
 | `notification_duration_ms` | `2000` | Durée des notifications toast |
 | `moment_confidence_min` | `0` | En dessous de ce postérieur `narrative_moment_confidence` stocké (0–1), les libellés de moment sont affichés atténués avec un suffixe « (uncertain) » dans l'en-tête Scènes, l'en-tête du groupe de scène du tri (Culling) et l'infobulle photo de la galerie. `0` = jamais atténué |
 
+### Badges de carte et écrêtage
+
+`viewer.badges` active ou désactive chaque badge de la carte de galerie. Tous les
+badges antérieurs à ce bloc valent `true` par défaut : omettre le bloc ne change
+donc rien.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Clé | Défaut | Description |
+|-----|--------|-------------|
+| `badges.favorite` | `true` | Badge cœur sur une photo favorite (mode édition) |
+| `badges.star_rating` | `true` | Badge étoile + compteur sur une photo notée (mode édition) |
+| `badges.rejected` | `true` | Badge pouce baissé sur une photo rejetée (mode édition) |
+| `badges.sequence_kind` | `true` | Badge bracketing/panorama, affiché seulement quand l'option de masquage replie la série |
+| `badges.sequence_override_pending` | `true` | Badge horloge pour une correction de panorama en attente de la prochaine détection |
+| `badges.keeper_hint` | `true` | Flèche « une meilleure photo existe dans ce groupe » issue du modèle de sélection appris |
+| `badges.best_of_burst` | `true` | Badge « Meilleure » sur la photo de tête d'une rafale. Affiché uniquement quand `hide_bursts` est désactivé : sinon toutes les photos de rafale à l'écran sont déjà des têtes de groupe |
+| `badges.clipping_highlight` | `true` | Badge sur une photo dont les hautes lumières dépassent `clipping.badge_percent` |
+| `badges.clipping_shadow` | `false` | Idem pour les ombres bouchées. Désactivé par défaut : l'écrêtage des ombres est souvent intentionnel (silhouettes, nuit, low-key) |
+
+`viewer.clipping` est la définition unique de « écrêté », partagée par le badge de
+la carte, les repères de l'histogramme et le filtre de galerie, afin que les trois
+ne puissent pas diverger.
+
+| Clé | Défaut | Description |
+|-----|--------|-------------|
+| `badge_percent` | `5` | Pourcentage de pixels, dans le pire des canaux R/V/B, au-delà duquel la carte est badgée. Mesuré sur un échantillon de 28 photos : l'écrêtage des hautes lumières du pire canal avait une médiane de 0,31 % et un p90 de 2,35 %, donc 5 % se déclenche sur environ 1 photo sur 25 |
+| `indicator_percent` | `1` | Seuil des repères R/V/B de l'histogramme. Plus fin que le badge, car vous regardez déjà une seule photo |
+| `histogram_mode` | `"rgb"` | Valeur par défaut de l'histogramme du **panneau de détail** : `"luma"`, `"rgb"`, ou un canal isolé (`"r"` / `"g"` / `"b"`). Le choix propre de l'utilisateur pour cette surface est stocké dans `localStorage` sous `facet_histogram_mode` et prévaut sur cette valeur |
+| `tooltip_histogram_mode` | `"luma"` | Valeur par défaut de l'histogramme de l'**infobulle au survol/épinglée**, mêmes cinq valeurs possibles. Volontairement indépendante de `histogram_mode` et persistée sous sa propre clé `localStorage` (`facet_histogram_mode_tooltip`) : le panneau de détail sert à étudier une seule photo, où le détail par canal se justifie ; l'infobulle sert à parcourir rapidement de nombreuses photos, où une simple courbe de luminance se lit généralement plus vite. Modifier l'une ne retouche jamais l'autre, et le bouton pour la changer ne s'affiche que lorsque l'infobulle est épinglée (rail ancré, ou `tooltip_mode: "click"`) — en simple survol, elle affiche son mode résolu en lecture seule |
+
+**L'écrêtage est mesuré par canal, exactement aux bins 0 et 255.** Il est stocké
+dans `photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` sous forme du
+pourcentage de pixels du pire canal — une mesure *différente* des indicateurs
+`shadow_clipped` / `highlight_clipped`, qui sont binaires, couvrent les plages de
+luminance 0–30 et 225–255 et alimentent `exposure_score`.
+
+**`NULL` signifie inconnu, jamais propre.** Une photo dont l'histogramme stocké
+précède le format par canal n'a aucune donnée de canal : elle ne porte aucun badge
+et ne correspond à aucun des deux côtés du filtre. Lancez
+`python facet.py --backfill-clipping` pour dériver les colonnes des lignes qui
+possèdent déjà un histogramme complet — la commande ne lit que la base, ne décode
+aucune image et est reprenable.
+
 ### Fonctionnalités
 
 Activez ou désactivez des fonctionnalités optionnelles pour réduire l'utilisation mémoire ou simplifier l'interface :
@@ -1410,7 +1607,6 @@ Activez ou désactivez des fonctionnalités optionnelles pour réduire l'utilisa
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1427,7 +1623,6 @@ Activez ou désactivez des fonctionnalités optionnelles pour réduire l'utilisa
 | `show_similar_button` | `true` | Afficher le bouton « Trouver des similaires » sur les cartes photo (utilise numpy pour la similarité CLIP) |
 | `show_merge_suggestions` | `true` | Activer la fonctionnalité de suggestions de fusion sur la page de gestion des personnes |
 | `show_rating_controls` | `true` | Afficher les commandes de notation par étoiles et de favori |
-| `show_rating_badge` | `true` | Afficher le badge de notation sur les cartes photo |
 | `show_scan_button` | `false` | Afficher le bouton de déclenchement d'analyse pour les superadmins (nécessite un GPU sur l'hôte de la visionneuse) |
 | `metrics_enabled` | `false` | Activer le point d'accès public Prometheus `GET /metrics`. Désactivé par défaut — il expose les nombres de photos/personnes/visages, la taille de la base et la mémoire du processus ; à n'activer que lorsque le point d'accès est joignable depuis le réseau du collecteur, et non depuis Internet public. |
 | `show_semantic_search` | `true` | Afficher la barre de recherche sémantique (recherche texte-vers-image via les embeddings CLIP/SigLIP) |
@@ -2036,6 +2231,32 @@ python facet.py --recompute-text   # relit toute la bibliothèque
 
 **Coût.** Une miniature 640px prend environ 0,4 s sur CPU, si bien qu'une bibliothèque de 50 000 photos représente une nuit de travail CPU — c'est un remplissage rétroactif ponctuel, et les analyses suivantes n'ajoutent que de nouvelles photos. Un GPU est utilisé automatiquement lorsque torch en signale un.
 
+## Destinations d'export et de tri
+
+Tout endpoint qui copie, lie symboliquement ou déplace des fichiers photo hors de la bibliothèque — l'export « panier » d'album (`POST /api/albums/{id}/export`, modes `copy`/`symlink`) et le tri vers un dossier (`POST /api/cull/apply`, actions `copy_keeps` / `move_rejects`) — écrit dans un `target_dir` qui doit se résoudre sous une racine autorisée, sinon la requête est refusée avant de toucher le moindre fichier.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Réglage | Défaut | Description |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(clé absente)* | Répertoires racine supplémentaires dans lesquels un export copie/symlink ou un tri-vers-dossier copie/déplacement peut écrire, en plus des répertoires de scan (toujours autorisés). **Absente par défaut** : par défaut, les seules destinations d'export inscriptibles sont vos répertoires de scan configurés |
+
+**Ordre de résolution.** La liste d'autorisation est d'abord `allowed_target_dirs`, puis chaque répertoire de scan (par utilisateur, partagé, et les cibles de `path_mapping`) — exporter *à l'intérieur* de l'arborescence photo ne demande donc aucune configuration, mais une destination en dehors nécessite une entrée ici. Le `target_dir` demandé et chaque racine autorisée sont tous deux canonicalisés avec `os.path.realpath()` (liens symboliques résolus, `..` réduits) avant comparaison, si bien qu'un lien symbolique se résolvant hors d'une racine autorisée est refusé même si le lien lui-même se trouve dans l'une d'elles.
+
+**Fermé par défaut (fail-closed).** Sans aucune racine du tout — ni `allowed_target_dirs` ni répertoires de scan configurés —, l'export copie/symlink/déplacement est refusé purement et simplement plutôt que de se rabattre sur une écriture n'importe où. En pratique ce cas est rare une fois une bibliothèque scannée, puisque les répertoires de scan sont toujours dans la liste d'autorisation.
+
+**Dépannage « accès refusé ».** Ce contrôle s'exécute avant tout accès au système de fichiers, si bien qu'une destination refusée ne touche jamais le disque et ne produit aucune trace d'erreur dans les journaux du serveur — un `403` ici est une réponse HTTP normale issue d'un contrôle délibéré, pas une erreur serveur. L'interface web affiche actuellement un message générique « Accès refusé » pour *tout* `403` sur ces endpoints, sans en préciser la raison ; ouvrez l'onglet Réseau de votre navigateur, repérez la requête `/api/cull/apply` ou `/api/albums/{id}/export` en échec, et lisez le champ `detail` du corps de la réponse pour connaître la cause réelle (cette liste d'autorisation, ou une session d'édition expirée). Un vrai problème de droits du système de fichiers se présente différemment : la requête elle-même réussit (`200`), le nombre `errors` de la réponse est non nul, et le serveur journalise une trace complète pour chaque fichier en échec — voir [Déploiement — Sémantique des chemins en conteneur](DEPLOYMENT.md#sémantique-des-chemins-en-conteneur) pour le cas du conteneur, où cela est souvent confondu avec une divergence d'UID.
+
+Voir [Visionneuse web — Trier vers un dossier](VIEWER.md#trier-vers-un-dossier) et [Visionneuse web — Export vers éditeur](VIEWER.md#export-vers-éditeur).
+
 ## Export social
 
 Recadrages sensibles au sujet pour les formats des réseaux sociaux (`GET /api/photo/social_crop`, réservé à l'édition). Chaque préréglage recadre l'original en pleine résolution vers un format cible et le cadre sur le sujet détecté — le plus grand rectangle de ce format tenant dans l'image, centré sur le sujet et borné aux bords. La boîte du sujet suit une chaîne de repli : la boîte de sujet BiRefNet persistée (`photos.subject_bbox`) → l'union des boîtes de visages détectés → un recadrage centré simple. Voir [Visionneuse web — Téléchargement](VIEWER.md#download).
@@ -2081,7 +2302,7 @@ Exportez un album sous forme de galerie HTML statique autonome qu'un photographe
 | `max_edge` | `2048` | Plafond du grand côté (px) pour les originaux exportés ; la requête peut le remplacer (borné 256–8000) |
 | `jpeg_quality` | `88` | Qualité JPEG des images exportées |
 
-Le `target_dir` passe par la même liste d'autorisation que les endpoints d'export copie/déplacement (`viewer.export.allowed_target_dirs` plus les répertoires de scan). Contrôlé par `viewer.features.show_portfolio_export` (par défaut `true`).
+Le `target_dir` passe par la même liste d'autorisation que les endpoints d'export copie/déplacement (`viewer.export.allowed_target_dirs` plus les répertoires de scan — voir [Destinations d'export et de tri](#destinations-dexport-et-de-tri)). Contrôlé par `viewer.features.show_portfolio_export` (par défaut `true`).
 
 ## Cadre photo / Kiosque
 

--- a/docs/fr/DEPLOYMENT.md
+++ b/docs/fr/DEPLOYMENT.md
@@ -56,6 +56,43 @@ Plusieurs mappages sont pris en charge (la première correspondance l'emporte) 
 - Les chemins UNC (`\\server\share`) comme les lettres de lecteur (`Z:\`) sont pris en charge
 - Le premier préfixe correspondant l'emporte
 
+## Sémantique des chemins en conteneur
+
+Tout ce que vous saisissez dans un champ de dossier de la visionneuse — une cible « Trier vers un dossier », la destination d'export copie/symlink d'un album, ou `viewer.export.allowed_target_dirs` dans `scoring_config.json` — est résolu par le processus Facet lui-même. **Sous Docker/Podman, ce processus s'exécute à l'intérieur du conteneur**, si bien que chaque chemin est celui que *le conteneur* voit : le point de montage, jamais le chemin côté hôte.
+
+**Exemple.** Le `docker-compose.yml` fourni monte votre dossier photo sur `/data/photos` :
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+Pour trier les rejetées vers un sous-dossier `rejects`, saisissez `/data/photos/rejects` dans la boîte de dialogue — jamais le chemin hôte (`/home/vous/Photos`, `D:\Photos`, …), que le conteneur ne peut pas voir du tout. Il en va de même pour `viewer.export.allowed_target_dirs` : indiquez le chemin côté conteneur.
+
+Pour écrire ailleurs que dans l'arborescence photo scannée — un volume d'export séparé, par exemple —, montez-le d'abord dans le conteneur, puis ajoutez son chemin côté conteneur à `viewer.export.allowed_target_dirs` :
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # volume supplémentaire pour la sortie de tri/export
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+Une destination qui se résout hors de tout volume monté est refusée (`403`) — le contrôle de target-dir de Facet exécute `os.path.realpath()` à la fois sur la requête *et* sur chaque racine autorisée, résolvant les liens symboliques et les `..` avant comparaison, si bien qu'un chemin qui ne semble correct que depuis l'extérieur du conteneur (ou un lien symbolique pointant hors d'un montage) échoue quand même au test de confinement. Voir [Configuration — Destinations d'export et de tri](CONFIGURATION.md#destinations-dexport-et-de-tri) pour la référence complète de la liste d'autorisation.
+
+**Ce n'est pas un problème de droits de l'utilisateur conteneur.** L'UID de l'utilisateur `facet` à l'intérieur du conteneur diffère couramment de celui de votre compte hôte, et cela peut causer un vrai problème de droits du système de fichiers, distinct, sur un montage bind — mais cela se produit *après* que ce contrôle de chemin a été franchi, quand la copie/le lien symbolique/le déplacement s'exécute réellement, et c'est journalisé côté serveur avec l'erreur système sous-jacente pour le fichier en échec. Un `403 target_dir is not an allowed export location` (ou un « accès refusé » générique dans l'interface) se produit *avant* que le moindre fichier ne soit touché et n'a rien à voir avec les UID.
+
 ## Compilation du client Angular
 
 Le serveur FastAPI sert la SPA pré-compilée depuis `client/dist/client/browser/`. Compilez-la avant le déploiement :
@@ -101,7 +138,8 @@ python database.py --export-viewer-db
 ```
 
 Cela crée `photo_scores_viewer.db`, qui :
-- Supprime les embeddings CLIP, les données d'histogramme et les embeddings de visage
+- Supprime les embeddings CLIP, les embeddings de légende et les embeddings de visage
+- Conserve l'histogramme par photo (~2 Ko chacun), lu par le widget d'histogramme RVB de la galerie
 - Réduit les miniatures de 640 px à 320 px
 - Fait généralement passer une base de données de 14 Go à environ 4-5 Go
 
@@ -211,9 +249,12 @@ Ce qui suit ne couvre que ce qui diffère sur un NAS.
 
 **Les deux images publiées sont uniquement en `linux/amd64` (x86_64).** Cela couvre le matériel NAS x86 (Synology Plus/x86, UGREEN, UnifyDrive, et tout ce qui fait tourner Coolify, Portainer ou un Docker classique sur un CPU Intel/AMD). Il n'existe pas d'image `arm64` : la compilation croisée d'une pile ML de plusieurs gigaoctets sous QEMU coûte des heures par tag, et la variante CUDA est de toute façon réservée à x86. Sur un NAS ARM ou un Raspberry Pi, compilez localement avec `docker compose build` plutôt que de récupérer l'image — `docker compose up` conserve `build: .` sous la clé `image:` précisément pour ce cas.
 
-**Prévoyez l'espace disque.** L'image CPU fait ~3,3 Go et l'image CUDA ~21 Go, plus les
-poids des modèles que chaque profil télécharge au premier lancement (~3–4 Go pour
-`legacy`/`8gb`, ~10–11 Go pour `16gb`, ~18 Go pour `24gb` — tableau complet dans
+**Prévoyez l'espace disque.** Une fois décompressée, l'image CPU pèse environ 3,3 Go
+sur disque et l'image CUDA environ 21 Go (valeurs approximatives, non revérifiées par
+rapport à la build actuelle : le téléchargement lui-même transfère moins,
+compressé — voir [Taille de l'image](#taille-de-limage) plus bas), plus les poids des
+modèles que chaque profil télécharge au premier lancement (`legacy` 4,69 Go, `8gb`
+6,93 Go, `16gb` 14,55 Go, `24gb` 19,13 Go — tableau complet dans
 [Installation › Tailles de téléchargement](INSTALLATION.md#tailles-de-téléchargement)).
 `docker compose down -v` supprime les volumes de modèles et force un nouveau
 téléchargement.
@@ -331,10 +372,16 @@ Aucune des deux images publiées ne contient les poids des modèles — ils se t
 lancement dans les volumes nommés ([totaux par profil](INSTALLATION.md#tailles-de-téléchargement)). Prévoyez de l'espace disque pour
 l'image **plus** ces volumes.
 
-| Image | Taille mesurée | Base |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3,3 Go | `python:3.12-slim` + PyTorch en wheels CPU |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 Go | PyTorch CUDA + RAPIDS cuML |
+| Image | Téléchargement compressé | Sur disque (approx.) | Base |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4,18 Go | ~3,3 Go | `python:3.12-slim` + PyTorch en wheels CPU |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7,33 Go | ~21 Go | PyTorch CUDA + RAPIDS cuML |
+
+Le « téléchargement compressé » est ce que transfère `docker pull`, mesuré à partir des
+manifestes actuels du registre `ghcr.io/ncoevoet/facet`. La valeur « sur disque » est
+l'empreinte de l'image une fois décompressée ; ces chiffres n'ont pas été revérifiés par
+rapport au digest `:latest` actuel pour cette passe — traitez-les comme un ordre de
+grandeur pour la planification plutôt qu'une mesure précise et actuelle.
 
 L'image CPU est dominée par la pile de dépendances ML (~1,9 Go) plutôt que par PyTorch
 lui-même (~960 Mo), plus les bibliothèques système (~288 Mo) et l'OS de base (~150 Mo). Dans l'image CUDA,

--- a/docs/fr/INSTALLATION.md
+++ b/docs/fr/INSTALLATION.md
@@ -156,8 +156,9 @@ testé.
 ## Premier lancement : à quoi s'attendre
 
 - **Un téléchargement.** Le premier scan récupère les modèles IA de votre profil —
-  environ 3–4 Go pour `legacy` et `8gb`, 10–11 Go pour `16gb`, 18 Go pour `24gb`. Cela
-  n'arrive qu'une fois ; les lancements suivants démarrent immédiatement.
+  environ 4,7 Go pour `legacy`, 6,9 Go pour `8gb`, 14,6 Go pour `16gb`, 19,1 Go pour
+  `24gb` (détail complet dans [Tailles de téléchargement](#tailles-de-téléchargement)).
+  Cela n'arrive qu'une fois ; les lancements suivants démarrent immédiatement.
 - **Aucune configuration.** Il n'y a rien à paramétrer. Facet crée sa base de données au
   premier scan et fonctionne avec des réglages par défaut opérationnels.
 - **Vos photos ne sont pas modifiées.** Le scan se contente de les lire ; les résultats
@@ -239,8 +240,11 @@ Les fichiers par profil (`docker-compose.legacy.yml`, `docker-compose.8gb.yml`,
 profil au `vram_profile` propre à la configuration (par défaut `auto`).
 
 Deux images sont publiées à partir d'un seul `Dockerfile` : `ghcr.io/ncoevoet/facet:latest`
-est une version CPU allégée (~3,3 Go), `ghcr.io/ncoevoet/facet:latest-cuda` embarque CUDA
-et RAPIDS cuML (~21 Go) et c'est elle que récupèrent les profils GPU. Les deux sont
+est une version CPU allégée (~3,3 Go décompressés sur disque, valeur approximative —
+la récupérer transfère moins, 4,18 Go compressés ; voir
+[Tailles de téléchargement](#tailles-de-téléchargement)), `ghcr.io/ncoevoet/facet:latest-cuda`
+embarque CUDA et RAPIDS cuML (~21 Go décompressés sur disque, approximatif ; 7,33 Go
+compressés à récupérer) et c'est elle que récupèrent les profils GPU. Les deux sont
 uniquement en `linux/amd64` — sur une machine ARM, compilez localement avec
 `docker compose build` plutôt que de récupérer l'image. `docker compose build`
 (ou `up --build`) compile toujours depuis ce dépôt ; voir les arguments de compilation
@@ -404,23 +408,58 @@ dans l'autre.
 
 ## Tailles de téléchargement
 
-Les modèles se téléchargent à la première utilisation dans `~/.cache/` et
-`~/.insightface/` (ou les volumes nommés Docker). Aucun poids de modèle n'est intégré à
-l'image.
+Les modèles se téléchargent à la première utilisation dans `~/.cache/huggingface/`
+(modèles Hugging Face), `~/.cache/torch/hub/` (poids PyIQA) et `~/.insightface/`
+(détection/reconnaissance de visages), ou les volumes nommés Docker. `samp_net.pth`,
+`u2netp.pth`, `face_landmarker.task` et le `aesthetic_predictor_weights.pth` de la tête
+esthétique CLIP-MLP (`legacy`/`8gb` uniquement) atterrissent tous dans
+`pretrained_models/`, résolu par rapport à la racine du dépôt plutôt qu'au répertoire de
+travail du processus — sous Docker, c'est le volume monté `facet-pretrained`, donc aucun
+d'eux ne se retélécharge à la recréation du conteneur. Aucun poids de modèle n'est
+intégré à l'image.
+
+Les tailles ci-dessous sont décimales (Go = 10⁹ octets, Mo = 10⁶ octets), mesurées à
+partir des caches de modèles locaux et de l'API Hugging Face.
 
 | Modèle | Taille | Profils |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (embeddings + tagging) | ~1,6 Go | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (embeddings) | ~4,3 Go | `16gb`/`24gb` |
-| Qwen3.5-2B (tagging par VLM) | ~4,2 Go | `16gb` |
-| Qwen3.5-4B (tagging par VLM) | ~8 Go | `24gb` |
-| Qwen2-VL-2B (composition) | ~4,2 Go | `24gb` |
-| InsightFace buffalo_l (visages) | ~600 Mo | tous |
-| Poids SAMP-Net (composition) | ~175 Mo | tous (`24gb` utilise Qwen2-VL à la place) |
-| BiRefNet_dynamic (saillance du sujet) | ~424 Mo | tous |
-| U2-Net-P (auxiliaire de saillance) | ~5 Mo | tous |
+| CLIP ViT-L-14 laion2b (embeddings + tagging CLIP + esthétique CLIP-MLP) | 1,711 Go | `legacy`/`8gb` |
+| Tête esthétique MLP (`sac+logos+ava1-l14-linearMSE.pth`) | 3,7 Mo | `legacy`/`8gb` uniquement |
+| SigLIP 2 NaFlex SO400M (embeddings) | 4,581 Go | `16gb`/`24gb` |
+| Qwen3.5-2B (tagging par VLM) | 4,571 Go | `16gb` |
+| Qwen3.5-4B (tagging par VLM) | 9,343 Go | `24gb` |
+| Qwen2-VL-2B (composition) | 4,430 Go | aucun par défaut — uniquement si vous définissez manuellement `composition_model: "qwen2-vl-2b"` **et** `processing.mode: "single-pass"` |
+| InsightFace buffalo_l (visages) | 289 Mo téléchargés / 630 Mo sur disque (le zip est conservé à côté des fichiers `.onnx` extraits) | tous |
+| Poids SAMP-Net (composition) | 183 Mo | tous |
+| U2-Net-P (sous-modèle de saillance de SAMP-Net) | 4,7 Mo | même profils que SAMP-Net |
+| BiRefNet_dynamic (saillance du sujet) | 445 Mo | tous |
+| TOPIQ NR (modèle esthétique) | 181 Mo | `16gb`/`24gb` |
+| TOPIQ IAA (esthétique complémentaire) | 873 Mo | tous |
+| TOPIQ NR-Face (qualité des visages complémentaire) | 376 Mo | tous |
+| LIQE (qualité/distorsion complémentaire) | 708 Mo | tous |
+| timm resnet50.a1_in1k (backbone PyIQA partagé) | 102 Mo | tous |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2,235 Go | `8gb`/`16gb`/`24gb`, **activé par défaut** (`"auto"` s'active sur tous les profils sauf `legacy`) |
 
-Totaux par profil : `legacy`/`8gb` ~3–4 Go · `16gb` ~10–11 Go · `24gb` ~18 Go.
+Totaux par profil (téléchargement) : `legacy` 4,69 Go · `8gb` 6,93 Go ·
+`16gb` 14,55 Go · `24gb` 19,32 Go · `24gb` avec `composition_model: "qwen2-vl-2b"` et
+`processing.mode: "single-pass"` 23,56 Go (le remplacement manuel se substitue à
+SAMP-Net/U2-Net-P plutôt que de s'y ajouter).
+
+Pour référence, télécharger l'image Docker elle-même (avant tout téléchargement de
+modèle) transfère `ghcr.io/ncoevoet/facet:latest` sur 4,18 Go compressés et
+`:latest-cuda` sur 7,33 Go compressés, d'après les manifestes actuels du registre.
+
+Modèles optionnels non comptés dans les totaux ci-dessus :
+
+| Modèle | Taille | Déclencheur |
+|-------|------|----------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16,41 Go | désactivé par défaut |
+| Backbone SigLIP so400m-patch14-384 (`iqa_extended.aesthetic_v25`) | 3,515 Go | désactivé par défaut, **déprécié** (AGPL-3.0, non maintenu en amont — préférer `qrealign`) |
+| Helsinki-NLP OPUS-MT, par langue cible (traduction des légendes) | en→fr 303 Mo · en→de 298 Mo · en→es 312 Mo · en→it 343 Mo · en→pt 465 Mo | uniquement pour les langues activées |
+| MediaPipe `face_landmarker.task` | 3,76 Mo | uniquement si `mediapipe` est installé |
+
+`reverse_geocoder` ne nécessite aucun téléchargement : ses données sont
+embarquées dans le wheel.
 
 Les poids SAMP-Net proviennent de la
 [version model-weights-v1](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth)
@@ -490,7 +529,6 @@ utilisées tout au long de la documentation :
 | Embeddings SigLIP 2 | oui | `16gb`/`24gb` | — | — |
 | Tagging par VLM (Qwen3.5) | oui | `16gb`/`24gb` | — | — |
 | Motif de composition (SAMP-Net) | optionnel | tout (`legacy` = CPU) | — | — |
-| Composition (Qwen2-VL) | oui | `24gb` | — | — |
 | Saillance du sujet (BiRefNet) | optionnel | tout (`legacy` = CPU) | — | — |
 | Légendes IA (générer / consulter) | oui | `16gb`/`24gb` | — | — |
 | Légendes IA (modifier) | oui | `16gb`/`24gb` | edition | — |

--- a/docs/fr/VIEWER.md
+++ b/docs/fr/VIEWER.md
@@ -155,10 +155,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Motifs de composition
 
-Filtrer par les motifs détectés par SAMP-Net :
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Filtrer par les motifs détectés par SAMP-Net (le modèle n'en émet que ces
+8, dans `models/samp_net.py`) :
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Tri
 
@@ -215,6 +215,10 @@ Un contrôle **Garder le top %** dans la barre d'outils de la galerie (mode édi
 ### Trier vers un dossier
 
 La boîte de dialogue **Trier vers un dossier…** de la barre d'actions groupées (mode édition) copie les gardés, ou déplace/met à la corbeille les rejetés, vers un dossier cible en une étape (la corbeille du système est conditionnée par `viewer.cull.allow_trash`, jamais une suppression définitive). L'application est sûre par construction : `POST /api/cull/apply` ne fait jamais confiance à la liste de suppression fournie par le client — il redérive côté serveur l'ensemble réellement ciblé par l'action à partir de l'état `is_rejected` propre à chaque photo (la copie n'agit que sur les gardés, le déplacement/la corbeille que sur les rejetés) et signale tout ce qui sort de ce périmètre comme `excluded_by_state` plutôt que d'agir dessus. Chaque appel est par défaut un essai à blanc (dry run) — un aperçu s'exécute toujours avant toute écriture — et le déplacement/la corbeille exigent un `dry_run=false` explicite pour s'exécuter ; inclure le RAW ou le sidecar non touché d'une photo rejetée est optionnel (`include_companions`), afin que rejeter un JPEG dérivé n'entraîne jamais silencieusement son RAW avec lui. Plusieurs outils photo du commerce ont connu des bugs de suppression de la mauvaise sélection ; le point d'entrée d'application de Facet est conçu pour que le client ne puisse jamais spécifier directement un ensemble à supprimer.
+
+**Où vous pouvez écrire.** Sans `viewer.export.allowed_target_dirs` configuré, les seuls dossiers dans lesquels Facet peut écrire sont vos répertoires de scan — pointez la boîte de dialogue vers un sous-dossier de l'arborescence photo (par exemple `_rejected`) et cela fonctionne sans configuration. Pour utiliser un dossier situé hors de l'arborescence scannée, ajoutez-le d'abord à `viewer.export.allowed_target_dirs` ; tout le reste est refusé avec un `403`, quels que soient les droits du système de fichiers. Voir [Configuration — Destinations d'export et de tri](CONFIGURATION.md#destinations-dexport-et-de-tri). En Docker/Podman, le chemin saisi est résolu **à l'intérieur du conteneur**, par rapport à ce qui y est réellement monté — jamais par rapport au système de fichiers hôte — voir [Déploiement — Sémantique des chemins en conteneur](DEPLOYMENT.md#sémantique-des-chemins-en-conteneur).
+
+**« Accès refusé » à chaque action.** Il s'agit d'un `403` — un refus délibéré du contrôle de dossier cible ci-dessus, ou une session d'édition expirée — jamais un problème de droits du système de fichiers ou d'utilisateur conteneur. Le message ne précise pas lequel des deux ; vérifiez le corps de la réponse de la requête échouée dans l'onglet Réseau de votre navigateur pour le champ `detail`. Un vrai problème de droits du système de fichiers se présente différemment : l'action rapporte un succès partiel avec un nombre `errors` non nul, et le serveur journalise l'erreur système sous-jacente pour chaque fichier en échec.
 
 ### Options d'affichage
 
@@ -318,7 +322,7 @@ Chaque album peut porter un contexte de notation qui détermine quelle catégori
 
 ### Export de portfolio
 
-Lorsque `viewer.features.show_portfolio_export` vaut `true` (par défaut) et que le mode édition est déverrouillé, chaque carte d'album manuel gagne une action **Exporter le portfolio**. Elle ouvre une petite boîte de dialogue (titre de la galerie, dossier cible, bascule d'inclusion des légendes) et restitue l'album sous forme de galerie HTML statique autonome — le cas d'usage de thumbsup/sigal, mais natif, sans dépendance à un outil externe. Le répertoire de sortie contient `index.html` (une grille de vignettes responsive en CSS pur avec une visionneuse vanilla-JS intégrée — **zéro** référence externe/CDN, donc entièrement fonctionnelle hors ligne), un dossier `assets/` de JPEG nommés séquentiellement (aucun chemin de bibliothèque divulgué), et un `manifest.json` enregistrant les décomptes et les sources par photo. Chaque photo privilégie l'**original** sur disque (réduit à `portfolio.max_edge`, orientation EXIF appliquée) et se rabat sur la vignette 640 px stockée lorsque l'original est inaccessible (partages réseau hors ligne). L'endpoint est `POST /api/albums/{album_id}/export-portfolio` (réservé au mode édition) ; le `target_dir` est validé par rapport à la même liste d'autorisation (`viewer.export.allowed_target_dirs` plus les répertoires de scan) que les endpoints d'export copie/déplacement, et les albums dépassant `portfolio.max_photos` (500 par défaut) sont refusés. Réexporter le même album est idempotent — seuls les fichiers propres à l'export sont réécrits. Voir [Configuration de l'export de portfolio](CONFIGURATION.md#export-de-portfolio).
+Lorsque `viewer.features.show_portfolio_export` vaut `true` (par défaut) et que le mode édition est déverrouillé, chaque carte d'album manuel gagne une action **Exporter le portfolio**. Elle ouvre une petite boîte de dialogue (titre de la galerie, dossier cible, bascule d'inclusion des légendes) et restitue l'album sous forme de galerie HTML statique autonome — le cas d'usage de thumbsup/sigal, mais natif, sans dépendance à un outil externe. Le répertoire de sortie contient `index.html` (une grille de vignettes responsive en CSS pur avec une visionneuse vanilla-JS intégrée — **zéro** référence externe/CDN, donc entièrement fonctionnelle hors ligne), un dossier `assets/` de JPEG nommés séquentiellement (aucun chemin de bibliothèque divulgué), et un `manifest.json` enregistrant les décomptes et les sources par photo. Chaque photo privilégie l'**original** sur disque (réduit à `portfolio.max_edge`, orientation EXIF appliquée) et se rabat sur la vignette 640 px stockée lorsque l'original est inaccessible (partages réseau hors ligne). L'endpoint est `POST /api/albums/{album_id}/export-portfolio` (réservé au mode édition) ; le `target_dir` est validé par rapport à la même liste d'autorisation (`viewer.export.allowed_target_dirs` plus les répertoires de scan, voir [Configuration — Destinations d'export et de tri](CONFIGURATION.md#destinations-dexport-et-de-tri)) que les endpoints d'export copie/déplacement, et les albums dépassant `portfolio.max_photos` (500 par défaut) sont refusés. Réexporter le même album est idempotent — seuls les fichiers propres à l'export sont réécrits. Voir [Configuration de l'export de portfolio](CONFIGURATION.md#export-de-portfolio).
 
 API : voir la section [Points d'accès API](#points-daccès-api) ci-dessous.
 
@@ -529,7 +533,7 @@ Trouvez les clusters de personnes susceptibles de désigner le même individu. A
 Écrivez vos notes, favoris et rejets sur le disque sous forme de sidecars XMP, afin que les éditeurs externes (darktable, Lightroom) les reprennent. Nécessite le mode édition.
 
 - **Depuis la galerie** — sélectionnez des photos, puis **Actions → Exporter** écrit un sidecar à côté de chaque fichier.
-- **Depuis un album** (« panier ») — exportez tout l'album sous forme de sidecars, ou copiez/liez symboliquement les fichiers vers un répertoire cible.
+- **Depuis un album** (« panier ») — exportez tout l'album sous forme de sidecars, ou copiez/liez symboliquement les fichiers vers un répertoire cible (même liste d'autorisation de destination que [Trier vers un dossier](#trier-vers-un-dossier)).
 - **Écrire les métadonnées dans le fichier** — l'action « Écrire les métadonnées dans le fichier » de la page de détail de la photo intègre la note/les mots-clés directement dans le fichier d'origine (JPEG/HEIC/TIFF/PNG/DNG via exiftool) en plus d'écrire le sidecar, de sorte que tout l'écosystème photo les voie. Les originaux RAW propriétaires ne sont jamais modifiés. Contrôlé par `viewer.features.show_embed_metadata` (par défaut : `true`).
 
 API : voir la section [Points d'accès API](#points-daccès-api) ci-dessous.
@@ -1025,6 +1029,7 @@ La documentation interactive de l'API est disponible à `/api/docs` (Swagger UI)
 |----------|-------------|
 | `GET /api/photos` | Liste paginée de photos avec filtres |
 | `GET /api/photo` | Détails d'une seule photo |
+| `GET /api/photo/histogram?path=&bins=` | Bins de luminance + R/V/B prêts à dessiner (`bins` ∈ 32/64/128/256, 64 par défaut), mesurés lors de l'analyse sur l'image pleine résolution. Chaque canal est mis à l'échelle par un maximum global unique, jamais par le sien. `r`/`g`/`b` valent `null` pour une ligne enregistrée avant le format par canal ; 404 lorsque la ligne n'a aucun histogramme, ce qui indique au widget de retomber sur l'échantillonnage de la miniature |
 | `GET /api/type_counts` | Nombre de photos par type |
 | `GET /api/similar_photos/{path}` | Photos similaires (modes : `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Recherche sémantique texte-vers-image (`scope=text` = texte OCR/légende uniquement) |

--- a/docs/fr/VIEWER.md
+++ b/docs/fr/VIEWER.md
@@ -1029,6 +1029,7 @@ La documentation interactive de l'API est disponible à `/api/docs` (Swagger UI)
 |----------|-------------|
 | `GET /api/photos` | Liste paginée de photos avec filtres |
 | `GET /api/photo` | Détails d'une seule photo |
+| `GET /api/photo/set?path=` | L'ensemble bracketing/panorama/hdr_panorama/rafale/doublon auquel appartient une photo (la séquence l'emporte sur la rafale, la rafale sur le doublon), indexé sur `path` — jamais un identifiant de groupe, que les passes de bracketing et de panorama renumérotent chacune à partir de 1 à chaque exécution |
 | `GET /api/photo/histogram?path=&bins=` | Bins de luminance + R/V/B prêts à dessiner (`bins` ∈ 32/64/128/256, 64 par défaut), mesurés lors de l'analyse sur l'image pleine résolution. Chaque canal est mis à l'échelle par un maximum global unique, jamais par le sien. `r`/`g`/`b` valent `null` pour une ligne enregistrée avant le format par canal ; 404 lorsque la ligne n'a aucun histogramme, ce qui indique au widget de retomber sur l'échantillonnage de la miniature |
 | `GET /api/type_counts` | Nombre de photos par type |
 | `GET /api/similar_photos/{path}` | Photos similaires (modes : `visual`, `color`, `person`) |

--- a/docs/it/COMMANDS.md
+++ b/docs/it/COMMANDS.md
@@ -217,8 +217,33 @@ Gli embedding alimentano il tagging semantico, il rilevamento dei duplicati, la 
 | Comando | Descrizione |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Corregge la rotazione delle miniature memorizzate usando l'orientamento EXIF |
+| `python facet.py --refresh-thumbnails` | Ricostruisce le miniature RAW a partire dall'anteprima incorporata dalla fotocamera |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | Lo stesso, con più letture in parallelo |
 
 Legge l'orientamento EXIF dai file originali e ruota i byte della miniatura memorizzata; per le foto elaborate prima dell'esistenza della gestione EXIF. Legge solo l'intestazione EXIF e la miniatura memorizzata, non le immagini complete.
+
+`--refresh-thumbnails` ridisegna la miniatura memorizzata di ogni foto RAW attraverso il profilo di visualizzazione (prima l'anteprima della fotocamera, poi la demosaicizzazione come ripiego — vedi [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). È la migrazione per una libreria scansionata prima che questo profilo esistesse: le miniature scritte da una scansione più vecchia portano la luminosità automatica per scatto di LibRaw, che appiattisce le differenze di esposizione tra gli scatti di un bracket. Non viene caricato alcun modello e nessuna colonna di punteggio viene toccata — viene riscritto solo `photos.thumbnail`.
+
+Il comando è limitato dal throughput di storage piuttosto che dalla CPU, quindi il suo costo scala con la dimensione della libreria e con la velocità del disco o del mount di rete della libreria, non con il numero di core della macchina. `--refresh-thumbnails-workers` (predefinito 8) imposta quanti file vengono letti contemporaneamente: aumentalo su un mount di rete veloce dove ogni lettura passa il tempo in attesa, riducilo su un disco locale lento. Limita anche le demosaicizzazioni complete a cui ricade un RAW privo di anteprima, quindi valori molto alti costano memoria.
+
+È riprendibile. Ogni batch confermato registra fin dove è arrivato, quindi un'esecuzione interrotta con Ctrl+C (o da un mount disconnesso) lascia un database coerente, e il successivo `--refresh-thumbnails` riprende da dove si era fermato. Un'esecuzione completata cancella il marcatore, quindi una successiva riesecuzione riparte da zero.
+
+Una foto il cui nuovo rendering risulta completamente nero mantiene la sua miniatura esistente e viene registrata per nome. Non è paranoia: un RW2 Panasonic gravemente troncato non fallisce la decodifica — LibRaw lo riempie di zeri trasformandolo in un fotogramma nero valido a piena dimensione invece di fallire — quindi senza questo controllo un file corrotto sostituirebbe silenziosamente una buona miniatura con una nera. Una foto del genere resta non marcata e viene ritentata all'esecuzione successiva, quindi riparare il file è sufficiente per risolverlo.
+
+Una foto appartenente a un bracket viene ridisegnata senza l'anteprima della fotocamera e senza alcun guadagno di esposizione, così il suo riquadro mostra ciò che il sensore ha registrato (vedi [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Poiché l'appartenenza a un bracket deriva dal rilevamento delle sequenze, che viene eseguito dopo una scansione, esegui questo comando dopo `--detect-sequences` perché quei riquadri recepiscano il rendering.
+
+### Cosa aggiorna una miniatura memorizzata
+
+Le miniature memorizzate vengono generate al momento della scansione, quindi una libreria scansionata prima che il profilo di visualizzazione esistesse continua a mostrare il vecchio rendering nella griglia di galleria. `photos.render_version` registra quale pipeline ha generato la miniatura di ogni riga, e due percorsi la aggiornano:
+
+| Percorso | Copre | Costo |
+|------|--------|------|
+| Una nuova scansione (`python facet.py <directory>`) | Tutto ciò che scansiona, miniatura e istogramma | Scansione completa |
+| `--refresh-thumbnails` | La miniatura di ogni riga RAW | Limitato dallo storage, ore su una libreria grande |
+
+**Non succede nulla da solo.** La vista dettaglio è sempre aggiornata perché `/image` si renderizza al volo, ma la griglia di galleria legge `photos.thumbnail`, e nessuna quantità di navigazione lo riscrive. È proprio a questo che serve `--refresh-thumbnails`, ed è per questo che la galleria mostra un banner rimovibile che conta le righe ancora in attesa.
+
+Il conteggio del banner proviene da una voce `stats_cache` con un TTL di un'ora, aggiornata direttamente da `--refresh-thumbnails` e da `python database.py --refresh-stats`, quindi dopo una scansione può restare indietro rispetto alla realtà fino a un'ora.
 
 ## Diagnostica
 
@@ -230,6 +255,13 @@ Legge l'orientamento EXIF dai file originali e ruota i byte della miniatura memo
 Riporta la versione di Python, la build PyTorch/CUDA, il rilevamento della GPU e il driver, la raccomandazione del profilo VRAM, le dipendenze opzionali e lo stato di configurazione/database. Quando PyTorch non vede la GPU ma `nvidia-smi` sì, stampa il comando `pip install` per correggere la build CUDA.
 
 `--simulate-gpu NAME` e `--simulate-vram GB` testano il comportamento con hardware diverso. Entrambi richiedono `--doctor`; `--simulate-vram` richiede `--simulate-gpu`.
+
+| Comando | Descrizione |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | Renderizza 20 foto RAW campionate con le vecchie e le attuali impostazioni di decodifica |
+| `python facet.py --check-raw-rendering 50` | Campiona 50 foto invece |
+
+Sola lettura: decodifica un campione casuale direttamente dal disco e stampa la luminanza media prodotta da ogni rendering — la luminosità automatica per scatto di LibRaw, la demosaicizzazione a guadagno fisso delle metriche e l'anteprima incorporata dalla fotocamera usata da miniature e visualizzatore. Usalo per verificare `raw_decode.bright` sui tuoi file prima di avviare una scansione o un'esecuzione di `--refresh-thumbnails`; le colonne fisso e anteprima mantengono la scala di esposizione di un bracket, la colonna di luminosità automatica la appiattisce.
 
 ## Informazioni sui modelli
 

--- a/docs/it/COMMANDS.md
+++ b/docs/it/COMMANDS.md
@@ -55,7 +55,7 @@ campo `progress` di `/api/scan/status` e nel flusso SSE.
 | `quality-face` | TOPIQ NR-Face | punteggio `face_quality_iqa` (qualità del volto dedicata) | Condivisa con TOPIQ |
 | `quality-liqe` | LIQE | `liqe_score` + diagnosi delle distorsioni (sfocatura, sovraesposizione, rumore) | ~2 GB |
 | `tags` | CLIP / Qwen VLM | Tag semantici dal vocabolario configurato | 0-16 GB |
-| `composition` | SAMP-Net | `composition_pattern` (14 modelli) + `comp_score` | ~2 GB |
+| `composition` | SAMP-Net | `composition_pattern` (8 modelli) + `comp_score` | ~2 GB |
 | `faces` | InsightFace buffalo_l | Rilevamento volti, punti di riferimento, rilevamento occhi chiusi, embedding di riconoscimento | ~2 GB |
 | `embeddings` | CLIP ViT-L-14 o SigLIP 2 NaFlex | BLOB `clip_embedding` per somiglianza/tagging | 4-5 GB |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 GB |
@@ -142,6 +142,7 @@ Questi comandi aggiornano metriche specifiche, derivano nuovi dati (didascalie A
 | `python facet.py --recompute-embeddings` | Ricalcola gli embedding CLIP/SigLIP per tutte le foto (necessario dopo il cambio di modello) |
 | `python facet.py --score-topiq` | Riempie i punteggi di qualità TOPIQ dalle miniature memorizzate (richiede GPU) |
 | `python facet.py --backfill-focal-35mm` | Riempie la lunghezza focale equivalente a 35mm dall'EXIF per le foto che ne sono prive |
+| `python facet.py --backfill-clipping` | Deriva le percentuali di clipping per canale dagli istogrammi memorizzati. Solo database (nessuna decodifica di immagini) e riprendibile; le foto il cui istogramma precede il formato RGB restano sconosciute (NULL) |
 | `python facet.py --compute-recommendations` | Analizza il database, mostra un riepilogo dei punteggi |
 | `python facet.py --compute-recommendations --verbose` | Mostra statistiche dettagliate |
 | `python facet.py --compute-recommendations --apply-recommendations` | Applica automaticamente le correzioni dei punteggi |

--- a/docs/it/CONFIGURATION.md
+++ b/docs/it/CONFIGURATION.md
@@ -20,6 +20,7 @@ Tutte le impostazioni si trovano in `scoring_config.json`. Dopo averle modificat
 - [Modelli](#models)
 - [Modelli di valutazione della qualità](#quality-assessment-models)
 - [Elaborazione](#processing)
+- [Decodifica RAW](#decodifica-raw)
 - [Rilevamento raffiche](#burst-detection)
 - [Punteggio raffiche](#burst-scoring)
 - [Rilevamento duplicati](#duplicate-detection)
@@ -447,7 +448,7 @@ Seleziona quali modelli vengono usati per ciascun profilo VRAM.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Seleziona quali modelli vengono usati per ciascun profilo VRAM.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Seleziona quali modelli vengono usati per ciascun profilo VRAM.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Pesi pre-addestrati legacy |
 | `clip_legacy.embedding_dim` | `768` | Dimensioni dell'embedding legacy |
 | `clip_legacy.similarity_threshold_percent` | `22` | Soglia di corrispondenza dei tag per CLIP legacy |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Percorso HuggingFace (VLM di composizione 24gb) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Percorso HuggingFace per l'opt-in manuale `composition_model: "qwen2-vl-2b"` — nessun profilo lo seleziona di default |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Modello di tagging per il profilo 16gb |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Immagini per batch di inferenza VLM |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Modello di tagging per il profilo 24gb |
@@ -526,7 +520,6 @@ Seleziona quali modelli vengono usati per ciascun profilo VRAM.
 | `saliency.resolution` | `1024` | Risoluzione di inferenza |
 | `saliency.mask_threshold` | `0.3` | Soglia sigmoide per la maschera binaria del soggetto |
 | `saliency.min_subject_pixels` | `50` | Pixel minimi del soggetto perché venga considerato rilevato |
-| `samp_net.input_size` | `384` | Dimensione di input del modello di composizione |
 
 ### Rilevamento automatico della VRAM
 
@@ -723,6 +716,149 @@ python facet.py /path --pass saliency      # Saliency del soggetto BiRefNet
 # Elenca i modelli disponibili
 python facet.py --list-models
 ```
+
+---
+
+## Decodifica RAW
+
+Come i file RAW vengono trasformati in pixel. Esistono due profili, e non sono
+intercambiabili.
+
+**Profilo metriche** — la demosaicizzazione da cui viene calcolato ogni punteggio, e
+lo spazio di pixel in cui vivono i riquadri dei volti memorizzati e
+`image_width`/`image_height`. È deliberatamente fedele: nessun adattamento per
+scatto, un unico guadagno di esposizione fisso per tutta la libreria.
+
+**Profilo di visualizzazione** — ciò che mostrano la miniatura memorizzata, la
+galleria e `/image`. Preferisce l'anteprima incorporata dalla fotocamera, che porta
+già la curva tonale, le modalità DR e l'esposizione proprie del modello, e ricade
+sulla demosaicizzazione del profilo metriche quando non esiste un'anteprima
+utilizzabile.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Impostazione | Predefinito | Descrizione |
+|---------------|-------------|-------------|
+| `bright` | `1.62` | Guadagno di esposizione fisso applicato a ogni demosaicizzazione (`1.0` = il livello proprio di LibRaw). L'unica costante arbitraria qui: corrisponde al valore predefinito di +0,7 EV di darktable, e nulla nel file lo impone — validalo sulla tua libreria con `--check-raw-rendering` prima di una scansione ampia |
+| `prefer_embedded_preview` | `true` | Genera le immagini di visualizzazione dall'anteprima della fotocamera quando ne esiste una. `false` esegue la demosaicizzazione di tutto, il che è più lento e perde la curva tonale della fotocamera |
+| `preview_min_sensor_ratio` | `0.5` | Quanta parte del sensore un'anteprima deve coprire perché `/image` la serva invece di demosaicizzare. Nikon, Pentax, Samsung e Canon CR3 incorporano un'anteprima quasi a piena dimensione (0,98-0,99); Panasonic si attesta a 0,52, mentre Olympus, Fuji, Sony e DNG incorporano un'anteprima piccola (0,29-0,49) e quindi vengono demosaicizzati |
+| `viewer_concurrency` | `3` | Numero massimo di demosaicizzazioni RAW simultanee per il percorso del viewer `/image`, su un budget proprio separato da `processing.raw_decode_concurrency` sopra, così una richiesta del viewer non si accoda mai dietro il lavoro di scansione o decodifica da CLI |
+| `faithful_bracket_render` | `true` | Renderizza uno scatto di bracketing senza alcuna correzione — nessuna anteprima della fotocamera, nessun guadagno `bright`. Vedi [più sotto](#i-fotogrammi-di-un-bracketing-vengono-renderizzati-senza-correzioni). `false` renderizza i bracketing come qualsiasi altra foto |
+
+### Compromesso di memoria
+
+`viewer_concurrency` e `processing.raw_decode_concurrency` sono budget indipendenti,
+ciascuno con il proprio semaforo, e nessuno dei due prende in prestito margine
+dall'altro. Nel caso peggiore, il processo può quindi avere in corso
+contemporaneamente demosaicizzazioni "libreria + viewer", ciascuna con un picco di
+circa 200-400 MB di dati intermedi — abbassa `viewer_concurrency` su un host con
+memoria limitata. In pratica questo budget è per lo più inattivo: viene speso solo
+quando `/image` deve ricadere su una demosaicizzazione completa, cosa che
+`preview_min_sensor_ratio` sopra già evita per qualsiasi RAW la cui anteprima
+incorporata sia abbastanza grande (Nikon, Pentax, Samsung, Canon CR3). Sony, Fuji,
+Olympus e DNG sono le fotocamere che lo consumano davvero.
+
+### Perché non c'è una luminosità automatica
+
+LibRaw schiarisce ogni scatto finché circa l'1% dei suoi *stessi* pixel non
+clippa, e sostituisce il pixel più luminoso di quello stesso scatto al livello di
+bianco della fotocamera. Entrambi i termini sono per scatto, quindi un bracketing
+risulta equalizzato: una serie Canon di 5 scatti misurata, che copre da -3,4 a
++3,3 EV, ha reso luminanze medie di 54-56 per i suoi tre scatti scuri,
+indistinguibili l'uno dall'altro. Con il guadagno fisso, la stessa serie va da 8,7
+a 160 — una scala di 18x invece di 2,6x.
+
+Aumentare `bright` scala linearmente ogni rendering; non ripristina mai il
+comportamento per scatto. Le metriche di esposizione si spostano con esso, quindi
+esegui di nuovo `--recompute-average` dopo averlo cambiato, e riscansiona per
+riscrivere le metriche stesse.
+
+### I fotogrammi di un bracketing vengono renderizzati senza correzioni
+
+Una foto il cui `sequence_kind` è `bracket` o `hdr_panorama` viene mostrata senza
+nessuna delle due correzioni sopra: nessuna anteprima incorporata dalla
+fotocamera, e nessun guadagno `bright`. Tutto il resto mantiene il profilo di
+visualizzazione. Un `panorama` semplice *non* è un bracketing ed è escluso — solo
+un panorama HDR, che è in bracketing a ogni posizione, si unisce ai bracketing
+qui.
+
+Il motivo è che entrambe le correzioni comprimono le alte luci, e il margine di
+alte luci è l'intero scopo degli scatti a +EV di un bracketing. Il guadagno
+uniforme preserva l'esposizione *relativa* tra gli scatti ma taglia l'estremità
+luminosa: a `bright` 2.0 una scala misurata di 4,85x è risultata di 3,67x, la
+differenza dovuta unicamente al clipping. Il JPEG incorporato dalla fotocamera ha
+la propria curva tonale, che comprime lo stesso intervallo per lo stesso motivo.
+Per una foto normale è un'immagine più gradevole; per un bracketing nasconde
+esattamente ciò che il fotografo sta valutando.
+
+Questo si applica a ogni superficie che renderizza un bracketing, così che non
+possano contraddirsi: `/image` (la vista dettaglio, la lente di confronto e la
+lente di selezione) lo renderizza così al volo, `--refresh-thumbnails` lo
+incorpora in `photos.thumbnail` per la scheda di galleria e la griglia di
+confronto, e `GET /api/download` con `type=original` lo converte allo stesso modo
+— uno scatto di bracketing scaricato è di solito diretto verso una fusione HDR,
+dove le alte luci tagliate introdotte dagli altri rendering sarebbero
+irrecuperabili.
+
+Due tipi di download sono deliberatamente lasciati intatti: `type=raw` copia il
+file RAW non toccato, e `type=darktable` è l'esportazione con "aspetto
+elaborato", il cui intero scopo è una curva tonale. `GET /api/photo/cull_preview`
+non è a sua volta interessato — renderizza tramite darktable-cli, non rawpy.
+
+*Non* viene applicato al momento della scansione, perché il rilevamento delle
+sequenze viene eseguito dopo una scansione e l'appartenenza a un bracketing non è
+ancora nota — esegui prima `--detect-sequences`, poi `--refresh-thumbnails`,
+perché le schede seguano.
+
+Il punteggio non è interessato. Le metriche vengono calcolate da
+`load_image_from_path`, che è una decodifica separata alle dimensioni del
+sensore ed è dove vivono ogni riquadro di volto memorizzato e
+`image_width`/`image_height`; nulla qui lo raggiunge.
+
+Imposta `faithful_bracket_render` su `false` per renderizzare i bracketing come
+qualsiasi altra foto.
+
+### Migrare una libreria scansionata prima di questo profilo
+
+Le miniature e gli istogrammi vengono generati al momento della scansione, quindi
+cambiare il profilo non modifica retroattivamente ciò che contiene una riga già
+scansionata. `photos.render_version` registra quale pipeline ha prodotto la
+miniatura memorizzata di ciascuna riga: `NULL` significa "da prima del
+correttivo", e la pipeline attuale marca `1`.
+
+Non c'è nulla da configurare — il marcatore è contabilità, non un'impostazione —
+ma vale la pena sapere quali percorsi lo fanno avanzare:
+
+- **Una nuova scansione** riscrive la miniatura e l'istogramma, e marca la riga.
+- **`--refresh-thumbnails`** riscrive le miniature RAW e le marca. Le righe non
+  vengono saltate in base al marcatore, quindi rieseguirlo dopo una modifica di
+  `bright` ricostruisce tutto.
+
+Questi sono gli unici due. Sfogliare la libreria non ripara nulla: `/image` si
+renderizza al volo, quindi la vista dettaglio è sempre aggiornata, ma la griglia
+di galleria legge `photos.thumbnail` e solo una scansione o
+`--refresh-thumbnails` la riscrivono.
+
+Il banner rimovibile della galleria conta le righe ancora sul rendering
+precedente. Legge una voce `stats_cache` con un TTL di un'ora invece di
+scansionare `photos` a ogni caricamento di pagina, quindi può restare indietro
+rispetto alla realtà dopo una nuova scansione; `python database.py
+--refresh-stats` lo ricalcola immediatamente.
+
+Un rendering che risulta completamente nero viene rifiutato invece di essere
+memorizzato, e la riga resta non marcata così che un'esecuzione successiva la
+ritenti. LibRaw riempie di zeri un RW2 Panasonic gravemente troncato trasformandolo
+in un fotogramma nero valido a piena dimensione invece di fallire, e una
+migrazione incustodita è il posto peggiore perché ciò passi inosservato. Il
+rifiuto viene registrato con il nome del file.
 
 ---
 
@@ -1397,6 +1533,72 @@ Visualizzazione e comportamento della galleria web.
 | `notification_duration_ms` | `2000` | Durata del toast |
 | `moment_confidence_min` | `0` | Al di sotto di questo posterior `narrative_moment_confidence` memorizzato (0–1), le etichette dei momenti vengono mostrate attenuate con un suffisso "(uncertain)" nell'intestazione delle Scene, nell'intestazione del gruppo di scena della selezione e nel tooltip della foto in galleria. `0` = non attenuare mai |
 
+### Badge delle schede e clipping
+
+`viewer.badges` attiva o disattiva i singoli badge della scheda in galleria.
+Tutti i badge precedenti a questo blocco valgono `true` per impostazione
+predefinita, quindi ometterlo non cambia nulla.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Chiave | Predefinito | Descrizione |
+|--------|-------------|-------------|
+| `badges.favorite` | `true` | Badge a cuore su una foto preferita (modalità edizione) |
+| `badges.star_rating` | `true` | Badge stella e contatore su una foto valutata (modalità edizione) |
+| `badges.rejected` | `true` | Badge pollice verso su una foto rifiutata (modalità edizione) |
+| `badges.sequence_kind` | `true` | Badge bracketing/panorama, mostrato solo finché l'opzione di nascondimento comprime la serie |
+| `badges.sequence_override_pending` | `true` | Badge orologio per una correzione panorama in attesa del prossimo rilevamento |
+| `badges.keeper_hint` | `true` | Freccia «esiste uno scatto migliore in questo gruppo» dal modello di selezione appreso |
+| `badges.best_of_burst` | `true` | Badge «Migliore» sullo scatto guida di una raffica. Mostrato solo con `hide_bursts` disattivato: altrimenti ogni foto di raffica a schermo è già la guida |
+| `badges.clipping_highlight` | `true` | Badge per una foto le cui alte luci superano `clipping.badge_percent` |
+| `badges.clipping_shadow` | `false` | Idem per le ombre chiuse. Disattivato per impostazione predefinita: il clipping delle ombre è spesso voluto (silhouette, notte, low-key) |
+
+`viewer.clipping` è l'unica definizione di «tagliato» condivisa da badge della
+scheda, marcatori dell'istogramma e filtro della galleria, così i tre non possono
+divergere.
+
+| Chiave | Predefinito | Descrizione |
+|--------|-------------|-------------|
+| `badge_percent` | `5` | Percentuale di pixel, nel peggiore dei canali R/G/B, oltre la quale la scheda riceve il badge. Misurato su 28 foto campione: mediana 0,31 % e p90 2,35 %, quindi il 5 % scatta su circa 1 foto su 25 |
+| `indicator_percent` | `1` | Soglia dei marcatori R/G/B dell'istogramma. Più fine del badge perché si sta già guardando una singola foto |
+| `histogram_mode` | `"rgb"` | Valore predefinito per l'istogramma del **pannello dei dettagli**: `"luma"`, `"rgb"`, oppure un singolo canale (`"r"` / `"g"` / `"b"`). La scelta dell'utente per questa superficie è salvata in `localStorage` sotto `facet_histogram_mode` e ha la precedenza su questo valore |
+| `tooltip_histogram_mode` | `"luma"` | Valore predefinito per l'istogramma del **tooltip al passaggio/appuntato**, stessi cinque valori. Volutamente indipendente da `histogram_mode` e persistito sotto una propria chiave `localStorage` (`facet_histogram_mode_tooltip`): il pannello dei dettagli serve a studiare una singola foto, dove il dettaglio per canale merita spazio; il tooltip serve a scorrere rapidamente molte foto, dove una semplice curva di luminanza si legge di solito più in fretta. Impostarne uno non modifica mai l'altro, e l'interruttore per cambiarlo compare solo mentre il tooltip è appuntato (barra ancorata, oppure `tooltip_mode: "click"`) — in modalità passaggio semplice mostra solo il proprio modo risolto in sola lettura |
+
+**Il clipping è misurato per canale, esattamente ai bin 0 e 255.** È memorizzato in
+`photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` come percentuale di
+pixel del peggior canale — una misura *diversa* dai flag `shadow_clipped` /
+`highlight_clipped`, che sono binari, coprono le bande di luminanza 0–30 e 225–255
+e alimentano `exposure_score`.
+
+**`NULL` significa sconosciuto, mai pulito.** Una foto il cui istogramma
+memorizzato precede il formato per canale non ha dati di canale: non porta badge e
+non corrisponde a nessun lato del filtro. Esegui
+`python facet.py --backfill-clipping` per derivare le colonne delle righe che hanno
+già un istogramma completo — legge solo il database, non decodifica immagini ed è
+riprendibile.
+
 ### Funzionalità
 
 Attiva o disattiva le funzionalità opzionali per ridurre l'uso della memoria o semplificare l'interfaccia:
@@ -1408,7 +1610,6 @@ Attiva o disattiva le funzionalità opzionali per ridurre l'uso della memoria o 
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1425,7 +1626,6 @@ Attiva o disattiva le funzionalità opzionali per ridurre l'uso della memoria o 
 | `show_similar_button` | `true` | Mostra il pulsante "Trova simili" sulle schede delle foto (usa numpy per la similarità CLIP) |
 | `show_merge_suggestions` | `true` | Abilita la funzionalità di suggerimenti di unione nella pagina di gestione delle persone |
 | `show_rating_controls` | `true` | Mostra i controlli di valutazione a stelle e preferiti |
-| `show_rating_badge` | `true` | Mostra il badge di valutazione sulle schede delle foto |
 | `show_scan_button` | `false` | Mostra il pulsante di avvio scansione per gli utenti superadmin (richiede GPU sull'host del viewer) |
 | `metrics_enabled` | `false` | Abilita l'endpoint Prometheus pubblico `GET /metrics`. Disattivato per impostazione predefinita — espone conteggi di foto/persone/volti, dimensione del DB e memoria del processo; abilitalo solo quando l'endpoint è raggiungibile dalla rete dello scraper, non da Internet pubblico. |
 | `show_semantic_search` | `true` | Mostra la barra di ricerca semantica (ricerca testo-immagine usando gli embedding CLIP/SigLIP) |
@@ -2034,6 +2234,32 @@ python facet.py --recompute-text   # rilegge l'intera libreria
 
 **Costo.** Una miniatura da 640px richiede circa 0,4s su CPU, quindi una libreria da 50.000 foto è un lavoro CPU notturno — è un backfill una tantum, e le scansioni successive aggiungono solo foto nuove. Una GPU viene usata automaticamente quando torch ne rileva una.
 
+## Destinazioni di esportazione e scarto
+
+Qualsiasi endpoint che copia, crea collegamenti simbolici o sposta file fotografici fuori dalla libreria — l'esportazione "paniere" di un album (`POST /api/albums/{id}/export`, modalità `copy`/`symlink`) e lo scarto in cartella (`POST /api/cull/apply`, azioni `copy_keeps` / `move_rejects`) — scrive in un `target_dir` che deve risolversi sotto una radice consentita, altrimenti la richiesta viene rifiutata prima di toccare qualsiasi file.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Impostazione | Predefinito | Descrizione |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(chiave assente)* | Directory radice aggiuntive in cui un'esportazione copia/symlink o uno scarto-in-cartella copia/sposta può scrivere, oltre alle directory di scansione (sempre consentite). **Assente per impostazione predefinita** — di base, le uniche destinazioni di esportazione scrivibili sono le directory di scansione configurate |
+
+**Ordine di risoluzione.** L'allow-list è prima `allowed_target_dirs`, poi ogni directory di scansione (per utente, condivisa, e i target di `path_mapping`) — esportare *all'interno* dell'albero fotografico non richiede quindi alcuna configurazione, ma una destinazione al di fuori richiede una voce qui. Sia il `target_dir` richiesto sia ogni radice consentita vengono canonicalizzati con `os.path.realpath()` (symlink risolti, `..` collassati) prima del confronto, quindi un symlink che si risolve al di fuori di una radice consentita viene rifiutato anche quando il link stesso si trova all'interno di una di esse.
+
+**Chiuso per impostazione predefinita (fail-closed).** Senza alcuna radice — né `allowed_target_dirs` né directory di scansione configurate —, l'esportazione copia/symlink/sposta viene rifiutata del tutto invece di ripiegare sulla scrittura ovunque. In pratica questo caso è raro una volta scansionata una libreria, poiché le directory di scansione sono sempre nell'allow-list.
+
+**Risoluzione dei problemi di "accesso negato".** Questo controllo viene eseguito prima di qualsiasi accesso al filesystem, quindi una destinazione rifiutata non tocca mai il disco e non produce alcun traceback nei log del server — un `403` qui è una normale risposta HTTP di un controllo deliberato, non un errore del server. L'interfaccia web mostra attualmente un messaggio generico "Accesso negato" per *qualsiasi* `403` su questi endpoint, senza indicarne il motivo; apri la scheda Rete del browser, trova la richiesta fallita verso `/api/cull/apply` o `/api/albums/{id}/export`, e leggi il campo `detail` nel corpo della risposta per la causa reale (questa allow-list, oppure una sessione di modifica scaduta). Un vero problema di permessi del filesystem si presenta diversamente: la richiesta stessa ha successo (`200`), il conteggio `errors` della risposta è diverso da zero, e il server registra un traceback completo per ogni file non riuscito — vedi [Deployment — Semantica dei percorsi nel container](DEPLOYMENT.md#semantica-dei-percorsi-nel-container) per il caso del container, dove questo viene spesso scambiato per una discrepanza di UID.
+
+Vedi [Visualizzatore web — Scarta in cartella](VIEWER.md#scarta-in-cartella) e [Visualizzatore web — Esportazione per editor](VIEWER.md#esportazione-per-editor).
+
 ## Esportazione social
 
 Ritagli consapevoli del soggetto per i rapporti d'aspetto dei social (`GET /api/photo/social_crop`, riservato all'edizione). Ogni preset ritaglia l'originale a piena risoluzione verso un rapporto d'aspetto obiettivo e lo inquadra sul soggetto rilevato — il più grande rettangolo di quel rapporto che entra nell'immagine, centrato sul soggetto e vincolato ai bordi. Il box del soggetto segue una catena di ripiego: il box del soggetto BiRefNet persistito (`photos.subject_bbox`) → l'unione dei box dei volti rilevati → un ritaglio centrato semplice. Vedi [Visualizzatore web — Download](VIEWER.md#download).
@@ -2079,7 +2305,7 @@ Esporta un album come galleria HTML statica e autonoma che un fotografo può car
 | `max_edge` | `2048` | Limite del lato lungo (px) per gli originali esportati; la richiesta può sovrascriverlo (limitato 256–8000) |
 | `jpeg_quality` | `88` | Qualità JPEG delle immagini esportate |
 
-Il `target_dir` passa attraverso la stessa allow-list degli endpoint di esportazione copia/spostamento (`viewer.export.allowed_target_dirs` più le directory di scansione). Controllato da `viewer.features.show_portfolio_export` (predefinito `true`).
+Il `target_dir` passa attraverso la stessa allow-list degli endpoint di esportazione copia/spostamento (`viewer.export.allowed_target_dirs` più le directory di scansione — vedi [Destinazioni di esportazione e scarto](#destinazioni-di-esportazione-e-scarto)). Controllato da `viewer.features.show_portfolio_export` (predefinito `true`).
 
 ## Cornice digitale / Chiosco
 

--- a/docs/it/CONFIGURATION.md
+++ b/docs/it/CONFIGURATION.md
@@ -1520,7 +1520,8 @@ Visualizzazione e comportamento della galleria web.
 | `hide_brackets` | `true` | Mostra per impostazione predefinita solo l'esposizione base di ogni bracketing |
 | `hide_panoramas` | `true` | Mostrare per impostazione predefinita un solo fotogramma per panorama |
 | `hide_details` | `true` | Nasconde per impostazione predefinita i dettagli della foto sulle schede |
-| `tooltip_mode` | `"hover"` | Attivazione del tooltip: `"hover"`, `"click"` o `"off"`. Sostituisce il precedente booleano `hide_tooltip`. |
+| `tooltip_mode` | `"hover"` | Attivazione del tooltip: `"hover"`, `"click"`, `"off"` o `"panel"` (barra ancorata invece di un tooltip fluttuante — vedi `panel_activation` sotto). Sostituisce il precedente booleano `hide_tooltip`. |
+| `panel_activation` | `"both"` | Gesto che aggiorna la foto selezionata nella barra ancorata quando `tooltip_mode` è `"panel"`: `"hover"`, `"click"` o `"both"`. Nessun effetto sugli altri modi tooltip. Il valore predefinito `"both"` preserva il comportamento originale del pannello |
 | `hide_rejected` | `true` | Nasconde per impostazione predefinita le foto rifiutate |
 | `gallery_mode` | `"mosaic"` | Layout predefinito della galleria (`"grid"` o `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/it/DEPLOYMENT.md
+++ b/docs/it/DEPLOYMENT.md
@@ -56,6 +56,43 @@ Sono supportate più mappature (vince la prima corrispondenza):
 - Sono supportati sia i percorsi UNC (`\\server\share`) che le lettere di unità (`Z:\`)
 - Vince il primo prefisso corrispondente
 
+## Semantica dei percorsi nel container
+
+Qualsiasi cosa digiti in un campo cartella nel viewer — una destinazione "Scarta in cartella", la destinazione di esportazione copia/symlink di un album, oppure `viewer.export.allowed_target_dirs` in `scoring_config.json` — viene risolta dal processo Facet stesso. **Su Docker/Podman quel processo gira dentro il container**, quindi ogni percorso è il percorso che *il container* vede: il punto di montaggio, mai il percorso lato host.
+
+**Esempio.** Il `docker-compose.yml` fornito monta la tua cartella fotografica su `/data/photos`:
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+Per scartare gli elementi rifiutati in una sottocartella `rejects`, inserisci `/data/photos/rejects` nella finestra di dialogo — mai il percorso host (`/home/tu/Immagini`, `D:\Foto`, …), che il container non può vedere affatto. Lo stesso vale per `viewer.export.allowed_target_dirs`: elenca il percorso lato container.
+
+Per scrivere altrove rispetto all'albero fotografico scansionato — ad esempio un volume di esportazione separato — montalo prima nel container, quindi aggiungi il suo percorso lato container a `viewer.export.allowed_target_dirs`:
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # volume aggiuntivo per l'output di cull/export
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+Una destinazione che si risolve al di fuori di ogni volume montato viene rifiutata (`403`) — il controllo del target-dir di Facet esegue `os.path.realpath()` sia sulla richiesta *sia* su ogni radice consentita, risolvendo symlink e `..` prima del confronto, quindi un percorso che sembra corretto solo dall'esterno del container (o un symlink che punta fuori da un mount) fallisce comunque il test di contenimento. Vedi [Configurazione — Destinazioni di esportazione e scarto](CONFIGURATION.md#destinazioni-di-esportazione-e-scarto) per il riferimento completo dell'allow-list.
+
+**Questo non è un problema di permessi dell'utente del container.** La UID dell'utente `facet` all'interno del container spesso differisce da quella del tuo account host, e questo può causare un vero e separato problema di permessi del filesystem su un bind mount — ma ciò accade *dopo* che questo controllo del percorso è stato superato, quando la copia/symlink/spostamento viene effettivamente eseguita, e viene registrato lato server con l'errore del sistema operativo sottostante per il file non riuscito. Un `403 target_dir is not an allowed export location` (o un generico "accesso negato" nell'interfaccia) avviene *prima* che qualsiasi file venga toccato e non ha nulla a che fare con le UID.
+
 ## Compilazione del client Angular
 
 Il server FastAPI serve la SPA precompilata da `client/dist/client/browser/`. Compilala prima del deployment:
@@ -101,7 +138,8 @@ python database.py --export-viewer-db
 ```
 
 Questo crea `photo_scores_viewer.db`, che:
-- Rimuove gli embedding CLIP, i dati dell'istogramma e gli embedding dei volti
+- Rimuove gli embedding CLIP, gli embedding delle didascalie e gli embedding dei volti
+- Mantiene l'istogramma per foto (~2 KB ciascuno), letto dal widget istogramma RGB della galleria
 - Riduce le miniature da 640px a 320px
 - Riduce tipicamente un database di 14GB a ~4-5GB
 
@@ -211,9 +249,12 @@ Quanto segue è solo ciò che cambia su un NAS.
 
 **Entrambe le immagini pubblicate sono solo `linux/amd64` (x86_64).** Questo copre l'hardware NAS x86 (Synology Plus/x86, UGREEN, UnifyDrive e qualsiasi cosa esegua Coolify, Portainer o Docker semplice su una CPU Intel/AMD). Non esiste un'immagine `arm64`: la compilazione incrociata di uno stack ML di diversi gigabyte sotto QEMU costa ore per tag, e la variante CUDA è comunque disponibile solo per x86. Su un NAS ARM o un Raspberry Pi, compila in locale con `docker compose build` invece di scaricare l'immagine — `docker compose up` mantiene `build: .` sotto la chiave `image:` proprio per questo caso.
 
-**Prevedi lo spazio su disco.** L'immagine CPU è ~3,3 GB e quella CUDA ~21 GB, più i pesi
-dei modelli scaricati da ogni profilo al primo avvio (~3–4 GB per `legacy`/`8gb`, ~10–11 GB
-per `16gb`, ~18 GB per `24gb` — tabella completa in
+**Prevedi lo spazio su disco.** Decompressa, l'immagine CPU occupa circa 3,3 GB su
+disco e quella CUDA circa 21 GB (valori approssimativi, non riverificati rispetto alla
+build attuale; il download vero e proprio trasferisce meno, compresso — vedi
+[Dimensione dell'immagine](#dimensione-dellimmagine) più sotto), più i pesi dei modelli
+scaricati da ogni profilo al primo avvio (`legacy` 4,69 GB, `8gb` 6,93 GB, `16gb`
+14,55 GB, `24gb` 19,13 GB — tabella completa in
 [Installazione › Dimensioni dei download](INSTALLATION.md#dimensioni-dei-download)).
 `docker compose down -v` elimina i volumi dei modelli e forza un nuovo download.
 
@@ -336,10 +377,16 @@ Nessuna delle due immagini pubblicate contiene i pesi dei modelli — questi si 
 al primo avvio nei volumi con nome ([totali per profilo](INSTALLATION.md#dimensioni-dei-download)).
 Prevedi spazio su disco per l'immagine **più** questi volumi.
 
-| Immagine | Dimensione misurata | Base |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3,3 GB | `python:3.12-slim` + PyTorch in wheel CPU |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+| Immagine | Download compresso | Su disco (approssimativo) | Base |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4,18 GB | ~3,3 GB | `python:3.12-slim` + PyTorch in wheel CPU |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7,33 GB | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+
+Il "download compresso" è ciò che trasferisce `docker pull`, misurato dagli attuali
+manifest del registro `ghcr.io/ncoevoet/facet`. Il valore "su disco" è l'ingombro
+dell'immagine decompressa; queste cifre non sono state riverificate rispetto al digest
+`:latest` attuale in questo passaggio, quindi trattale come una stima di
+pianificazione approssimativa e non come una misurazione attuale precisa.
 
 Nell'immagine CPU domina lo stack di dipendenze ML (~1,9 GB) più che PyTorch stesso
 (~960 MB), più le librerie di sistema (~288 MB) e l'OS di base (~150 MB). Nell'immagine

--- a/docs/it/INSTALLATION.md
+++ b/docs/it/INSTALLATION.md
@@ -154,8 +154,9 @@ Usa [Docker](#installa-con-docker). Per usare una scheda NVIDIA su Windows, segu
 ## Primo avvio: cosa aspettarsi
 
 - **Un download.** La prima scansione scarica i modelli IA per il tuo profilo — circa
-  3–4 GB per `legacy` e `8gb`, 10–11 GB per `16gb`, 18 GB per `24gb`. Succede una sola
-  volta; le esecuzioni successive partono subito.
+  4,7 GB per `legacy`, 6,9 GB per `8gb`, 14,6 GB per `16gb`, 19,1 GB per `24gb`
+  (dettaglio completo in [Dimensioni dei download](#dimensioni-dei-download)). Succede
+  una sola volta; le esecuzioni successive partono subito.
 - **Nessuna configurazione.** Non c'è nulla da configurare. Facet crea il proprio
   database alla prima scansione e viene fornito con impostazioni già funzionanti.
 - **Le tue foto non vengono modificate.** La scansione si limita a leggerle; i risultati
@@ -234,9 +235,12 @@ I file per profilo (`docker-compose.legacy.yml`, `docker-compose.8gb.yml`,
 alla `vram_profile` propria della configurazione (predefinito `auto`).
 
 Due immagini vengono pubblicate a partire da un solo `Dockerfile`:
-`ghcr.io/ncoevoet/facet:latest` è una build snella solo CPU (~3,3 GB),
-`ghcr.io/ncoevoet/facet:latest-cuda` include CUDA e RAPIDS cuML (~21 GB) ed è quella
-scaricata dai profili GPU. Entrambe sono solo `linux/amd64` — su una macchina ARM,
+`ghcr.io/ncoevoet/facet:latest` è una build snella solo CPU (~3,3 GB decompressa su
+disco, valore approssimativo — scaricarla trasferisce meno, 4,18 GB compressi; vedi
+[Dimensioni dei download](#dimensioni-dei-download)), `ghcr.io/ncoevoet/facet:latest-cuda`
+include CUDA e RAPIDS cuML (~21 GB decompressa su disco, approssimativo; 7,33 GB
+compressi da scaricare) ed è quella scaricata dai profili GPU. Entrambe sono solo
+`linux/amd64` — su una macchina ARM,
 compila in locale con `docker compose build` invece di scaricare l'immagine.
 `docker compose build` (o `up --build`) compila sempre a partire da questo repository;
 vedi gli argomenti di build `BASE_IMAGE`, `STRIP_TORCH` e `INSTALL_CUML` nel `Dockerfile`.
@@ -396,22 +400,56 @@ com'è, quindi impostane uno per scavalcare queste soglie in entrambe le direzio
 
 ## Dimensioni dei download
 
-I modelli si scaricano al primo utilizzo in `~/.cache/` e `~/.insightface/` (oppure nei
-volumi Docker con nome). Nessun peso dei modelli è incorporato nell'immagine.
+I modelli si scaricano al primo utilizzo in `~/.cache/huggingface/` (modelli Hugging
+Face), `~/.cache/torch/hub/` (pesi PyIQA) e `~/.insightface/` (rilevamento/riconoscimento
+dei volti), oppure nei volumi Docker con nome. `samp_net.pth`, `u2netp.pth`,
+`face_landmarker.task` e `aesthetic_predictor_weights.pth` della testa estetica CLIP-MLP
+(solo `legacy`/`8gb`) finiscono tutti in `pretrained_models/`, risolto rispetto alla radice
+del repository anziché alla directory di lavoro del processo — in Docker è il volume
+montato `facet-pretrained`, quindi nessuno di essi viene riscaricato alla ricreazione del
+container. Nessun peso dei modelli è incorporato nell'immagine.
+
+Le dimensioni seguenti sono decimali (GB = 10⁹ byte, MB = 10⁶ byte), misurate dalle
+cache dei modelli locali e dall'API di Hugging Face.
 
 | Modello | Dimensione | Profili |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (embedding + tagging) | ~1,6 GB | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (embedding) | ~4,3 GB | `16gb`/`24gb` |
-| Qwen3.5-2B (tagging VLM) | ~4,2 GB | `16gb` |
-| Qwen3.5-4B (tagging VLM) | ~8 GB | `24gb` |
-| Qwen2-VL-2B (composizione) | ~4,2 GB | `24gb` |
-| InsightFace buffalo_l (volti) | ~600 MB | tutti |
-| Pesi SAMP-Net (composizione) | ~175 MB | tutti (`24gb` usa Qwen2-VL al suo posto) |
-| BiRefNet_dynamic (salienza del soggetto) | ~424 MB | tutti |
-| U2-Net-P (supporto alla salienza) | ~5 MB | tutti |
+| CLIP ViT-L-14 laion2b (embedding + tagging CLIP + estetica CLIP-MLP) | 1,711 GB | `legacy`/`8gb` |
+| Testa estetica MLP (`sac+logos+ava1-l14-linearMSE.pth`) | 3,7 MB | solo `legacy`/`8gb` |
+| SigLIP 2 NaFlex SO400M (embedding) | 4,581 GB | `16gb`/`24gb` |
+| Qwen3.5-2B (tagging VLM) | 4,571 GB | `16gb` |
+| Qwen3.5-4B (tagging VLM) | 9,343 GB | `24gb` |
+| Qwen2-VL-2B (composizione) | 4,430 GB | nessun profilo per impostazione predefinita — solo se imposti manualmente `composition_model: "qwen2-vl-2b"` **e** `processing.mode: "single-pass"` |
+| InsightFace buffalo_l (volti) | 289 MB scaricati / 630 MB su disco (lo zip resta accanto ai file `.onnx` estratti) | tutti |
+| Pesi SAMP-Net (composizione) | 183 MB | tutti |
+| U2-Net-P (sotto-modello di salienza di SAMP-Net) | 4,7 MB | stessi profili di SAMP-Net |
+| BiRefNet_dynamic (salienza del soggetto) | 445 MB | tutti |
+| TOPIQ NR (modello estetico) | 181 MB | `16gb`/`24gb` |
+| TOPIQ IAA (estetica complementare) | 873 MB | tutti |
+| TOPIQ NR-Face (qualità dei volti complementare) | 376 MB | tutti |
+| LIQE (qualità/distorsione complementare) | 708 MB | tutti |
+| timm resnet50.a1_in1k (backbone PyIQA condiviso) | 102 MB | tutti |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2,235 GB | `8gb`/`16gb`/`24gb`, **attivo di default** (`"auto"` si risolve in attivo su ogni profilo tranne `legacy`) |
 
-Totali per profilo: `legacy`/`8gb` ~3–4 GB · `16gb` ~10–11 GB · `24gb` ~18 GB.
+Totali per profilo (download): `legacy` 4,69 GB · `8gb` 6,93 GB · `16gb` 14,55 GB ·
+`24gb` 19,32 GB · `24gb` con `composition_model: "qwen2-vl-2b"` e
+`processing.mode: "single-pass"` 23,56 GB (la sostituzione manuale rimpiazza
+SAMP-Net/U2-Net-P invece di sommarsi ad essi).
+
+Per riferimento, scaricare l'immagine Docker stessa (prima di qualsiasi download di
+modelli) trasferisce `ghcr.io/ncoevoet/facet:latest` a 4,18 GB compressi e
+`:latest-cuda` a 7,33 GB compressi, secondo gli attuali manifest del registro.
+
+Modelli opzionali non conteggiati nei totali sopra:
+
+| Modello | Dimensione | Attivazione |
+|-------|------|----------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16,41 GB | disattivato di default |
+| Backbone SigLIP so400m-patch14-384 (`iqa_extended.aesthetic_v25`) | 3,515 GB | disattivato di default, **deprecato** (AGPL-3.0, non mantenuto a monte — preferire `qrealign`) |
+| Helsinki-NLP OPUS-MT, per lingua di destinazione (traduzione delle didascalie) | en→fr 303 MB · en→de 298 MB · en→es 312 MB · en→it 343 MB · en→pt 465 MB | solo per le lingue attivate |
+| MediaPipe `face_landmarker.task` | 3,76 MB | solo se `mediapipe` è installato |
+
+`reverse_geocoder` non richiede alcun download: i suoi dati sono inclusi nel wheel.
 
 I pesi SAMP-Net provengono dalla
 [release model-weights-v1](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth)

--- a/docs/it/VIEWER.md
+++ b/docs/it/VIEWER.md
@@ -155,10 +155,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Modelli compositivi
 
-Filtra per modelli rilevati da SAMP-Net:
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Filtra per modelli rilevati da SAMP-Net (il modello ne emette esattamente questi 8,
+da `models/samp_net.py`):
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Ordinamento
 
@@ -215,6 +215,10 @@ Un controllo **Tieni top %** nella barra degli strumenti della galleria (modalit
 ### Scarta in cartella
 
 La finestra di dialogo **Scarta in cartella…** nella barra delle azioni di gruppo (modalità di modifica) copia i mantenuti, o sposta/cestina gli scartati, in una cartella di destinazione in un solo passaggio (il cestino di sistema è vincolato a `viewer.cull.allow_trash`, mai un'eliminazione permanente). L'applicazione è sicura per costruzione: `POST /api/cull/apply` non si fida mai ciecamente di un elenco di eliminazione fornito dal client — rideriva lato server l'insieme effettivo dell'azione a partire dallo stato `is_rejected` proprio di ogni foto (la copia agisce solo sui mantenuti, lo spostamento/cestino solo sugli scartati) e segnala tutto ciò che è fuori da questo ambito come `excluded_by_state` invece di agirvi sopra. Ogni chiamata ha come predefinito una simulazione (dry run): un'anteprima viene sempre eseguita prima di qualsiasi scrittura, e spostamento/cestino richiedono un `dry_run=false` esplicito per procedere; includere il RAW o il sidecar non toccato di una foto scartata è opzionale (`include_companions`), così scartare un JPEG derivato non trascina mai silenziosamente il suo RAW. Diversi strumenti fotografici commerciali hanno avuto bug di selezione dell'eliminazione che hanno colpito le foto sbagliate; l'endpoint di applicazione di Facet è progettato in modo che il client non possa mai specificare direttamente un insieme da eliminare.
+
+**Dove è possibile scrivere.** Senza `viewer.export.allowed_target_dirs` configurato, le uniche cartelle in cui Facet può scrivere sono le directory di scansione — punta la finestra di dialogo verso una sottocartella dell'albero fotografico (ad es. `_rejected`) e funziona senza alcuna configurazione. Per usare una cartella fuori dall'albero scansionato, aggiungila prima a `viewer.export.allowed_target_dirs`; qualsiasi altra cosa viene rifiutata con un `403`, indipendentemente dai permessi del filesystem. Vedi [Configurazione — Destinazioni di esportazione e scarto](CONFIGURATION.md#destinazioni-di-esportazione-e-scarto). In esecuzione su Docker/Podman, il percorso digitato viene risolto **all'interno del container**, rispetto a ciò che è effettivamente montato lì — mai rispetto al filesystem host — vedi [Deployment — Semantica dei percorsi nel container](DEPLOYMENT.md#semantica-dei-percorsi-nel-container).
+
+**"Accesso negato" a ogni azione.** È un `403` — un rifiuto deliberato del controllo sulla cartella di destinazione sopra descritto, oppure una sessione di modifica scaduta — mai un problema di permessi del filesystem o dell'utente del container. Il messaggio non specifica quale dei due casi si sia verificato; controlla il corpo della risposta della richiesta fallita nella scheda Rete del browser per il campo `detail`. Un vero problema di permessi del filesystem si presenta diversamente: l'azione segnala un successo parziale con un conteggio `errors` diverso da zero, e il server registra l'errore del sistema operativo sottostante per ogni file non riuscito.
 
 ### Opzioni di visualizzazione
 
@@ -318,7 +322,7 @@ Ogni album può portare un contesto di punteggio che decide quale categoria vinc
 
 ### Esportazione portfolio
 
-Quando `viewer.features.show_portfolio_export` è `true` (predefinito) e la modalità di modifica è sbloccata, ogni scheda di album manuale acquisisce un'azione **Esporta portfolio**. Apre una piccola finestra di dialogo (titolo della galleria, cartella di destinazione, interruttore per includere le didascalie) e trasforma l'album in una galleria HTML statica autonoma — il caso d'uso di thumbsup/sigal, ma nativo, senza dipendenza da strumenti esterni. La directory di output contiene `index.html` (una griglia di miniature responsive solo in CSS con una lightbox vanilla-JS integrata — **zero** riferimenti esterni/CDN, quindi funziona completamente offline), una cartella `assets/` di JPEG con nomi sequenziali (nessun percorso della libreria viene divulgato) e un `manifest.json` che registra conteggi e sorgenti per foto. Ogni foto preferisce l'**originale** su disco (ridotto a `portfolio.max_edge`, con orientamento EXIF applicato) e ripiega sulla miniatura da 640 px memorizzata quando l'originale è irraggiungibile (condivisioni di rete offline). L'endpoint è `POST /api/albums/{album_id}/export-portfolio` (riservato alla modalità di modifica); il `target_dir` viene convalidato rispetto alla stessa allow-list (`viewer.export.allowed_target_dirs` più le directory di scansione) degli endpoint di esportazione copia/spostamento, e gli album oltre `portfolio.max_photos` (predefinito 500) vengono rifiutati. Riesportare lo stesso album è idempotente — vengono riscritti solo i file propri dell'esportazione. Vedi [Configurazione dell'esportazione portfolio](CONFIGURATION.md#esportazione-portfolio).
+Quando `viewer.features.show_portfolio_export` è `true` (predefinito) e la modalità di modifica è sbloccata, ogni scheda di album manuale acquisisce un'azione **Esporta portfolio**. Apre una piccola finestra di dialogo (titolo della galleria, cartella di destinazione, interruttore per includere le didascalie) e trasforma l'album in una galleria HTML statica autonoma — il caso d'uso di thumbsup/sigal, ma nativo, senza dipendenza da strumenti esterni. La directory di output contiene `index.html` (una griglia di miniature responsive solo in CSS con una lightbox vanilla-JS integrata — **zero** riferimenti esterni/CDN, quindi funziona completamente offline), una cartella `assets/` di JPEG con nomi sequenziali (nessun percorso della libreria viene divulgato) e un `manifest.json` che registra conteggi e sorgenti per foto. Ogni foto preferisce l'**originale** su disco (ridotto a `portfolio.max_edge`, con orientamento EXIF applicato) e ripiega sulla miniatura da 640 px memorizzata quando l'originale è irraggiungibile (condivisioni di rete offline). L'endpoint è `POST /api/albums/{album_id}/export-portfolio` (riservato alla modalità di modifica); il `target_dir` viene convalidato rispetto alla stessa allow-list (`viewer.export.allowed_target_dirs` più le directory di scansione, vedi [Configurazione — Destinazioni di esportazione e scarto](CONFIGURATION.md#destinazioni-di-esportazione-e-scarto)) degli endpoint di esportazione copia/spostamento, e gli album oltre `portfolio.max_photos` (predefinito 500) vengono rifiutati. Riesportare lo stesso album è idempotente — vengono riscritti solo i file propri dell'esportazione. Vedi [Configurazione dell'esportazione portfolio](CONFIGURATION.md#esportazione-portfolio).
 
 API: vedi la sezione [Endpoint API](#endpoint-api) più sotto.
 
@@ -528,7 +532,7 @@ Trova cluster di persone che potrebbero essere lo stesso individuo. Accessibile 
 Scrivi su disco le tue valutazioni, preferiti e scarti come sidecar XMP, così che gli editor esterni (darktable, Lightroom) li rilevino. Richiede la modalità di modifica.
 
 - **Dalla galleria** — seleziona le foto, quindi **Azioni → Esporta** scrive un sidecar accanto a ogni file.
-- **Da un album** ("paniere") — esporta l'intero album come sidecar, oppure copia/crea collegamenti simbolici dei file in una directory di destinazione.
+- **Da un album** ("paniere") — esporta l'intero album come sidecar, oppure copia/crea collegamenti simbolici dei file in una directory di destinazione (stessa allow-list di destinazione di [Scarta in cartella](#scarta-in-cartella)).
 - **Scrivi metadati nel file** — l'azione "Scrivi metadati nel file" della pagina di dettaglio incorpora la valutazione/le parole chiave direttamente nel file originale (JPEG/HEIC/TIFF/PNG/DNG tramite exiftool) oltre a scrivere il sidecar, così che l'intero ecosistema fotografico le veda. I file RAW proprietari originali non vengono mai modificati. Controllato da `viewer.features.show_embed_metadata` (predefinito: `true`).
 
 API: vedi la sezione [Endpoint API](#endpoint-api) più sotto.
@@ -1023,6 +1027,7 @@ La documentazione interattiva delle API è disponibile in `/api/docs` (Swagger U
 |----------|-------------|
 | `GET /api/photos` | Elenco foto impaginato con filtri |
 | `GET /api/photo` | Dettagli di una singola foto |
+| `GET /api/photo/histogram?path=&bins=` | Bin di luminanza + R/G/B pronti da disegnare (`bins` ∈ 32/64/128/256, predefinito 64), misurati durante la scansione sull'immagine a piena risoluzione. Ogni canale è scalato da un unico massimo globale, mai dal proprio. `r`/`g`/`b` sono `null` per una riga salvata prima del formato per canale; 404 quando la riga non ha alcun istogramma, il segnale per cui il widget ripiega sul campionamento della miniatura |
 | `GET /api/type_counts` | Conteggi foto per tipo |
 | `GET /api/similar_photos/{path}` | Foto simili (modalità: `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Ricerca semantica testo-immagine (`scope=text` = solo testo OCR/didascalia) |

--- a/docs/it/VIEWER.md
+++ b/docs/it/VIEWER.md
@@ -1027,6 +1027,7 @@ La documentazione interattiva delle API è disponibile in `/api/docs` (Swagger U
 |----------|-------------|
 | `GET /api/photos` | Elenco foto impaginato con filtri |
 | `GET /api/photo` | Dettagli di una singola foto |
+| `GET /api/photo/set?path=` | L'insieme bracketing/panorama/hdr_panorama/raffica/duplicato a cui appartiene una foto (la sequenza ha la precedenza sulla raffica, la raffica sul duplicato), indicizzato su `path` — mai un ID di gruppo, che i passaggi di bracketing e panorama rinumerano ciascuno a partire da 1 a ogni esecuzione |
 | `GET /api/photo/histogram?path=&bins=` | Bin di luminanza + R/G/B pronti da disegnare (`bins` ∈ 32/64/128/256, predefinito 64), misurati durante la scansione sull'immagine a piena risoluzione. Ogni canale è scalato da un unico massimo globale, mai dal proprio. `r`/`g`/`b` sono `null` per una riga salvata prima del formato per canale; 404 quando la riga non ha alcun istogramma, il segnale per cui il widget ripiega sul campionamento della miniatura |
 | `GET /api/type_counts` | Conteggi foto per tipo |
 | `GET /api/similar_photos/{path}` | Foto simili (modalità: `visual`, `color`, `person`) |

--- a/docs/pt/COMMANDS.md
+++ b/docs/pt/COMMANDS.md
@@ -55,7 +55,7 @@ campo `progress` de `/api/scan/status` e no fluxo SSE.
 | `quality-face` | TOPIQ NR-Face | pontuação `face_quality_iqa` (qualidade facial dedicada) | Compartilhado com TOPIQ |
 | `quality-liqe` | LIQE | `liqe_score` + diagnóstico de distorção (desfoque, superexposição, ruído) | ~2 GB |
 | `tags` | CLIP / Qwen VLM | Tags semânticas do vocabulário configurado | 0-16 GB |
-| `composition` | SAMP-Net | `composition_pattern` (14 padrões) + `comp_score` | ~2 GB |
+| `composition` | SAMP-Net | `composition_pattern` (8 padrões) + `comp_score` | ~2 GB |
 | `faces` | InsightFace buffalo_l | Detecção facial, landmarks, detecção de piscadas, embeddings de reconhecimento | ~2 GB |
 | `embeddings` | CLIP ViT-L-14 ou SigLIP 2 NaFlex | BLOB `clip_embedding` para similaridade/marcação | 4-5 GB |
 | `saliency` | BiRefNet_dynamic | `subject_sharpness`, `subject_prominence`, `subject_placement`, `bg_separation` | ~2 GB |
@@ -142,6 +142,7 @@ Esses comandos atualizam métricas específicas, derivam novos dados (legendas p
 | `python facet.py --recompute-embeddings` | Recalcula os embeddings CLIP/SigLIP para todas as fotos (necessário após troca de modelo) |
 | `python facet.py --score-topiq` | Preenche retroativamente as pontuações de qualidade TOPIQ a partir das miniaturas armazenadas (requer GPU) |
 | `python facet.py --backfill-focal-35mm` | Preenche retroativamente a distância focal equivalente a 35mm a partir do EXIF para fotos que não a têm |
+| `python facet.py --backfill-clipping` | Deriva as percentagens de recorte por canal a partir dos histogramas armazenados. Apenas base de dados (sem descodificar imagens) e retomável; as fotos cujo histograma é anterior ao formato RGB ficam desconhecidas (NULL) |
 | `python facet.py --compute-recommendations` | Analisa o banco de dados, exibe um resumo de pontuação |
 | `python facet.py --compute-recommendations --verbose` | Exibe estatísticas detalhadas |
 | `python facet.py --compute-recommendations --apply-recommendations` | Aplica automaticamente as correções de pontuação |

--- a/docs/pt/COMMANDS.md
+++ b/docs/pt/COMMANDS.md
@@ -217,8 +217,33 @@ Os embeddings impulsionam a marcação semântica, a detecção de duplicatas, a
 | Comando | Descrição |
 |---------|-------------|
 | `python facet.py --fix-thumbnail-rotation` | Corrige a rotação das miniaturas armazenadas usando a orientação EXIF |
+| `python facet.py --refresh-thumbnails` | Reconstrói as miniaturas RAW a partir da pré-visualização incorporada pela câmera |
+| `python facet.py --refresh-thumbnails --refresh-thumbnails-workers 16` | O mesmo, com mais leituras em paralelo |
 
 Lê a orientação EXIF dos arquivos originais e gira os bytes da miniatura armazenada; para fotos processadas antes de existir o tratamento de EXIF. Lê apenas o cabeçalho EXIF e a miniatura armazenada, não as imagens completas.
+
+`--refresh-thumbnails` renderiza novamente a miniatura armazenada de cada foto RAW através do perfil de exibição (pré-visualização da câmera primeiro, demosaicagem como alternativa — veja [CONFIGURATION.md](CONFIGURATION.md#raw-decode)). É a migração para uma biblioteca varrida antes de esse perfil existir: as miniaturas escritas por uma varredura mais antiga carregam o brilho automático por fotograma do LibRaw, que achata as diferenças de exposição entre os fotogramas de um bracket de exposição. Nenhum modelo é carregado e nenhuma coluna de pontuação é tocada — apenas `photos.thumbnail` é reescrita.
+
+O comando é limitado pela taxa de transferência do armazenamento em vez da CPU, então seu custo escala com o tamanho da biblioteca e com a velocidade do disco ou do ponto de montagem de rede da biblioteca, não com o número de núcleos da máquina. `--refresh-thumbnails-workers` (padrão 8) define quantos arquivos são lidos ao mesmo tempo: aumente-o em um ponto de montagem de rede rápido, onde cada leitura passa o tempo esperando, diminua-o em um disco local lento. Também limita as demosaicagens completas para as quais um RAW sem pré-visualização recorre, então valores muito altos custam memória.
+
+É retomável. Cada lote confirmado registra até onde chegou, de modo que uma execução interrompida com Ctrl+C (ou por um ponto de montagem perdido) deixa um banco de dados consistente, e o próximo `--refresh-thumbnails` continua de onde parou. Uma execução concluída limpa o marcador, então executá-lo novamente mais tarde recomeça do zero.
+
+Uma foto cuja nova renderização volta totalmente preta mantém sua miniatura existente e é registrada pelo nome. Isso não é paranoia: um RW2 da Panasonic severamente truncado não falha ao decodificar — o LibRaw o preenche com zeros, transformando-o em um fotograma preto válido de tamanho completo em vez de falhar — então, sem essa verificação, um arquivo corrompido substituiria silenciosamente uma boa miniatura por uma preta. Essa foto permanece sem marcação e é tentada novamente na próxima execução, então reparar o arquivo já é suficiente para corrigi-la.
+
+Uma foto pertencente a um bracket de exposição é renderizada novamente sem a pré-visualização da câmera e sem nenhum ganho de exposição, de modo que sua miniatura mostra o que o sensor registrou (veja [CONFIGURATION.md](CONFIGURATION.md#bracketed-frames-render-uncorrected)). Como a associação a um bracket vem da detecção de sequências, que roda depois de uma varredura, execute este comando após `--detect-sequences` para que essas miniaturas recebam a renderização.
+
+### O que atualiza uma miniatura armazenada
+
+As miniaturas armazenadas são geradas no momento da varredura, então uma biblioteca varrida antes de o perfil de exibição existir continua mostrando a renderização antiga na grade da galeria. `photos.render_version` registra qual pipeline gerou a miniatura de cada linha, e dois caminhos a atualizam:
+
+| Caminho | Cobre | Custo |
+|------|--------|------|
+| Uma nova varredura (`python facet.py <diretório>`) | Tudo o que ela varre, miniatura e histograma | Varredura completa |
+| `--refresh-thumbnails` | A miniatura de cada linha RAW | Limitado pelo armazenamento, horas em uma biblioteca grande |
+
+**Nada acontece sozinho.** A visualização detalhada está sempre atualizada porque `/image` renderiza em tempo real, mas a grade da galeria lê `photos.thumbnail`, e nenhuma quantidade de navegação a reescreve. É para isso que serve `--refresh-thumbnails`, e por isso a galeria mostra um banner descartável contando as linhas ainda pendentes.
+
+A contagem do banner vem de uma entrada de `stats_cache` com um TTL de uma hora, atualizada diretamente por `--refresh-thumbnails` e por `python database.py --refresh-stats`, então, depois de uma varredura, ela pode ficar atrás da realidade em até uma hora.
 
 ## Diagnostics
 
@@ -230,6 +255,13 @@ Lê a orientação EXIF dos arquivos originais e gira os bytes da miniatura arma
 Reporta a versão do Python, o build do PyTorch/CUDA, a detecção e o driver da GPU, a recomendação de perfil de VRAM, as dependências opcionais e o status da configuração/banco de dados. Quando o PyTorch não consegue enxergar a GPU mas o `nvidia-smi` consegue, ele imprime o comando `pip install` para corrigir o build do CUDA.
 
 `--simulate-gpu NAME` e `--simulate-vram GB` testam o comportamento com hardware diferente. Ambos requerem `--doctor`; `--simulate-vram` requer `--simulate-gpu`.
+
+| Comando | Descrição |
+|---------|-------------|
+| `python facet.py --check-raw-rendering` | Renderiza 20 fotos RAW amostradas com as configurações de decodificação antigas e atuais |
+| `python facet.py --check-raw-rendering 50` | Amostra 50 fotos em vez disso |
+
+Somente leitura: decodifica uma amostra aleatória diretamente do disco e imprime a luminância média que cada renderização produz — o brilho automático por fotograma do LibRaw, a demosaicagem de ganho fixo das métricas e a pré-visualização incorporada pela câmera usada pelas miniaturas e pelo visualizador. Use-o para verificar `raw_decode.bright` nos seus próprios arquivos antes de iniciar uma varredura ou uma execução de `--refresh-thumbnails`; as colunas fixo e pré-visualização mantêm a escada de exposição de um bracket, a coluna de brilho automático a achata.
 
 ## Model Information
 

--- a/docs/pt/CONFIGURATION.md
+++ b/docs/pt/CONFIGURATION.md
@@ -1521,7 +1521,8 @@ Exibição e comportamento da galeria web.
 | `hide_brackets` | `true` | Mostra apenas a exposição base de cada bracketing por padrão |
 | `hide_panoramas` | `true` | Mostrar por predefinição apenas um fotograma representativo por panorâmica |
 | `hide_details` | `true` | Oculta os detalhes da foto nos cartões por padrão |
-| `tooltip_mode` | `"hover"` | Gatilho do tooltip: `"hover"`, `"click"` ou `"off"`. Substitui o antigo booleano `hide_tooltip`. |
+| `tooltip_mode` | `"hover"` | Gatilho do tooltip: `"hover"`, `"click"`, `"off"` ou `"panel"` (barra fixada em vez de um tooltip flutuante — veja `panel_activation` abaixo). Substitui o antigo booleano `hide_tooltip`. |
+| `panel_activation` | `"both"` | Gesto que atualiza a foto selecionada na barra fixada quando `tooltip_mode` é `"panel"`: `"hover"`, `"click"` ou `"both"`. Sem efeito nos outros modos de tooltip. O padrão `"both"` preserva o comportamento original do painel |
 | `hide_rejected` | `true` | Oculta fotos rejeitadas por padrão |
 | `gallery_mode` | `"mosaic"` | Layout padrão da galeria (`"grid"` ou `"mosaic"`) |
 | **allowed_origins** | | |

--- a/docs/pt/CONFIGURATION.md
+++ b/docs/pt/CONFIGURATION.md
@@ -20,6 +20,7 @@ Todas as configurações ficam em `scoring_config.json`. Após modificar, execut
 - [Modelos](#models)
 - [Modelos de Avaliação de Qualidade](#quality-assessment-models)
 - [Processamento](#processing)
+- [Decodificação RAW](#decodificação-raw)
 - [Detecção de Rajadas](#burst-detection)
 - [Pontuação de Rajadas](#burst-scoring)
 - [Detecção de Duplicatas](#duplicate-detection)
@@ -447,7 +448,7 @@ Seleciona quais modelos são usados por perfil de VRAM.
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": ["topiq_iaa", "topiq_nr_face", "liqe"],
         "saliency_enabled": true,
@@ -490,14 +491,7 @@ Seleciona quais modelos são usados por perfil de VRAM.
       "min_subject_pixels": 50
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none", "center", "rule_of_thirds", "golden_ratio", "triangle",
-        "horizontal", "vertical", "diagonal", "symmetric", "curved",
-        "radial", "vanishing_point", "pattern", "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     }
   }
 }
@@ -517,7 +511,7 @@ Seleciona quais modelos são usados por perfil de VRAM.
 | `clip_legacy.pretrained` | `"laion2b_s32b_b82k"` | Pesos pré-treinados legados |
 | `clip_legacy.embedding_dim` | `768` | Dimensões do embedding legado |
 | `clip_legacy.similarity_threshold_percent` | `22` | Limiar de correspondência de tag para o CLIP legado |
-| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Caminho no HuggingFace (VLM de composição 24gb) |
+| `qwen2_vl.model_path` | `"Qwen/Qwen2-VL-2B-Instruct"` | Caminho no Hugging Face para a opção manual `composition_model: "qwen2-vl-2b"` — nenhum perfil a seleciona por padrão |
 | `qwen3_5_2b.model_path` | `"Qwen/Qwen3.5-2B"` | Modelo de tagging para o perfil 16gb |
 | `qwen3_5_2b.vlm_batch_size` | `4` | Imagens por lote de inferência do VLM |
 | `qwen3_5_4b.model_path` | `"Qwen/Qwen3.5-4B"` | Modelo de tagging para o perfil 24gb |
@@ -526,7 +520,6 @@ Seleciona quais modelos são usados por perfil de VRAM.
 | `saliency.resolution` | `1024` | Resolução de inferência |
 | `saliency.mask_threshold` | `0.3` | Limiar sigmoide para a máscara binária do assunto |
 | `saliency.min_subject_pixels` | `50` | Mínimo de pixels de assunto para contar um assunto como detectado |
-| `samp_net.input_size` | `384` | Tamanho de entrada do modelo de composição |
 
 ### Detecção Automática de VRAM
 
@@ -723,6 +716,151 @@ python facet.py /path --pass saliency      # Saliência de assunto BiRefNet
 # Lista os modelos disponíveis
 python facet.py --list-models
 ```
+
+---
+
+## Decodificação RAW
+
+Como os arquivos RAW são transformados em píxeis. Existem dois perfis, e não são
+intercambiáveis.
+
+**Perfil de métricas** — a demosaicagem a partir da qual cada pontuação é
+calculada, e o espaço de píxeis em que vivem as caixas de rosto armazenadas e
+`image_width`/`image_height`. É deliberadamente fiel: sem adaptação por
+fotograma, um único ganho de exposição fixo para toda a biblioteca.
+
+**Perfil de exibição** — o que a miniatura armazenada, a galeria e `/image`
+mostram. Prefere a pré-visualização incorporada pela câmara, que já traz a
+curva de tons, os modos de gama dinâmica e a exposição próprios do modelo, e
+recai na demosaicagem do perfil de métricas quando não existe uma
+pré-visualização utilizável.
+
+```json
+"raw_decode": {
+  "bright": 1.62,
+  "prefer_embedded_preview": true,
+  "preview_min_sensor_ratio": 0.5,
+  "viewer_concurrency": 3,
+  "faithful_bracket_render": true
+}
+```
+
+| Definição | Padrão | Descrição |
+|-----------|--------|-----------|
+| `bright` | `1.62` | Ganho de exposição fixo aplicado a cada demosaicagem (`1.0` = o nível próprio do LibRaw). A única constante arbitrária aqui: corresponde ao padrão de +0,7 EV do darktable, e nada no arquivo o impõe — valide-o na sua própria biblioteca com `--check-raw-rendering` antes de uma varredura grande |
+| `prefer_embedded_preview` | `true` | Gera as imagens de exibição a partir da pré-visualização da câmara quando existe uma. `false` faz a demosaicagem de tudo, o que é mais lento e descarta a curva de tons da câmara |
+| `preview_min_sensor_ratio` | `0.5` | Quanto do sensor uma pré-visualização precisa cobrir para que `/image` a sirva em vez de fazer a demosaicagem. Nikon, Pentax, Samsung e Canon CR3 incorporam uma pré-visualização quase de tamanho completo (0,98-0,99); a Panasonic fica em 0,52, enquanto Olympus, Fuji, Sony e DNG incorporam uma pré-visualização pequena (0,29-0,49) e por isso passam pela demosaicagem |
+| `viewer_concurrency` | `3` | Máximo de demosaicagens RAW simultâneas para o caminho do visualizador `/image`, com orçamento próprio separado de `processing.raw_decode_concurrency` acima, para que um pedido do visualizador nunca fique na fila atrás do trabalho de varredura ou de decodificação via CLI |
+| `faithful_bracket_render` | `true` | Renderiza um fotograma de bracketing sem qualquer correção — sem pré-visualização da câmara, sem ganho `bright`. Veja [mais abaixo](#fotogramas-de-bracketing-são-renderizados-sem-correção). `false` renderiza os bracketings como qualquer outra foto |
+
+### Compromisso de memória
+
+`viewer_concurrency` e `processing.raw_decode_concurrency` são orçamentos
+independentes, cada um com o seu próprio semáforo, e nenhum empresta margem ao
+outro. No pior caso, o processo pode assim manter em curso, ao mesmo tempo,
+demosaicagens de "biblioteca + visualizador", cada uma com um pico de cerca de
+200-400 MB de dados intermédios — reduza `viewer_concurrency` num host com
+memória limitada. Na prática este orçamento está maioritariamente inativo: só
+é gasto quando `/image` precisa de recorrer a uma demosaicagem completa, algo
+que `preview_min_sensor_ratio` acima já evita para qualquer RAW cuja
+pré-visualização incorporada seja suficientemente grande (Nikon, Pentax,
+Samsung, Canon CR3). Sony, Fuji, Olympus e DNG são as câmaras que
+efetivamente o consomem.
+
+### Por que não há brilho automático
+
+O LibRaw clareia cada fotograma até que cerca de 1% dos seus *próprios*
+píxeis fique cortado, e substitui o píxel mais claro desse mesmo fotograma
+pelo nível de branco da câmara. Ambos os termos são por fotograma, pelo que
+um bracketing sai equalizado: uma série Canon de 5 fotogramas medida,
+abrangendo -3,4 a +3,3 EV, rendeu luminâncias médias de 54-56 para os seus
+três fotogramas escuros, indistinguíveis entre si. Com o ganho fixo, a mesma
+série vai de 8,7 a 160 — uma escala de 18x em vez de 2,6x.
+
+Aumentar `bright` escala linearmente cada renderização; nunca restaura o
+comportamento por fotograma. As métricas de exposição movem-se com ele, por
+isso execute novamente `--recompute-average` depois de o alterar, e volte a
+fazer a varredura para reescrever as próprias métricas.
+
+### Fotogramas de bracketing são renderizados sem correção
+
+Uma foto cujo `sequence_kind` é `bracket` ou `hdr_panorama` é exibida sem
+nenhuma das duas correções acima: sem pré-visualização incorporada pela
+câmara, e sem ganho `bright`. Tudo o resto mantém o perfil de exibição. Uma
+`panorama` comum *não* é um bracketing e fica excluída — só uma panorâmica
+HDR, que está em bracketing em cada posição, se junta aos bracketings aqui.
+
+A razão é que ambas as correções comprimem as luzes altas, e a margem de
+luzes altas é todo o propósito dos fotogramas a +EV de um bracketing. O ganho
+uniforme preserva a exposição *relativa* entre os fotogramas mas corta a
+extremidade clara: a `bright` 2.0, uma escala medida de 4,85x saiu como
+3,67x, sendo a diferença apenas o corte. O JPEG incorporado da câmara tem a
+sua própria curva de tons, que comprime a mesma faixa pela mesma razão. Para
+uma foto comum isso é uma imagem mais favorecedora; para um bracketing,
+esconde exatamente aquilo que o fotógrafo está a avaliar.
+
+Isto aplica-se a toda a superfície que renderiza um bracketing, para que não
+possam discordar: `/image` (a vista de detalhe, a lupa de comparação e a lupa
+de triagem) renderiza-o assim em tempo real, `--refresh-thumbnails` incorpora-o
+em `photos.thumbnail` para a miniatura da galeria e a grelha de comparação, e
+`GET /api/download` com `type=original` converte-o da mesma forma — um
+fotograma de bracketing descarregado está normalmente a caminho de uma fusão
+HDR, onde as luzes altas cortadas que as outras renderizações introduzem
+seriam irrecuperáveis.
+
+Dois tipos de download são deliberadamente deixados intocados: `type=raw`
+copia o arquivo RAW sem alterações, e `type=darktable` é a exportação de
+"aspeto editado", cujo propósito inteiro é uma curva de tons. `GET
+/api/photo/cull_preview` também não é afetado — renderiza através do
+darktable-cli, não do rawpy.
+
+*Não* é aplicado no momento da varredura, porque a deteção de sequências
+corre depois de uma varredura e a pertença a um bracketing ainda não é
+conhecida — execute primeiro `--detect-sequences`, depois
+`--refresh-thumbnails`, para que as miniaturas acompanhem.
+
+A pontuação não é afetada. As métricas são calculadas a partir de
+`load_image_from_path`, que é uma decodificação separada nas dimensões do
+sensor e é onde vivem cada caixa de rosto armazenada e
+`image_width`/`image_height`; nada aqui a alcança.
+
+Defina `faithful_bracket_render` como `false` para renderizar os bracketings
+como qualquer outra foto.
+
+### Migrando uma biblioteca varrida antes deste perfil
+
+As miniaturas e os histogramas são gerados no momento da varredura, por isso
+mudar de perfil não altera retroativamente o que uma linha já varrida contém.
+`photos.render_version` regista qual pipeline produziu a miniatura
+armazenada de cada linha: `NULL` significa "de antes da correção", e o
+pipeline atual marca `1`.
+
+Não há nada para configurar — a marca é contabilidade, não uma definição —
+mas vale a pena saber que caminhos a fazem avançar:
+
+- **Uma nova varredura** reescreve a miniatura e o histograma, e marca a
+  linha.
+- **`--refresh-thumbnails`** reescreve as miniaturas RAW e marca-as. As
+  linhas não são ignoradas com base na marca, por isso executar novamente
+  depois de uma alteração de `bright` reconstrói tudo.
+
+Esses são os únicos dois. Navegar pela biblioteca não repara nada: `/image`
+renderiza em tempo real, por isso a vista de detalhe está sempre atualizada,
+mas a grelha da galeria lê `photos.thumbnail`, e só uma varredura ou
+`--refresh-thumbnails` a reescrevem.
+
+O banner descartável da galeria conta as linhas ainda na renderização
+antiga. Lê uma entrada de `stats_cache` com um TTL de uma hora em vez de
+percorrer `photos` a cada carregamento de página, por isso pode ficar atrás
+da realidade depois de uma nova varredura; `python database.py
+--refresh-stats` recalcula-o imediatamente.
+
+Uma renderização que sai totalmente preta é recusada em vez de armazenada, e
+a linha fica sem marca para que uma execução posterior a tente de novo. O
+LibRaw preenche com zeros um RW2 Panasonic gravemente truncado, transformando-o
+num fotograma preto válido de tamanho completo em vez de falhar, e uma
+migração sem supervisão é o pior lugar para isso passar despercebido. A
+recusa é registada com o nome do arquivo.
 
 ---
 
@@ -1396,6 +1534,72 @@ Exibição e comportamento da galeria web.
 | `notification_duration_ms` | `2000` | Duração do toast |
 | `moment_confidence_min` | `0` | Abaixo deste posterior de `narrative_moment_confidence` armazenado (0–1), os rótulos de momento são renderizados esmaecidos com um sufixo "(incerto)" no cabeçalho de Cenas, no cabeçalho de grupo de cena da Triagem e na dica da foto na galeria. `0` = nunca esmaecer |
 
+### Selos do cartão e recorte
+
+`viewer.badges` liga e desliga cada selo do cartão da galeria. Todos os selos
+anteriores a este bloco valem `true` por predefinição, portanto omiti-lo não muda
+nada.
+
+```json
+{
+  "viewer": {
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    }
+  }
+}
+```
+
+| Chave | Predefinição | Descrição |
+|-------|--------------|-----------|
+| `badges.favorite` | `true` | Selo de coração numa foto favorita (modo de edição) |
+| `badges.star_rating` | `true` | Selo de estrela e contador numa foto classificada (modo de edição) |
+| `badges.rejected` | `true` | Selo de polegar para baixo numa foto rejeitada (modo de edição) |
+| `badges.sequence_kind` | `true` | Selo de bracketing/panorama, visível apenas enquanto a opção de ocultar recolhe a série |
+| `badges.sequence_override_pending` | `true` | Selo de relógio para uma correção de panorama à espera da próxima deteção |
+| `badges.keeper_hint` | `true` | Seta «existe uma foto melhor neste grupo» do modelo de seleção aprendido |
+| `badges.best_of_burst` | `true` | Selo «Melhor» na foto principal de uma rajada. Só aparece com `hide_bursts` desativado: caso contrário, todas as fotos de rajada no ecrã já são a principal |
+| `badges.clipping_highlight` | `true` | Selo numa foto cujas altas luzes ultrapassam `clipping.badge_percent` |
+| `badges.clipping_shadow` | `false` | O mesmo para sombras empastadas. Desativado por predefinição: o recorte de sombras é muitas vezes intencional (silhuetas, noite, low-key) |
+
+`viewer.clipping` é a definição única de «recortado» partilhada pelo selo do
+cartão, pelos marcadores do histograma e pelo filtro da galeria, para que os três
+não possam divergir.
+
+| Chave | Predefinição | Descrição |
+|-------|--------------|-----------|
+| `badge_percent` | `5` | Percentagem de píxeis, no pior dos canais R/G/B, acima da qual o cartão recebe selo. Medido em 28 fotos de amostra: mediana de 0,31 % e p90 de 2,35 %, pelo que 5 % dispara em cerca de 1 foto em 25 |
+| `indicator_percent` | `1` | Limiar dos marcadores R/G/B do histograma. Mais fino do que o selo porque já se está a olhar para uma única foto |
+| `histogram_mode` | `"rgb"` | Predefinição do histograma do **painel de detalhe**: `"luma"`, `"rgb"`, ou um único canal (`"r"` / `"g"` / `"b"`). A escolha do utilizador para esta superfície fica em `localStorage` sob `facet_histogram_mode` e prevalece sobre este valor |
+| `tooltip_histogram_mode` | `"luma"` | Predefinição do histograma do **tooltip ao pairar/fixado**, os mesmos cinco valores. Deliberadamente independente de `histogram_mode` e persistido sob a sua própria chave de `localStorage` (`facet_histogram_mode_tooltip`): o painel de detalhe serve para estudar uma única foto, onde o detalhe por canal justifica o espaço; o tooltip serve para percorrer muitas fotos rapidamente, onde uma curva de luminância simples costuma ler-se mais depressa. Ajustar um nunca reajusta o outro, e o alternador para o mudar só aparece enquanto o tooltip está fixado (barra fixada, ou `tooltip_mode: "click"`) — em modo de simples pairar, mostra apenas o seu modo resolvido em modo só de leitura |
+
+**O recorte é medido por canal, exatamente nos bins 0 e 255.** Fica em
+`photos.channel_clip_shadow_pct` / `channel_clip_highlight_pct` como a percentagem
+de píxeis do pior canal — uma medida *diferente* dos indicadores `shadow_clipped` /
+`highlight_clipped`, que são binários, cobrem as faixas de luminância 0–30 e
+225–255 e alimentam `exposure_score`.
+
+**`NULL` significa desconhecido, nunca limpo.** Uma foto cujo histograma
+armazenado é anterior ao formato por canal não tem dados de canal: não leva selo e
+não corresponde a nenhum lado do filtro. Execute
+`python facet.py --backfill-clipping` para derivar as colunas das linhas que já têm
+um histograma completo — lê apenas a base de dados, não descodifica imagens e é
+retomável.
+
 ### Recursos
 
 Ative/desative recursos opcionais para reduzir o uso de memória ou simplificar a interface:
@@ -1407,7 +1611,6 @@ Ative/desative recursos opcionais para reduzir o uso de memória ou simplificar 
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_memories": true,
       "show_captions": true,
       "show_timeline": true,
@@ -1424,7 +1627,6 @@ Ative/desative recursos opcionais para reduzir o uso de memória ou simplificar 
 | `show_similar_button` | `true` | Mostra o botão "Encontrar Similares" nos cartões de foto (usa numpy para similaridade CLIP) |
 | `show_merge_suggestions` | `true` | Ativa o recurso de sugestões de mesclagem na página de gerenciamento de pessoas |
 | `show_rating_controls` | `true` | Mostra os controles de avaliação por estrelas e favoritos |
-| `show_rating_badge` | `true` | Mostra o selo de avaliação nos cartões de foto |
 | `show_scan_button` | `false` | Mostra o botão de disparo de escaneamento para usuários superadmin (requer GPU no host do visualizador) |
 | `metrics_enabled` | `false` | Ativa o endpoint público Prometheus `GET /metrics`. Desligado por padrão — ele expõe contagens de fotos/pessoas/faces, tamanho do banco de dados e memória do processo; habilite apenas quando o endpoint for acessível pela rede do coletor, não pela internet pública. |
 | `show_semantic_search` | `true` | Mostra a barra de busca semântica (busca de texto para imagem usando embeddings CLIP/SigLIP) |
@@ -2033,6 +2235,32 @@ python facet.py --recompute-text   # relê a biblioteca inteira
 
 **Custo.** Uma miniatura de 640px leva cerca de 0,4s na CPU, então uma biblioteca de 50 mil fotos é um trabalho de CPU de uma noite inteira — é um backfill único, e os escaneamentos posteriores só adicionam fotos novas. Uma GPU é usada automaticamente quando o torch reporta uma.
 
+## Destinos de exportação e seleção
+
+Qualquer endpoint que copie, crie links simbólicos ou mova arquivos de fotos para fora da biblioteca — exportação "cesta" de álbum (`POST /api/albums/{id}/export`, modos `copy`/`symlink`) e seleção-para-pasta (`POST /api/cull/apply`, ações `copy_keeps` / `move_rejects`) — grava em um `target_dir` que precisa se resolver sob uma raiz permitida, ou a requisição é recusada antes de tocar em qualquer arquivo.
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+| Configuração | Padrão | Descrição |
+|---------|---------|-------------|
+| `allowed_target_dirs` | *(chave ausente)* | Diretórios raiz adicionais nos quais uma exportação copiar/symlink ou uma seleção-para-pasta copiar/mover pode gravar, além dos diretórios de varredura (sempre permitidos). **Ausente por padrão** — de fábrica, os únicos destinos de exportação graváveis são seus diretórios de varredura configurados |
+
+**Ordem de resolução.** A lista de permissões é primeiro `allowed_target_dirs`, depois cada diretório de varredura (por usuário, compartilhados e destinos de `path_mapping`) — assim, exportar *dentro* da árvore de fotos não precisa de nenhuma configuração, mas um destino fora dela precisa de uma entrada aqui. Tanto o `target_dir` solicitado quanto cada raiz permitida são canonicalizados com `os.path.realpath()` (links simbólicos resolvidos, `..` colapsados) antes da comparação, então um link simbólico que se resolve fora de uma raiz permitida é recusado mesmo quando o próprio link está dentro de uma delas.
+
+**Fechado por padrão (fail-closed).** Sem nenhuma raiz — nem `allowed_target_dirs` nem diretórios de varredura configurados —, a exportação copiar/symlink/mover é recusada totalmente em vez de recorrer a gravar em qualquer lugar. Na prática esse caso é raro depois que você varreu uma biblioteca, já que os diretórios de varredura estão sempre na lista de permissões.
+
+**Solução de problemas de "acesso negado".** Essa verificação é executada antes de qualquer acesso ao sistema de arquivos, então um destino recusado nunca toca o disco e não produz nenhum traceback nos logs do servidor — um `403` aqui é uma resposta HTTP normal de uma verificação deliberada, não um erro de servidor. A interface web atualmente mostra um aviso genérico de "Acesso negado" para *qualquer* `403` nesses endpoints, sem nomear o motivo; abra a aba Rede do seu navegador, encontre a requisição que falhou para `/api/cull/apply` ou `/api/albums/{id}/export`, e leia o campo `detail` do corpo da resposta para a causa real (essa lista de permissões, ou uma sessão de edição expirada). Um problema real de permissões do sistema de arquivos se apresenta de forma diferente: a própria requisição tem sucesso (`200`), a contagem `errors` da resposta é diferente de zero, e o servidor registra um traceback completo para cada arquivo que falhou — veja [Implantação — Semântica de caminhos em contêiner](DEPLOYMENT.md#semântica-de-caminhos-em-contêiner) para o caso do contêiner, onde isso é frequentemente confundido com uma discrepância de UID.
+
+Veja [Visualizador web — Selecionar para pasta](VIEWER.md#selecionar-para-pasta) e [Visualizador web — Exportação para Editor](VIEWER.md#exportação-para-editor).
+
 ## Exportação social
 
 Recortes com reconhecimento do sujeito para proporções de redes sociais (`GET /api/photo/social_crop`, restrito à edição). Cada predefinição recorta o original em resolução total para uma proporção alvo e o enquadra no sujeito detectado — o maior retângulo dessa proporção que cabe na imagem, centrado no sujeito e limitado às bordas. A caixa do sujeito segue uma cadeia de fallback: a caixa de sujeito BiRefNet persistida (`photos.subject_bbox`) → a união das caixas de rostos detectados → um recorte centralizado simples. Veja [Visualizador web — Download](VIEWER.md#download).
@@ -2078,7 +2306,7 @@ Exporte um álbum como uma galeria HTML estática e autónoma que um fotógrafo 
 | `max_edge` | `2048` | Limite do lado maior (px) para os originais exportados; o pedido pode substituí-lo (limitado 256–8000) |
 | `jpeg_quality` | `88` | Qualidade JPEG das imagens exportadas |
 
-O `target_dir` passa pela mesma lista de permissões que os endpoints de exportação copiar/mover (`viewer.export.allowed_target_dirs` mais os diretórios de varredura). Controlado por `viewer.features.show_portfolio_export` (padrão `true`).
+O `target_dir` passa pela mesma lista de permissões que os endpoints de exportação copiar/mover (`viewer.export.allowed_target_dirs` mais os diretórios de varredura — veja [Destinos de exportação e seleção](#destinos-de-exportação-e-seleção)). Controlado por `viewer.features.show_portfolio_export` (padrão `true`).
 
 ## Moldura digital / Quiosque
 

--- a/docs/pt/DEPLOYMENT.md
+++ b/docs/pt/DEPLOYMENT.md
@@ -56,6 +56,43 @@ Vários mapeamentos são suportados (o primeiro que corresponder vence):
 - Tanto caminhos UNC (`\\server\share`) quanto letras de unidade (`Z:\`) são suportados
 - O primeiro prefixo correspondente vence
 
+## Semântica de caminhos em contêiner
+
+Tudo que você digita em um campo de pasta no visualizador — um destino de "Selecionar para pasta", o destino de exportação copiar/symlink de um álbum, ou `viewer.export.allowed_target_dirs` em `scoring_config.json` — é resolvido pelo próprio processo do Facet. **No Docker/Podman esse processo roda dentro do contêiner**, então todo caminho é o caminho que *o contêiner* vê: o ponto de montagem, nunca o caminho do lado do host.
+
+**Exemplo.** O `docker-compose.yml` fornecido monta sua pasta de fotos em `/data/photos`:
+
+```yaml
+volumes:
+  - ${PHOTOS_DIR:-./photos}:/data/photos
+```
+
+Para selecionar rejeitadas para uma subpasta `rejects`, digite `/data/photos/rejects` na caixa de diálogo — nunca o caminho do host (`/home/voce/Fotos`, `D:\Fotos`, …), que o contêiner não consegue ver de forma alguma. O mesmo vale para `viewer.export.allowed_target_dirs`: liste o caminho do lado do contêiner.
+
+Para gravar em outro lugar que não a árvore de fotos varrida — um volume de exportação separado, por exemplo —, monte-o primeiro no contêiner e depois adicione seu caminho do lado do contêiner a `viewer.export.allowed_target_dirs`:
+
+```yaml
+services:
+  facet:
+    volumes:
+      - ${PHOTOS_DIR:-./photos}:/data/photos
+      - /volume1/Exports:/data/exports   # volume extra para saída de cull/export
+```
+
+```json
+{
+  "viewer": {
+    "export": {
+      "allowed_target_dirs": ["/data/exports"]
+    }
+  }
+}
+```
+
+Um destino que se resolve fora de todo volume montado é recusado (`403`) — a verificação de target-dir do Facet executa `os.path.realpath()` tanto na requisição *quanto* em cada raiz permitida, resolvendo links simbólicos e `..` antes de comparar, então um caminho que só parece correto de fora do contêiner (ou um link simbólico apontando para fora de uma montagem) ainda falha no teste de contenção. Veja [Configuração — Destinos de exportação e seleção](CONFIGURATION.md#destinos-de-exportação-e-seleção) para a referência completa da lista de permissões.
+
+**Isso não é um problema de permissões do usuário do contêiner.** O UID do usuário `facet` dentro do contêiner costuma diferir do da sua conta no host, e isso pode causar um problema real e separado de permissões do sistema de arquivos em um bind mount — mas isso acontece *depois* que essa verificação de caminho é aprovada, quando a cópia/symlink/movimentação realmente roda, e é registrado no servidor com o erro subjacente do sistema operacional para o arquivo que falhou. Um `403 target_dir is not an allowed export location` (ou um "acesso negado" genérico na interface) acontece *antes* de qualquer arquivo ser tocado e não tem nada a ver com UIDs.
+
 ## Compilando o cliente Angular
 
 O servidor FastAPI serve a SPA pré-compilada a partir de `client/dist/client/browser/`. Compile-a antes da implantação:
@@ -101,7 +138,8 @@ python database.py --export-viewer-db
 ```
 
 Isso cria `photo_scores_viewer.db`, que:
-- Remove os embeddings CLIP, os dados de histograma e os embeddings de rostos
+- Remove os embeddings CLIP, os embeddings de legenda e os embeddings de rostos
+- Mantém o histograma por foto (~2 KB cada), lido pelo widget de histograma RGB da galeria
 - Reduz as miniaturas de 640px para 320px
 - Normalmente reduz um banco de dados de 14GB para ~4-5GB
 
@@ -209,9 +247,12 @@ O que segue é apenas o que muda em um NAS.
 
 **Ambas as imagens publicadas são apenas `linux/amd64` (x86_64).** Isso cobre o hardware NAS x86 (Synology Plus/x86, UGREEN, UnifyDrive e qualquer coisa que execute Coolify, Portainer ou Docker comum em uma CPU Intel/AMD). Não existe uma imagem `arm64`: a compilação cruzada de uma pilha de ML de vários gigabytes sob QEMU custa horas por tag, e a variante CUDA é, de qualquer forma, exclusiva de x86. Em um NAS ARM ou um Raspberry Pi, compile localmente com `docker compose build` em vez de baixar — `docker compose up` mantém `build: .` abaixo da chave `image:` exatamente para esse caso.
 
-**Reserve espaço em disco.** A imagem CPU tem ~3,3 GB e a imagem CUDA ~21 GB, além dos
-pesos de modelo que cada perfil baixa na primeira execução (~3–4 GB para `legacy`/`8gb`,
-~10–11 GB para `16gb`, ~18 GB para `24gb` — tabela completa em
+**Reserve espaço em disco.** Já descompactada, a imagem CPU tem aproximadamente 3,3 GB
+em disco e a imagem CUDA aproximadamente 21 GB (valores aproximados, não reverificados
+com a build atual; o próprio download transfere menos, compactado — veja
+[Tamanho da imagem](#tamanho-da-imagem) mais abaixo), além dos pesos de modelo que cada
+perfil baixa na primeira execução (`legacy` 4,69 GB, `8gb` 6,93 GB, `16gb` 14,55 GB,
+`24gb` 19,13 GB — tabela completa em
 [Instalação › Tamanhos de download](INSTALLATION.md#tamanhos-de-download)).
 `docker compose down -v` apaga os volumes de modelos e força um novo download.
 
@@ -335,10 +376,16 @@ primeira execução para os volumes nomeados
 ([totais por perfil](INSTALLATION.md#tamanhos-de-download)). Reserve espaço em disco
 para a imagem **mais** esses volumes.
 
-| Imagem | Tamanho medido | Base |
-|-------|------|------|
-| `ghcr.io/ncoevoet/facet:latest` (CPU) | ~3,3 GB | `python:3.12-slim` + PyTorch em wheels de CPU |
-| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+| Imagem | Download compactado | Em disco (aprox.) | Base |
+|-------|------|------|------|
+| `ghcr.io/ncoevoet/facet:latest` (CPU) | 4,18 GB | ~3,3 GB | `python:3.12-slim` + PyTorch em wheels de CPU |
+| `ghcr.io/ncoevoet/facet:latest-cuda` (GPU) | 7,33 GB | ~21 GB | PyTorch CUDA + RAPIDS cuML |
+
+O "download compactado" é o que o `docker pull` transfere, medido a partir dos
+manifestos atuais do registro `ghcr.io/ncoevoet/facet`. O valor "em disco" é o espaço
+ocupado pela imagem já descompactada; esses números não foram reverificados em relação
+ao digest `:latest` atual nesta rodada, então trate-os como uma estimativa aproximada
+de planejamento, não como uma medição atual precisa.
 
 A imagem CPU é dominada pela pilha de dependências de ML (~1,9 GB), e não pelo PyTorch em
 si (~960 MB), além das bibliotecas de sistema (~288 MB) e do SO base (~150 MB). Na imagem

--- a/docs/pt/INSTALLATION.md
+++ b/docs/pt/INSTALLATION.md
@@ -154,8 +154,9 @@ Use o [Docker](#instalar-com-docker). Para usar uma placa NVIDIA no Windows, sig
 ## Primeira execução: o que esperar
 
 - **Um download.** A primeira varredura baixa os modelos de IA do seu perfil — cerca de
-  3–4 GB para `legacy` e `8gb`, 10–11 GB para `16gb`, 18 GB para `24gb`. Isso acontece
-  uma vez; as próximas execuções começam na hora.
+  4,7 GB para `legacy`, 6,9 GB para `8gb`, 14,6 GB para `16gb`, 19,1 GB para `24gb`
+  (detalhamento completo em [Tamanhos de download](#tamanhos-de-download)). Isso
+  acontece uma vez; as próximas execuções começam na hora.
 - **Sem configuração.** Não há nada para configurar. O Facet cria o seu banco de dados na
   primeira varredura e já vem com configurações que funcionam.
 - **Suas fotos não são modificadas.** A varredura apenas as lê; os resultados vão para o
@@ -237,8 +238,11 @@ Os arquivos por perfil (`docker-compose.legacy.yml`, `docker-compose.8gb.yml`,
 por conta do próprio `vram_profile` da configuração (padrão `auto`).
 
 Duas imagens são publicadas a partir de um único `Dockerfile`: `ghcr.io/ncoevoet/facet:latest`
-é uma build enxuta somente CPU (~3,3 GB), e `ghcr.io/ncoevoet/facet:latest-cuda` traz CUDA e
-RAPIDS cuML (~21 GB) e é o que os perfis de GPU baixam. Ambas são apenas `linux/amd64` — em
+é uma build enxuta somente CPU (~3,3 GB descompactados em disco, valor aproximado — o
+download em si transfere menos, 4,18 GB compactados; veja
+[Tamanhos de download](#tamanhos-de-download)), e `ghcr.io/ncoevoet/facet:latest-cuda`
+traz CUDA e RAPIDS cuML (~21 GB descompactados em disco, aproximado; 7,33 GB compactados
+para baixar) e é o que os perfis de GPU baixam. Ambas são apenas `linux/amd64` — em
 uma máquina ARM, compile localmente com `docker compose build` em vez de baixar. O
 `docker compose build` (ou `up --build`) sempre compila a partir deste repositório; veja os
 build args `BASE_IMAGE`, `STRIP_TORCH` e `INSTALL_CUML` no `Dockerfile`.
@@ -398,22 +402,56 @@ defina um para substituir esses limites em qualquer direção.
 
 ## Tamanhos de download
 
-Os modelos são baixados no primeiro uso para `~/.cache/` e `~/.insightface/` (ou os
-volumes nomeados do Docker). Nenhum peso de modelo vem embutido na imagem.
+Os modelos são baixados no primeiro uso para `~/.cache/huggingface/` (modelos Hugging
+Face), `~/.cache/torch/hub/` (pesos do PyIQA) e `~/.insightface/` (detecção/reconhecimento
+facial), ou os volumes nomeados do Docker. `samp_net.pth`, `u2netp.pth`,
+`face_landmarker.task` e o `aesthetic_predictor_weights.pth` da cabeça estética CLIP-MLP
+(somente `legacy`/`8gb`) vão todos para `pretrained_models/`, resolvido em relação à raiz
+do repositório, e não ao diretório de trabalho do processo — no Docker isso é o volume
+montado `facet-pretrained`, então nenhum deles é baixado novamente ao recriar o contêiner.
+Nenhum peso de modelo vem embutido na imagem.
+
+Os tamanhos abaixo são decimais (GB = 10⁹ bytes, MB = 10⁶ bytes), medidos a partir dos
+caches de modelos locais e da API do Hugging Face.
 
 | Modelo | Tamanho | Perfis |
 |-------|------|----------|
-| CLIP ViT-L-14 laion2b (embeddings + marcação) | ~1,6 GB | `legacy`/`8gb` |
-| SigLIP 2 NaFlex SO400M (embeddings) | ~4,3 GB | `16gb`/`24gb` |
-| Qwen3.5-2B (marcação por VLM) | ~4,2 GB | `16gb` |
-| Qwen3.5-4B (marcação por VLM) | ~8 GB | `24gb` |
-| Qwen2-VL-2B (composição) | ~4,2 GB | `24gb` |
-| InsightFace buffalo_l (rostos) | ~600 MB | todos |
-| Pesos do SAMP-Net (composição) | ~175 MB | todos (o `24gb` usa o Qwen2-VL em vez disso) |
-| BiRefNet_dynamic (saliência do sujeito) | ~424 MB | todos |
-| U2-Net-P (auxiliar de saliência) | ~5 MB | todos |
+| CLIP ViT-L-14 laion2b (embeddings + marcação CLIP + estética CLIP-MLP) | 1,711 GB | `legacy`/`8gb` |
+| Cabeça estética MLP (`sac+logos+ava1-l14-linearMSE.pth`) | 3,7 MB | somente `legacy`/`8gb` |
+| SigLIP 2 NaFlex SO400M (embeddings) | 4,581 GB | `16gb`/`24gb` |
+| Qwen3.5-2B (marcação por VLM) | 4,571 GB | `16gb` |
+| Qwen3.5-4B (marcação por VLM) | 9,343 GB | `24gb` |
+| Qwen2-VL-2B (composição) | 4,430 GB | nenhum por padrão — somente se você definir manualmente `composition_model: "qwen2-vl-2b"` **e** `processing.mode: "single-pass"` |
+| InsightFace buffalo_l (rostos) | 289 MB baixados / 630 MB em disco (o zip é mantido ao lado dos arquivos `.onnx` extraídos) | todos |
+| Pesos do SAMP-Net (composição) | 183 MB | todos |
+| U2-Net-P (submodelo de saliência do SAMP-Net) | 4,7 MB | mesmos perfis do SAMP-Net |
+| BiRefNet_dynamic (saliência do sujeito) | 445 MB | todos |
+| TOPIQ NR (modelo estético) | 181 MB | `16gb`/`24gb` |
+| TOPIQ IAA (estética complementar) | 873 MB | todos |
+| TOPIQ NR-Face (qualidade facial complementar) | 376 MB | todos |
+| LIQE (qualidade/distorção complementar) | 708 MB | todos |
+| timm resnet50.a1_in1k (backbone PyIQA compartilhado) | 102 MB | todos |
+| Q-ReAlign-Mini-0.8B (`iqa_extended.qrealign`) | 2,235 GB | `8gb`/`16gb`/`24gb`, **ativado por padrão** (`"auto"` resulta em ativado em todos os perfis exceto `legacy`) |
 
-Totais por perfil: `legacy`/`8gb` ~3–4 GB · `16gb` ~10–11 GB · `24gb` ~18 GB.
+Totais por perfil (download): `legacy` 4,69 GB · `8gb` 6,93 GB · `16gb` 14,55 GB ·
+`24gb` 19,32 GB · `24gb` com `composition_model: "qwen2-vl-2b"` e
+`processing.mode: "single-pass"` 23,56 GB (a substituição manual troca SAMP-Net/U2-Net-P
+em vez de somar-se a eles).
+
+Como referência, baixar a própria imagem Docker (antes de qualquer download de modelo)
+transfere `ghcr.io/ncoevoet/facet:latest` com 4,18 GB comprimidos e `:latest-cuda` com
+7,33 GB comprimidos, de acordo com os manifestos atuais do registro.
+
+Modelos opcionais não contabilizados nos totais acima:
+
+| Modelo | Tamanho | Gatilho |
+|-------|------|----------|
+| DeQA-Score-Mix3 (`iqa_extended.deqa`) | 16,41 GB | desativado por padrão |
+| Backbone SigLIP so400m-patch14-384 (`iqa_extended.aesthetic_v25`) | 3,515 GB | desativado por padrão, **descontinuado** (AGPL-3.0, sem manutenção upstream — prefira `qrealign`) |
+| Helsinki-NLP OPUS-MT, por idioma de destino (tradução de legendas) | en→fr 303 MB · en→de 298 MB · en→es 312 MB · en→it 343 MB · en→pt 465 MB | somente para os idiomas ativados |
+| MediaPipe `face_landmarker.task` | 3,76 MB | somente quando `mediapipe` está instalado |
+
+`reverse_geocoder` não precisa de download algum — seus dados vêm embutidos no wheel.
 
 Os pesos do SAMP-Net vêm do
 [release model-weights-v1](https://github.com/ncoevoet/facet/releases/download/model-weights-v1/samp_net.pth)

--- a/docs/pt/VIEWER.md
+++ b/docs/pt/VIEWER.md
@@ -1027,6 +1027,7 @@ A documentação interativa da API está disponível em `/api/docs` (Swagger UI)
 |----------|-------------|
 | `GET /api/photos` | Lista paginada de fotos com filtros |
 | `GET /api/photo` | Detalhes de uma única foto |
+| `GET /api/photo/set?path=` | O conjunto bracket/panorâmica/hdr_panorama/sequência/duplicata ao qual uma foto pertence (bracket, panorâmica ou hdr_panorama têm prioridade sobre sequência, que por sua vez tem prioridade sobre duplicata), indexado por `path` — nunca um identificador de grupo, que as passagens de bracket e panorâmica renumeram cada uma a partir de 1 a cada execução |
 | `GET /api/photo/histogram?path=&bins=` | Bins de luminância + R/G/B prontos para desenhar (`bins` ∈ 32/64/128/256, padrão 64), medidos durante a análise na imagem em resolução total. Cada canal é escalado por um único máximo global, nunca pelo seu próprio. `r`/`g`/`b` são `null` para uma linha gravada antes do formato por canal; 404 quando a linha não tem histograma algum, o sinal para o widget recorrer à amostragem da miniatura |
 | `GET /api/type_counts` | Contagens de fotos por tipo |
 | `GET /api/similar_photos/{path}` | Fotos semelhantes (modos: `visual`, `color`, `person`) |

--- a/docs/pt/VIEWER.md
+++ b/docs/pt/VIEWER.md
@@ -155,10 +155,10 @@ python database.py --migrate-user-preferences --user alice
 
 ### Padrões de Composição
 
-Filtrar pelos padrões detectados pelo SAMP-Net:
-- rule_of_thirds, golden_ratio, center, diagonal
-- horizontal, vertical, symmetric, triangle
-- curved, radial, vanishing_point, pattern, fill_frame
+Filtrar pelos padrões detectados pelo SAMP-Net (o modelo emite exatamente estes 8,
+em `models/samp_net.py`):
+- global, horizontal, vertical, triangular
+- surround, quarter, cross, rule_of_thirds
 
 ## Ordenação
 
@@ -215,6 +215,10 @@ Um controle **Manter top %** na barra de ferramentas da galeria (modo de ediçã
 ### Selecionar para pasta
 
 O diálogo **Selecionar para pasta…** da barra de ações em lote (modo de edição) copia as mantidas, ou move/descarta para a lixeira as rejeitadas, para uma pasta de destino em uma única etapa (a lixeira do sistema é controlada por `viewer.cull.allow_trash`, nunca uma exclusão permanente). Aplicar é seguro por construção: `POST /api/cull/apply` nunca confia cegamente em uma lista de exclusão fornecida pelo cliente — ele rederiva no servidor o conjunto real da ação a partir do estado `is_rejected` de cada foto (copiar age apenas sobre as mantidas, mover/lixeira apenas sobre as rejeitadas) e reporta tudo fora desse escopo como `excluded_by_state`, em vez de agir sobre isso. Cada chamada tem `dry_run` habilitado por padrão — uma pré-visualização sempre roda antes de qualquer gravação — e mover/lixeira exigem um `dry_run=false` explícito para prosseguir; incluir o RAW ou sidecar intocado de uma foto rejeitada é opcional (`include_companions`), de forma que rejeitar um JPEG derivado nunca arrasta silenciosamente seu RAW junto. Várias ferramentas fotográficas comerciais já tiveram bugs de seleção de exclusão que afetaram as fotos erradas; o endpoint de aplicação do Facet foi projetado para que o cliente nunca possa especificar diretamente um conjunto a excluir.
+
+**Onde você pode gravar.** Sem `viewer.export.allowed_target_dirs` configurado, as únicas pastas nas quais o Facet pode gravar são seus diretórios de varredura — aponte a caixa de diálogo para uma subpasta da árvore de fotos (por exemplo, `_rejected`) e funciona sem nenhuma configuração. Para usar uma pasta fora da árvore varrida, adicione-a primeiro a `viewer.export.allowed_target_dirs`; qualquer outra coisa é recusada com um `403`, independentemente das permissões do sistema de arquivos. Veja [Configuração — Destinos de exportação e seleção](CONFIGURATION.md#destinos-de-exportação-e-seleção). Ao rodar em Docker/Podman, o caminho digitado é resolvido **dentro do contêiner**, em relação ao que está realmente montado ali — nunca em relação ao sistema de arquivos do host — veja [Implantação — Semântica de caminhos em contêiner](DEPLOYMENT.md#semântica-de-caminhos-em-contêiner).
+
+**"Acesso negado" em toda ação.** Isso é um `403` — uma recusa deliberada da verificação de pasta de destino acima, ou uma sessão de edição expirada — nunca um problema de permissões do sistema de arquivos ou do usuário do contêiner. O aviso não diz qual dos dois é; verifique o corpo da resposta da requisição que falhou na aba Rede do seu navegador para o campo `detail`. Um problema real de permissões do sistema de arquivos se apresenta de forma diferente: a ação reporta sucesso parcial com uma contagem `errors` diferente de zero, e o servidor registra o erro subjacente do sistema operacional para cada arquivo que falhou.
 
 ### Opções de Exibição
 
@@ -317,7 +321,7 @@ Cada álbum pode carregar um contexto de pontuação que decide qual categoria v
 
 ### Exportação de Portfólio
 
-Quando `viewer.features.show_portfolio_export` é `true` (padrão) e a edição está desbloqueada, cada cartão de álbum manual ganha uma ação **Exportar portfólio**. Ela abre uma pequena caixa de diálogo (título da galeria, pasta de destino, alternância para incluir legendas) e renderiza o álbum como uma galeria HTML estática autônoma — o caso de uso do thumbsup/sigal, mas nativo, sem dependência de ferramentas externas. O diretório de saída contém `index.html` (uma grade de miniaturas responsiva apenas em CSS com uma lightbox vanilla-JS integrada — **zero** referências externas/CDN, então funciona totalmente offline), uma pasta `assets/` de JPEG com nomes sequenciais (nenhum caminho da biblioteca é divulgado) e um `manifest.json` que registra contagens e origens por foto. Cada foto prefere o **original** em disco (reduzido para `portfolio.max_edge`, com a orientação EXIF aplicada) e recorre à miniatura de 640 px armazenada quando o original está inacessível (compartilhamentos de rede offline). O endpoint é `POST /api/albums/{album_id}/export-portfolio` (somente edição); o `target_dir` é validado contra a mesma lista de permissões (`viewer.export.allowed_target_dirs` mais os diretórios de varredura) que os endpoints de exportação copiar/mover, e álbuns acima de `portfolio.max_photos` (padrão 500) são recusados. Reexportar o mesmo álbum é idempotente — apenas os próprios arquivos da exportação são reescritos. Veja [Configuração da exportação de portfólio](CONFIGURATION.md#exportação-de-portefólio).
+Quando `viewer.features.show_portfolio_export` é `true` (padrão) e a edição está desbloqueada, cada cartão de álbum manual ganha uma ação **Exportar portfólio**. Ela abre uma pequena caixa de diálogo (título da galeria, pasta de destino, alternância para incluir legendas) e renderiza o álbum como uma galeria HTML estática autônoma — o caso de uso do thumbsup/sigal, mas nativo, sem dependência de ferramentas externas. O diretório de saída contém `index.html` (uma grade de miniaturas responsiva apenas em CSS com uma lightbox vanilla-JS integrada — **zero** referências externas/CDN, então funciona totalmente offline), uma pasta `assets/` de JPEG com nomes sequenciais (nenhum caminho da biblioteca é divulgado) e um `manifest.json` que registra contagens e origens por foto. Cada foto prefere o **original** em disco (reduzido para `portfolio.max_edge`, com a orientação EXIF aplicada) e recorre à miniatura de 640 px armazenada quando o original está inacessível (compartilhamentos de rede offline). O endpoint é `POST /api/albums/{album_id}/export-portfolio` (somente edição); o `target_dir` é validado contra a mesma lista de permissões (`viewer.export.allowed_target_dirs` mais os diretórios de varredura, veja [Configuração — Destinos de exportação e seleção](CONFIGURATION.md#destinos-de-exportação-e-seleção)) que os endpoints de exportação copiar/mover, e álbuns acima de `portfolio.max_photos` (padrão 500) são recusados. Reexportar o mesmo álbum é idempotente — apenas os próprios arquivos da exportação são reescritos. Veja [Configuração da exportação de portfólio](CONFIGURATION.md#exportação-de-portefólio).
 
 API: veja a seção [Endpoints da API](#endpoints-da-api) abaixo.
 
@@ -527,7 +531,7 @@ Encontre clusters de pessoas que podem ser o mesmo indivíduo. Acesse por `/merg
 Grave suas avaliações, favoritos e rejeições no disco como sidecars XMP, para que editores externos (darktable, Lightroom) os reconheçam. Requer o modo de edição.
 
 - **Da galeria** — selecione fotos, então **Ações → Exportar** grava um sidecar ao lado de cada arquivo.
-- **De um álbum** ("cesta") — exporte o álbum inteiro como sidecars, ou copie/crie links simbólicos dos arquivos para um diretório de destino.
+- **De um álbum** ("cesta") — exporte o álbum inteiro como sidecars, ou copie/crie links simbólicos dos arquivos para um diretório de destino (mesma lista de destinos permitidos que [Selecionar para pasta](#selecionar-para-pasta)).
 - **Gravar metadados no arquivo** — a ação "Gravar metadados no arquivo" nos detalhes da foto incorpora a avaliação/palavras-chave diretamente no arquivo original (JPEG/HEIC/TIFF/PNG/DNG via exiftool) além de gravar o sidecar, para que todo o ecossistema de fotos os veja. Originais RAW proprietários nunca são modificados. Controlado por `viewer.features.show_embed_metadata` (padrão: `true`).
 
 API: veja a seção [Endpoints da API](#endpoints-da-api) abaixo.
@@ -1023,6 +1027,7 @@ A documentação interativa da API está disponível em `/api/docs` (Swagger UI)
 |----------|-------------|
 | `GET /api/photos` | Lista paginada de fotos com filtros |
 | `GET /api/photo` | Detalhes de uma única foto |
+| `GET /api/photo/histogram?path=&bins=` | Bins de luminância + R/G/B prontos para desenhar (`bins` ∈ 32/64/128/256, padrão 64), medidos durante a análise na imagem em resolução total. Cada canal é escalado por um único máximo global, nunca pelo seu próprio. `r`/`g`/`b` são `null` para uma linha gravada antes do formato por canal; 404 quando a linha não tem histograma algum, o sinal para o widget recorrer à amostragem da miniatura |
 | `GET /api/type_counts` | Contagens de fotos por tipo |
 | `GET /api/similar_photos/{path}` | Fotos semelhantes (modos: `visual`, `color`, `person`) |
 | `GET /api/search?q=&limit=&threshold=&scope=` | Busca semântica de texto para imagem (`scope=text` = apenas texto OCR/legenda) |

--- a/facet.py
+++ b/facet.py
@@ -77,7 +77,7 @@ import json
 from pathlib import Path
 from datetime import datetime, timezone
 from db import DEFAULT_DB_PATH, init_database, get_connection, check_disk_space
-from db.render_version import CURRENT_RENDER_VERSION, raw_path_predicate
+from db.render_version import raw_path_predicate
 
 try:
     from tqdm import tqdm
@@ -798,21 +798,27 @@ def refresh_thumbnails(db_path, config, workers):
 
     Resumable: every committed chunk advances a watermark in ``stats_cache``,
     so an interrupted run picks up at the next path and a finished run clears
-    it. Reads run on the shared RAW decode pool because the cost here is
-    storage throughput, not CPU.
+    it. The reads run on a pool of this function's own, NOT on the shared RAW
+    decode pool: rendering a preview-less or bracketed RAW submits the demosaic
+    to that pool and waits on its future, so dispatching this work there too
+    would leave every worker blocked on a future queued behind the work those
+    same workers still have to run.
 
-    Every rewritten row is stamped ``CURRENT_RENDER_VERSION``, which is what
-    drops it out of the viewer's migration-status count. Rows are NOT skipped on
-    that stamp: a completed run starts over on purpose, so re-running after a
-    ``raw_decode.bright`` change rebuilds everything.
+    Every rewritten row is stamped with the rendering it was given, which is
+    what drops it out of the viewer's migration-status count. Rows are NOT
+    skipped on that stamp: a completed run starts over on purpose, so re-running
+    after a ``raw_decode.bright`` change rebuilds everything.
 
     Sequence detection runs after a scan, so bracket membership is only known
-    here — which is why a bracketed frame's uncorrected rendering is applied at
+    here — which is why a bracketed frame's uncorrected rendering, and the
+    ``FAITHFUL_RENDER_VERSION`` stamp that says it was applied, are written at
     refresh time rather than at scan time.
     """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from db.render_version import render_version_for
     from db.stats_cache import refresh_pending_render_stat
     from utils import configure_raw_decode_profile, configure_raw_decoding
-    from utils.image_loading import submit_decode
 
     configure_raw_decode_profile(config.get_raw_decode_settings())
     proc = config.get_processing_settings()
@@ -836,32 +842,36 @@ def refresh_thumbnails(db_path, config, workers):
     updated = 0
     failed = 0
     interrupted = False
-    with get_connection(db_path) as conn:
-        with tqdm(total=len(rows), desc="Thumbnails") as pbar:
-            for start in range(0, len(rows), REFRESH_THUMBNAILS_CHUNK):
-                chunk = rows[start:start + REFRESH_THUMBNAILS_CHUNK]
-                try:
-                    futures = [(p, submit_decode(_display_thumbnail_bytes, p, size, quality, kind))
-                               for p, kind in chunk]
-                    rendered = [(p, f.result()) for p, f in futures]
-                except KeyboardInterrupt:
-                    interrupted = True
-                    break
-                for path, blob in rendered:
-                    if blob is None:
-                        failed += 1
-                        continue
-                    conn.execute(
-                        "UPDATE photos SET thumbnail = ?, render_version = ? WHERE path = ?",
-                        (blob, CURRENT_RENDER_VERSION, path))
-                    updated += 1
-                _write_thumbnail_watermark(conn, chunk[-1][0])
-                conn.commit()
-                pbar.update(len(chunk))
-        if not interrupted:
-            _clear_thumbnail_watermark(conn)
-        refresh_pending_render_stat(conn)
-        conn.commit()
+    pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix='thumbrefresh')
+    try:
+        with get_connection(db_path) as conn:
+            with tqdm(total=len(rows), desc="Thumbnails") as pbar:
+                for start in range(0, len(rows), REFRESH_THUMBNAILS_CHUNK):
+                    chunk = rows[start:start + REFRESH_THUMBNAILS_CHUNK]
+                    try:
+                        futures = [(p, kind, pool.submit(_display_thumbnail_bytes, p, size, quality, kind))
+                                   for p, kind in chunk]
+                        rendered = [(p, kind, f.result()) for p, kind, f in futures]
+                    except KeyboardInterrupt:
+                        interrupted = True
+                        break
+                    for path, kind, blob in rendered:
+                        if blob is None:
+                            failed += 1
+                            continue
+                        conn.execute(
+                            "UPDATE photos SET thumbnail = ?, render_version = ? WHERE path = ?",
+                            (blob, render_version_for(kind), path))
+                        updated += 1
+                    _write_thumbnail_watermark(conn, chunk[-1][0])
+                    conn.commit()
+                    pbar.update(len(chunk))
+            if not interrupted:
+                _clear_thumbnail_watermark(conn)
+            refresh_pending_render_stat(conn)
+            conn.commit()
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
 
     if interrupted:
         logger.warning("Interrupted after %d thumbnails — re-run --refresh-thumbnails to continue.",

--- a/facet.py
+++ b/facet.py
@@ -77,6 +77,7 @@ import json
 from pathlib import Path
 from datetime import datetime, timezone
 from db import DEFAULT_DB_PATH, init_database, get_connection, check_disk_space
+from db.render_version import CURRENT_RENDER_VERSION, raw_path_predicate
 
 try:
     from tqdm import tqdm
@@ -628,6 +629,7 @@ UNKNOWN_LIBRARY_JOB = {'pid': None, 'kind': 'library job', 'origin': 'unknown'}
 DEFAULT_SCAN_STALE_SECONDS = 120
 
 LIBRARY_JOB_ARGS = (
+    'backfill_clipping',
     'backfill_focal_35mm',
     'cluster_faces_force',
     'cluster_faces_incremental',
@@ -667,6 +669,7 @@ LIBRARY_JOB_ARGS = (
     'tag_untagged',
     'refill_face_thumbnails_force',
     'refill_face_thumbnails_incremental',
+    'refresh_thumbnails',
     'rescan_gps',
     'score_topiq',
     'sync_label_comparisons',
@@ -716,6 +719,217 @@ def detect_all_sequences(db_path, config_path, incremental=False, contain_failur
         logger.warning("Panorama detection failed (non-fatal)", exc_info=True)
         panoramas = None
     return brackets, panoramas
+
+
+REFRESH_THUMBNAILS_WATERMARK_KEY = 'refresh_thumbnails_watermark'
+REFRESH_THUMBNAILS_CHUNK = 200
+
+# Refreshing thumbnails is bound by storage round-trips, not by CPU: each file
+# is a small read at the far end of whatever mount the library lives on. The
+# default is therefore wider than the scan's decode concurrency, which is sized
+# as a memory governor for full demosaics, while still bounding the demosaics a
+# preview-less RAW falls back to.
+DEFAULT_REFRESH_THUMBNAIL_WORKERS = 8
+
+DEFAULT_CHECK_RAW_SAMPLE = 20
+
+# An interrupted refresh has left work undone, and a wrapper script must be able
+# to tell that from a finished one.
+INTERRUPTED_EXIT_CODE = 130
+
+
+def _raw_rows_after(conn, watermark):
+    """``(path, sequence_kind)`` for every RAW row past the watermark.
+
+    The kind rides along because it selects the rendering — a bracketed frame
+    is re-rendered with no correction at all (see
+    ``utils.image_loading.renders_faithfully``).
+    """
+    where = f"({raw_path_predicate()})"
+    params = ()
+    if watermark:
+        where += " AND path > ?"
+        params = (watermark,)
+    return [(row['path'], row['sequence_kind']) for row in conn.execute(
+        f"SELECT path, sequence_kind FROM photos WHERE {where} ORDER BY path",
+        params).fetchall()]
+
+
+def _read_thumbnail_watermark(conn):
+    row = conn.execute("SELECT value FROM stats_cache WHERE key = ?",
+                       (REFRESH_THUMBNAILS_WATERMARK_KEY,)).fetchone()
+    return row[0] if row and row[0] else None
+
+
+def _write_thumbnail_watermark(conn, path):
+    conn.execute(
+        "INSERT OR REPLACE INTO stats_cache (key, value, updated_at) VALUES (?, ?, ?)",
+        (REFRESH_THUMBNAILS_WATERMARK_KEY, path, time.time()))
+
+
+def _clear_thumbnail_watermark(conn):
+    conn.execute("DELETE FROM stats_cache WHERE key = ?",
+                 (REFRESH_THUMBNAILS_WATERMARK_KEY,))
+
+
+def _display_thumbnail_bytes(path, size, quality, sequence_kind=None):
+    """Build one stored thumbnail from the display profile, or None if unusable.
+
+    "Unusable" covers more than a failed decode. A severely truncated Panasonic
+    RW2 decodes *successfully* into a zero-filled, full-size black frame, so a
+    bare ``is None`` check would let a corrupt file overwrite a good stored
+    thumbnail with a black one. Rejecting it here keeps the old thumbnail and
+    leaves the row unstamped, so a repaired file is picked up on a later run.
+    """
+    from utils import generate_photo_thumbnail, load_display_image, thumbnail_has_signal
+    img = load_display_image(path, sequence_kind=sequence_kind)
+    if img is None:
+        return None
+    blob = generate_photo_thumbnail(img, size=size, quality=quality)
+    if not thumbnail_has_signal(blob):
+        logger.warning("Discarded a black render of %s (truncated or corrupt file?) — "
+                       "kept the stored thumbnail", path)
+        return None
+    return blob
+
+
+def refresh_thumbnails(db_path, config, workers):
+    """Rebuild stored thumbnails for RAW rows from the display profile.
+
+    Resumable: every committed chunk advances a watermark in ``stats_cache``,
+    so an interrupted run picks up at the next path and a finished run clears
+    it. Reads run on the shared RAW decode pool because the cost here is
+    storage throughput, not CPU.
+
+    Every rewritten row is stamped ``CURRENT_RENDER_VERSION``, which is what
+    drops it out of the viewer's migration-status count. Rows are NOT skipped on
+    that stamp: a completed run starts over on purpose, so re-running after a
+    ``raw_decode.bright`` change rebuilds everything.
+
+    Sequence detection runs after a scan, so bracket membership is only known
+    here — which is why a bracketed frame's uncorrected rendering is applied at
+    refresh time rather than at scan time.
+    """
+    from db.stats_cache import refresh_pending_render_stat
+    from utils import configure_raw_decode_profile, configure_raw_decoding
+    from utils.image_loading import submit_decode
+
+    configure_raw_decode_profile(config.get_raw_decode_settings())
+    proc = config.get_processing_settings()
+    thumbs = proc.get('thumbnails', {})
+    size = thumbs.get('photo_size', 640)
+    quality = thumbs.get('photo_quality', 80)
+    configure_raw_decoding(concurrency=workers,
+                           timeout_seconds=proc.get('raw_decode_timeout_seconds', 120))
+
+    with get_connection(db_path) as conn:
+        watermark = _read_thumbnail_watermark(conn)
+        rows = _raw_rows_after(conn, watermark)
+    if watermark:
+        logger.info("Resuming thumbnail refresh after %s", watermark)
+    if not rows:
+        logger.info("No RAW photos left to refresh.")
+        return 0, 0, False
+
+    logger.info("Refreshing thumbnails for %d RAW photos (%d parallel reads)",
+                len(rows), workers)
+    updated = 0
+    failed = 0
+    interrupted = False
+    with get_connection(db_path) as conn:
+        with tqdm(total=len(rows), desc="Thumbnails") as pbar:
+            for start in range(0, len(rows), REFRESH_THUMBNAILS_CHUNK):
+                chunk = rows[start:start + REFRESH_THUMBNAILS_CHUNK]
+                try:
+                    futures = [(p, submit_decode(_display_thumbnail_bytes, p, size, quality, kind))
+                               for p, kind in chunk]
+                    rendered = [(p, f.result()) for p, f in futures]
+                except KeyboardInterrupt:
+                    interrupted = True
+                    break
+                for path, blob in rendered:
+                    if blob is None:
+                        failed += 1
+                        continue
+                    conn.execute(
+                        "UPDATE photos SET thumbnail = ?, render_version = ? WHERE path = ?",
+                        (blob, CURRENT_RENDER_VERSION, path))
+                    updated += 1
+                _write_thumbnail_watermark(conn, chunk[-1][0])
+                conn.commit()
+                pbar.update(len(chunk))
+        if not interrupted:
+            _clear_thumbnail_watermark(conn)
+        refresh_pending_render_stat(conn)
+        conn.commit()
+
+    if interrupted:
+        logger.warning("Interrupted after %d thumbnails — re-run --refresh-thumbnails to continue.",
+                       updated)
+    if failed:
+        logger.warning("%d photos could not be re-rendered and kept their old thumbnail "
+                       "(see the warnings above for which, and why).", failed)
+    return updated, failed, interrupted
+
+
+def _mean_luminance(pil_img):
+    import numpy as np
+    return float(np.asarray(pil_img.convert('L'), dtype=np.float32).mean())
+
+
+def _render_raw_variants(path):
+    """Mean luminance of one RAW under the pre-fix, fixed and display renderings."""
+    import rawpy
+    from PIL import Image
+    from utils.image_loading import load_display_image, raw_postprocess_kwargs
+
+    with rawpy.imread(path) as raw:
+        previous = Image.fromarray(raw.postprocess(**raw_postprocess_kwargs(auto_bright=True)))
+    with rawpy.imread(path) as raw:
+        metrics = Image.fromarray(raw.postprocess(**raw_postprocess_kwargs()))
+    display = load_display_image(path)
+    return (_mean_luminance(previous), _mean_luminance(metrics),
+            _mean_luminance(display) if display is not None else None)
+
+
+def check_raw_rendering(db_path, config, sample_size):
+    """Print how a sample of RAW files renders before and after the decode fix.
+
+    Answers "what would a rescan change?" without running one: per-frame
+    auto-brightness against the fixed ``raw_decode.bright`` gain, plus the
+    camera preview the stored thumbnail and the viewer now use.
+    """
+    from utils import configure_raw_decode_profile
+
+    if not os.path.exists(db_path):
+        logger.error("Database not found: %s", db_path)
+        return 1
+    bright = configure_raw_decode_profile(config.get_raw_decode_settings())['bright']
+    with get_connection(db_path) as conn:
+        rows = conn.execute(
+            f"SELECT path FROM photos WHERE ({raw_path_predicate()}) "
+            "ORDER BY RANDOM() LIMIT ?", (sample_size,)).fetchall()
+    sample = [row['path'] for row in rows if os.path.exists(row['path'])]
+    if not sample:
+        logger.error("No readable RAW photos found in %s", db_path)
+        return 1
+
+    logger.info("raw_decode.bright = %.2f — mean luminance per rendering (0-255)", bright)
+    logger.info("%-40s %10s %10s %10s %8s", "Filename", "auto-bright", "fixed", "preview", "delta%")
+    logger.info("%s %s %s %s %s", "-" * 40, "-" * 10, "-" * 10, "-" * 10, "-" * 8)
+    for path in tqdm(sample, desc="Rendering"):
+        try:
+            previous, metrics, display = _render_raw_variants(path)
+        except Exception as ex:
+            logger.warning("%-40s failed: %s", os.path.basename(path)[:39], ex)
+            continue
+        delta = (metrics - previous) / previous * 100 if previous else 0.0
+        logger.info("%-40s %10.1f %10.1f %10s %+8.1f",
+                    os.path.basename(path)[:39], previous, metrics,
+                    "-" if display is None else f"{display:.1f}", delta)
+    logger.info("A bracket rendered under 'auto-bright' converges to one exposure; "
+                "under 'fixed' and 'preview' it keeps its ladder.")
+    return 0
 
 
 class LibraryLockError(RuntimeError):
@@ -1356,7 +1570,7 @@ def _run_scan(args, resumed_run):
         exit(1)
 
     # 2. Main Processing Loop
-    from utils import configure_raw_decoding
+    from utils import configure_raw_decode_profile, configure_raw_decoding
     from processing.scan_state import ScanRun, scan_in_progress
     from processing.progress import emit_progress
     _proc = scorer.config.get_processing_settings()
@@ -1364,6 +1578,7 @@ def _run_scan(args, resumed_run):
         concurrency=_proc.get('raw_decode_concurrency', 0),
         timeout_seconds=_proc.get('raw_decode_timeout_seconds', 120),
     )
+    configure_raw_decode_profile(scorer.config.get_raw_decode_settings())
 
     # Concurrency guard: a run with a fresh heartbeat looks genuinely live.
     # Resuming on top of it would double-process, so refuse; a fresh scan only
@@ -1773,8 +1988,27 @@ Configuration:
                              'never rewrites the active config). Run --detect-moments first to populate caption_embedding.')
     db_group.add_argument('--discover-min-cluster-size', type=int, default=30, metavar='N',
                         help='HDBSCAN granularity for --discover-moments (smaller = more, finer moments; default 30)')
+    db_group.add_argument('--refresh-thumbnails', action='store_true',
+                        help='Rebuild stored thumbnails for RAW photos from the camera-embedded '
+                             'preview (CPU only, no models, no scoring column touched). Bound by '
+                             'storage throughput, so the cost scales with library size and link '
+                             'speed. Resumable: re-run it after an interrupt to continue.')
+    db_group.add_argument('--refresh-thumbnails-workers', type=int, metavar='N',
+                        default=DEFAULT_REFRESH_THUMBNAIL_WORKERS,
+                        help=f'Parallel reads for --refresh-thumbnails (default '
+                             f'{DEFAULT_REFRESH_THUMBNAIL_WORKERS}). The work is storage-bound; '
+                             'raise it for a fast network mount, lower it for a slow disk')
+    db_group.add_argument('--check-raw-rendering', type=int, nargs='?', metavar='N',
+                        const=DEFAULT_CHECK_RAW_SAMPLE, default=None,
+                        help=f'Render N sampled RAW photos (default {DEFAULT_CHECK_RAW_SAMPLE}) '
+                             'under the pre-fix and current decode settings and print the '
+                             'mean-luminance deltas. Read-only — validate settings before a rescan')
     db_group.add_argument('--backfill-focal-35mm', action='store_true',
                         help='Backfill focal_length_35mm from EXIF for photos missing it')
+    db_group.add_argument('--backfill-clipping', action='store_true',
+                        help='Derive per-channel clipping percentages from stored histograms. '
+                             'Database-only (no image decode) and resumable; photos whose '
+                             'histogram predates the RGB format stay unknown')
     db_group.add_argument('--score-topiq', action='store_true',
                         help='Backfill TOPIQ quality scores from stored thumbnails (requires GPU)')
     db_group.add_argument('--recompute-iqa', action='store_true',
@@ -1995,6 +2229,10 @@ Configuration:
     if args.dry_run_count != 10 and not args.dry_run:
         parser.error("--dry-run-count requires --dry-run")
 
+    if (args.refresh_thumbnails_workers != DEFAULT_REFRESH_THUMBNAIL_WORKERS
+            and not args.refresh_thumbnails):
+        parser.error("--refresh-thumbnails-workers requires --refresh-thumbnails")
+
     # Whole-library rewriters take the cross-process lock before any work, so
     # a conflict costs nothing. --upgrade-db is deliberately absent: it runs
     # the locked jobs below as subprocesses and would deadlock every one. Its
@@ -2176,6 +2414,20 @@ Configuration:
         list_available_models()
         exit()
 
+    # Compare RAW renderings before committing to a rescan (read-only, no GPU)
+    if args.check_raw_rendering is not None:
+        exit(check_raw_rendering(args.db, ScoringConfig(args.config),
+                                 args.check_raw_rendering))
+
+    # Rebuild RAW thumbnails from the display profile (storage-bound, no GPU)
+    if args.refresh_thumbnails:
+        init_database(args.db)
+        updated, failed, interrupted = refresh_thumbnails(
+            args.db, ScoringConfig(args.config), args.refresh_thumbnails_workers)
+        logger.info("Thumbnail refresh %s: %d updated, %d unreadable.",
+                    "stopped early" if interrupted else "complete", updated, failed)
+        exit(INTERRUPTED_EXIT_CODE if interrupted else 0)
+
     # Detect duplicate photos (lightweight - no GPU needed)
     if args.detect_duplicates:
         from utils.duplicate import detect_duplicates
@@ -2238,6 +2490,13 @@ Configuration:
         elif apply_recs:
             logger.info("No recommendations to apply.")
 
+        exit()
+
+    # Derive per-channel clipping from stored histograms (no image decode)
+    if args.backfill_clipping:
+        from db.maintenance import backfill_channel_clipping
+        init_database(args.db)
+        backfill_channel_clipping(args.db)
         exit()
 
     # Backfill focal_length_35mm from EXIF (lightweight - no GPU needed)
@@ -2872,6 +3131,7 @@ Configuration:
     if args.generate_captions:
         from models.vlm_tagger import VLMTagger
         from PIL import Image
+        from utils import load_display_image
         import io
 
         config = ScoringConfig(args.config)
@@ -2927,15 +3187,9 @@ Configuration:
                             if row['thumbnail']:
                                 img = Image.open(io.BytesIO(row['thumbnail'])).convert('RGB')
                             else:
-                                path = row['path']
-                                ext = os.path.splitext(path)[1].lower()
-                                if ext in RAW_EXTENSIONS:
-                                    import rawpy
-                                    with rawpy.imread(path) as raw:
-                                        rgb = raw.postprocess()
-                                    img = Image.fromarray(rgb).convert('RGB')
-                                else:
-                                    img = Image.open(path).convert('RGB')
+                                img = load_display_image(row['path'])
+                                if img is None:
+                                    raise RuntimeError("image could not be decoded")
                                 img.thumbnail((640, 640))
                             caption = vlm.generate(img, "Describe this photo in one concise sentence.", max_new_tokens=100)
                             conn.execute("UPDATE photos SET caption = ? WHERE path = ?", (caption.strip(), row['path']))

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -202,7 +202,8 @@
     "histogram_spread": "Histogramm",
     "star_rating": "Bewertung",
     "topiq_score": "TOPIQ",
-    "persons": "Personen",
+    "filter_by_person": "Nach {name} filtern",
+    "set_section": "Gruppe",
     "histogram": "Histogramm"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Filter wiederherstellen",
       "showing_all": "Alle Fotos werden angezeigt – einschließlich Blinzler, Serien und Duplikate"
     },
+    "render_migration": {
+      "message": "{n} RAW-Fotos zeigen noch eine Miniatur aus der vorherigen Darstellung.",
+      "command_hint": "Führen Sie {command} aus, um alle auf einmal aufzufrischen."
+    },
+    "set_scope": {
+      "message": "Eine Fotogruppe wird angezeigt: {kind}"
+    },
     "all_photos": "Alle Fotos",
     "sort": "Sortieren nach",
     "sort_aggregate": "Gesamtwertung",
@@ -1079,6 +1087,12 @@
       "panel": "Seitenleiste",
       "off": "Aus",
       "panel_empty": "Fahre über ein Foto oder klicke es an, um seine Details hier zu sehen"
+    },
+    "panel_activation": {
+      "label": "Panel-Aktivierung",
+      "hover": "Hover",
+      "click": "Klick",
+      "both": "Hover oder Klick"
     },
     "hide_blinks": "Blinzler ausblenden",
     "hide_bursts": "Beste aus Serie",
@@ -1238,7 +1252,13 @@
       "title": "{count} Fotos im Vergleich",
       "hint": "Scrollen zum Zoomen, Ziehen zum Verschieben – alle Bereiche bewegen sich gemeinsam. Doppelklick setzt zurück.",
       "reset_zoom": "Zoom zurücksetzen"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Beschnittene Lichter: {percent}% der Pixel",
+      "badge_shadow": "Beschnittene Schatten: {percent}% der Pixel"
+    },
+    "channel_clip_highlight_range": "Beschnittene Lichter %",
+    "channel_clip_shadow_range": "Beschnittene Schatten %"
   },
   "composition_patterns": {
     "none": "Keines",
@@ -2294,7 +2314,13 @@
     "add_location": "Standort hinzufügen",
     "gps_click_to_place": "Klicken Sie auf die Karte, um eine Markierung zu setzen",
     "gps_clear": "Standort entfernen",
-    "social_crop": "Social-Zuschnitt"
+    "social_crop": "Social-Zuschnitt",
+    "set": {
+      "title": "Gruppe",
+      "ev_span": "EV-Spanne",
+      "kind_duplicate": "Duplikat",
+      "open_in_gallery": "Diese Gruppe in der Galerie öffnen"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "Einstellungen konnten nicht gespeichert werden",
       "redetect_started": "Erkennung gestartet; sie läuft im Hintergrund",
       "redetect_failed": "Erkennung konnte nicht gestartet werden"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Histogramm-Kanäle",
+      "luminance": "Lum",
+      "rgb": "RGB",
+      "red": "R",
+      "green": "G",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Schatten beschnitten: {channels}",
+      "highlight": "Lichter beschnitten: {channels}"
     }
   }
 }

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -543,7 +543,8 @@
     "access_denied": "Zugriff verweigert",
     "edition_expired": "Bearbeitungsmodus nicht mehr aktiv - Bearbeitung entsperren und erneut versuchen",
     "server_error": "Serverfehler — bitte versuchen Sie es erneut",
-    "action_failed": "Aktion fehlgeschlagen — Änderung rückgängig gemacht"
+    "action_failed": "Aktion fehlgeschlagen — Änderung rückgängig gemacht",
+    "server_detail": "Servermeldung:"
   },
   "language": {
     "en": "Englisch",
@@ -2319,7 +2320,8 @@
       "title": "Gruppe",
       "ev_span": "EV-Spanne",
       "kind_duplicate": "Duplikat",
-      "open_in_gallery": "Diese Gruppe in der Galerie öffnen"
+      "open_in_gallery": "Diese Gruppe in der Galerie öffnen",
+      "member_position": "Bild {position} von {count}"
     }
   },
   "photo": {

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -202,7 +202,8 @@
     "form_fractal": "Fractal",
     "color_harmony": "Color Harmony",
     "caption": "Caption",
-    "persons": "Persons",
+    "filter_by_person": "Filter by {name}",
+    "set_section": "Set",
     "histogram": "Histogram"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Restore filters",
       "showing_all": "Showing every photo — blinks, bursts and duplicates included"
     },
+    "render_migration": {
+      "message": "{n} RAW photos still show a thumbnail from the previous rendering.",
+      "command_hint": "Run {command} to refresh them all at once."
+    },
+    "set_scope": {
+      "message": "Showing one photo set: {kind}"
+    },
     "all_photos": "All Photos",
     "sort": "Sort by",
     "sort_aggregate": "Aggregate",
@@ -1079,6 +1087,12 @@
       "panel": "Side panel",
       "off": "Off",
       "panel_empty": "Hover or click a photo to see its details here"
+    },
+    "panel_activation": {
+      "label": "Panel activation",
+      "hover": "Hover",
+      "click": "Click",
+      "both": "Hover or click"
     },
     "hide_blinks": "Hide Blinks",
     "hide_bursts": "Best of Burst",
@@ -1238,7 +1252,13 @@
       "title": "Comparing {count} photos",
       "hint": "Scroll to zoom, drag to pan — every pane moves together. Double-click to reset.",
       "reset_zoom": "Reset zoom"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Clipped highlights: {percent}% of pixels",
+      "badge_shadow": "Clipped shadows: {percent}% of pixels"
+    },
+    "channel_clip_highlight_range": "Clipped Highlights %",
+    "channel_clip_shadow_range": "Clipped Shadows %"
   },
   "composition_patterns": {
     "none": "None",
@@ -2294,7 +2314,13 @@
     "caption_error": "Failed to generate caption",
     "translating_caption": "Translating...",
     "location": "Location",
-    "social_crop": "Social crop"
+    "social_crop": "Social crop",
+    "set": {
+      "title": "Set",
+      "ev_span": "EV span",
+      "kind_duplicate": "Duplicate",
+      "open_in_gallery": "Open this set in the gallery"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "Could not save the settings",
       "redetect_started": "Detection started; it runs in the background",
       "redetect_failed": "Could not start detection"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Histogram channels",
+      "luminance": "Lum",
+      "rgb": "RGB",
+      "red": "R",
+      "green": "G",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Shadow clipping: {channels}",
+      "highlight": "Highlight clipping: {channels}"
     }
   }
 }

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -543,7 +543,8 @@
     "access_denied": "Access denied",
     "edition_expired": "Edition mode is no longer active - unlock Edition and try again",
     "server_error": "Server error — please try again",
-    "action_failed": "Action failed — change reverted"
+    "action_failed": "Action failed — change reverted",
+    "server_detail": "Server message:"
   },
   "language": {
     "en": "English",
@@ -2319,7 +2320,8 @@
       "title": "Set",
       "ev_span": "EV span",
       "kind_duplicate": "Duplicate",
-      "open_in_gallery": "Open this set in the gallery"
+      "open_in_gallery": "Open this set in the gallery",
+      "member_position": "Frame {position} of {count}"
     }
   },
   "photo": {

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -202,7 +202,8 @@
     "histogram_spread": "Histograma",
     "star_rating": "Valoración",
     "topiq_score": "TOPIQ",
-    "persons": "Personas",
+    "filter_by_person": "Filtrar por {name}",
+    "set_section": "Grupo",
     "histogram": "Histograma"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Restaurar filtros",
       "showing_all": "Se muestran todas las fotos, incluidos parpadeos, ráfagas y duplicados"
     },
+    "render_migration": {
+      "message": "{n} fotos RAW aún muestran una miniatura del renderizado anterior.",
+      "command_hint": "Ejecuta {command} para actualizarlas todas de una vez."
+    },
+    "set_scope": {
+      "message": "Se muestra un grupo de fotos: {kind}"
+    },
     "all_photos": "Todas las fotos",
     "sort": "Ordenar por",
     "sort_aggregate": "Global",
@@ -1079,6 +1087,12 @@
       "panel": "Panel lateral",
       "off": "Desactivado",
       "panel_empty": "Pasa el cursor sobre una foto o haz clic en ella para ver aquí sus detalles"
+    },
+    "panel_activation": {
+      "label": "Activación del panel",
+      "hover": "Hover",
+      "click": "Clic",
+      "both": "Hover o clic"
     },
     "hide_blinks": "Ocultar parpadeos",
     "hide_bursts": "Mejor de ráfaga",
@@ -1238,7 +1252,13 @@
       "title": "Comparando {count} fotos",
       "hint": "Rueda para ampliar, arrastra para desplazar: todos los paneles se mueven juntos. Doble clic para restablecer.",
       "reset_zoom": "Restablecer zoom"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Altas luces recortadas: {percent}% de los píxeles",
+      "badge_shadow": "Sombras recortadas: {percent}% de los píxeles"
+    },
+    "channel_clip_highlight_range": "% de altas luces recortadas",
+    "channel_clip_shadow_range": "% de sombras recortadas"
   },
   "composition_patterns": {
     "none": "Ninguno",
@@ -2294,7 +2314,13 @@
     "add_location": "Añadir ubicación",
     "gps_click_to_place": "Haz clic en el mapa para colocar un marcador",
     "gps_clear": "Borrar ubicación",
-    "social_crop": "Recorte social"
+    "social_crop": "Recorte social",
+    "set": {
+      "title": "Grupo",
+      "ev_span": "Rango EV",
+      "kind_duplicate": "Duplicado",
+      "open_in_gallery": "Abrir este grupo en la galería"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "No se pudieron guardar los ajustes",
       "redetect_started": "Detección iniciada; se ejecuta en segundo plano",
       "redetect_failed": "No se pudo iniciar la detección"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Canales del histograma",
+      "luminance": "Lum",
+      "rgb": "RGB",
+      "red": "R",
+      "green": "G",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Sombras recortadas: {channels}",
+      "highlight": "Altas luces recortadas: {channels}"
     }
   }
 }

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -543,7 +543,8 @@
     "access_denied": "Acceso denegado",
     "edition_expired": "El modo edición ya no está activo - desbloquea Edición e inténtalo de nuevo",
     "server_error": "Error del servidor — por favor inténtelo de nuevo",
-    "action_failed": "Error en la acción — cambio revertido"
+    "action_failed": "Error en la acción — cambio revertido",
+    "server_detail": "Mensaje del servidor:"
   },
   "language": {
     "en": "Inglés",
@@ -2319,7 +2320,8 @@
       "title": "Grupo",
       "ev_span": "Rango EV",
       "kind_duplicate": "Duplicado",
-      "open_in_gallery": "Abrir este grupo en la galería"
+      "open_in_gallery": "Abrir este grupo en la galería",
+      "member_position": "Fotograma {position} de {count}"
     }
   },
   "photo": {

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -543,7 +543,8 @@
     "access_denied": "Accès refusé",
     "edition_expired": "Le mode édition n'est plus actif - déverrouillez Édition et réessayez",
     "server_error": "Erreur serveur — veuillez réessayer",
-    "action_failed": "Échec de l'action — modification annulée"
+    "action_failed": "Échec de l'action — modification annulée",
+    "server_detail": "Message du serveur :"
   },
   "language": {
     "en": "Anglais",
@@ -2319,7 +2320,8 @@
       "title": "Groupe",
       "ev_span": "Écart EV",
       "kind_duplicate": "Doublon",
-      "open_in_gallery": "Ouvrir ce groupe dans la galerie"
+      "open_in_gallery": "Ouvrir ce groupe dans la galerie",
+      "member_position": "Image {position} sur {count}"
     }
   },
   "photo": {

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -202,7 +202,8 @@
     "form_fractal": "Fractale",
     "color_harmony": "Harmonie couleurs",
     "caption": "Légende",
-    "persons": "Personnes",
+    "filter_by_person": "Filtrer par {name}",
+    "set_section": "Groupe",
     "histogram": "Histogramme"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Rétablir les filtres",
       "showing_all": "Toutes les photos sont affichées, y compris clignements, rafales et doublons"
     },
+    "render_migration": {
+      "message": "{n} photos RAW affichent encore une miniature issue du rendu précédent.",
+      "command_hint": "Lancez {command} pour toutes les rafraîchir d'un coup."
+    },
+    "set_scope": {
+      "message": "Un groupe de photos est affiché : {kind}"
+    },
     "all_photos": "Toutes les photos",
     "sort": "Trier par",
     "sort_aggregate": "Agrégat",
@@ -1079,6 +1087,12 @@
       "panel": "Panneau latéral",
       "off": "Désactivée",
       "panel_empty": "Survolez une photo ou cliquez dessus pour voir ses détails ici"
+    },
+    "panel_activation": {
+      "label": "Activation du panneau",
+      "hover": "Survol",
+      "click": "Clic",
+      "both": "Survol ou clic"
     },
     "hide_blinks": "Masquer clignements",
     "hide_bursts": "Meilleure de la rafale",
@@ -1238,7 +1252,13 @@
       "title": "Comparaison de {count} photos",
       "hint": "Molette pour zoomer, glisser pour déplacer : tous les volets bougent ensemble. Double-clic pour réinitialiser.",
       "reset_zoom": "Réinitialiser le zoom"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Hautes lumières écrêtées : {percent} % des pixels",
+      "badge_shadow": "Ombres écrêtées : {percent} % des pixels"
+    },
+    "channel_clip_highlight_range": "Hautes lumières écrêtées %",
+    "channel_clip_shadow_range": "Ombres écrêtées %"
   },
   "composition_patterns": {
     "none": "Aucun",
@@ -2294,7 +2314,13 @@
     "caption_error": "Échec de la génération de la légende",
     "translating_caption": "Traduction en cours...",
     "location": "Localisation",
-    "social_crop": "Recadrage social"
+    "social_crop": "Recadrage social",
+    "set": {
+      "title": "Groupe",
+      "ev_span": "Écart EV",
+      "kind_duplicate": "Doublon",
+      "open_in_gallery": "Ouvrir ce groupe dans la galerie"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "Impossible d'enregistrer les réglages",
       "redetect_started": "Détection lancée ; elle s'exécute en arrière-plan",
       "redetect_failed": "Impossible de lancer la détection"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Canaux de l’histogramme",
+      "luminance": "Lum",
+      "rgb": "RVB",
+      "red": "R",
+      "green": "V",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Écrêtage des ombres : {channels}",
+      "highlight": "Écrêtage des hautes lumières : {channels}"
     }
   }
 }

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -543,7 +543,8 @@
     "access_denied": "Accesso negato",
     "edition_expired": "La modalità di modifica non è più attiva - sbloccala e riprova",
     "server_error": "Errore del server — riprovare",
-    "action_failed": "Azione non riuscita — modifica annullata"
+    "action_failed": "Azione non riuscita — modifica annullata",
+    "server_detail": "Messaggio del server:"
   },
   "language": {
     "en": "Inglese",
@@ -2319,7 +2320,8 @@
       "title": "Gruppo",
       "ev_span": "Intervallo EV",
       "kind_duplicate": "Duplicato",
-      "open_in_gallery": "Apri questo gruppo nella galleria"
+      "open_in_gallery": "Apri questo gruppo nella galleria",
+      "member_position": "Fotogramma {position} di {count}"
     }
   },
   "photo": {

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -202,7 +202,8 @@
     "histogram_spread": "Istogramma",
     "star_rating": "Valutazione",
     "topiq_score": "TOPIQ",
-    "persons": "Persone",
+    "filter_by_person": "Filtra per {name}",
+    "set_section": "Gruppo",
     "histogram": "Istogramma"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Ripristina i filtri",
       "showing_all": "Vengono mostrate tutte le foto, inclusi occhi chiusi, raffiche e duplicati"
     },
+    "render_migration": {
+      "message": "{n} foto RAW mostrano ancora una miniatura del rendering precedente.",
+      "command_hint": "Esegui {command} per aggiornarle tutte in una volta."
+    },
+    "set_scope": {
+      "message": "Viene mostrato un gruppo di foto: {kind}"
+    },
     "all_photos": "Tutte le foto",
     "sort": "Ordina per",
     "sort_aggregate": "Aggregato",
@@ -1079,6 +1087,12 @@
       "panel": "Pannello laterale",
       "off": "Disattivato",
       "panel_empty": "Passa il cursore su una foto o fai clic per vederne qui i dettagli"
+    },
+    "panel_activation": {
+      "label": "Attivazione pannello",
+      "hover": "Hover",
+      "click": "Clic",
+      "both": "Hover o clic"
     },
     "hide_blinks": "Nascondi occhi chiusi",
     "hide_bursts": "Migliore della raffica",
@@ -1238,7 +1252,13 @@
       "title": "Confronto di {count} foto",
       "hint": "Rotella per ingrandire, trascina per spostare: tutti i riquadri si muovono insieme. Doppio clic per reimpostare.",
       "reset_zoom": "Reimposta lo zoom"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Alte luci tagliate: {percent}% dei pixel",
+      "badge_shadow": "Ombre tagliate: {percent}% dei pixel"
+    },
+    "channel_clip_highlight_range": "% alte luci tagliate",
+    "channel_clip_shadow_range": "% ombre tagliate"
   },
   "composition_patterns": {
     "none": "Nessuno",
@@ -2294,7 +2314,13 @@
     "caption_error": "Generazione della didascalia non riuscita",
     "translating_caption": "Traduzione in corso...",
     "location": "Posizione",
-    "social_crop": "Ritaglio social"
+    "social_crop": "Ritaglio social",
+    "set": {
+      "title": "Gruppo",
+      "ev_span": "Intervallo EV",
+      "kind_duplicate": "Duplicato",
+      "open_in_gallery": "Apri questo gruppo nella galleria"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "Impossibile salvare le impostazioni",
       "redetect_started": "Rilevamento avviato; viene eseguito in background",
       "redetect_failed": "Impossibile avviare il rilevamento"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Canali dell’istogramma",
+      "luminance": "Lum",
+      "rgb": "RGB",
+      "red": "R",
+      "green": "G",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Ombre tagliate: {channels}",
+      "highlight": "Alte luci tagliate: {channels}"
     }
   }
 }

--- a/i18n/translations/pt.json
+++ b/i18n/translations/pt.json
@@ -202,7 +202,8 @@
     "form_fractal": "Fractal",
     "color_harmony": "Harmonia de cores",
     "caption": "Legenda",
-    "persons": "Pessoas",
+    "filter_by_person": "Filtrar por {name}",
+    "set_section": "Grupo",
     "histogram": "Histograma"
   },
   "photoCard": {
@@ -1033,6 +1034,13 @@
       "restore": "Restaurar filtros",
       "showing_all": "A mostrar todas as fotos, incluindo piscadelas, rajadas e duplicados"
     },
+    "render_migration": {
+      "message": "{n} fotos RAW ainda mostram uma miniatura da renderização anterior.",
+      "command_hint": "Execute {command} para atualizar todas de uma vez."
+    },
+    "set_scope": {
+      "message": "A mostrar um grupo de fotos: {kind}"
+    },
     "all_photos": "Todas as fotos",
     "sort": "Ordenar por",
     "sort_aggregate": "Agregado",
@@ -1079,6 +1087,12 @@
       "panel": "Painel lateral",
       "off": "Desligado",
       "panel_empty": "Passe o cursor sobre uma foto ou clique nela para ver aqui os seus detalhes"
+    },
+    "panel_activation": {
+      "label": "Ativação do painel",
+      "hover": "Passar o mouse",
+      "click": "Clicar",
+      "both": "Passar o mouse ou clicar"
     },
     "hide_blinks": "Ocultar piscadas",
     "hide_bursts": "Melhor da rajada",
@@ -1238,7 +1252,13 @@
       "title": "A comparar {count} fotos",
       "hint": "Roda para ampliar, arraste para deslocar — todos os painéis se movem juntos. Duplo clique para repor.",
       "reset_zoom": "Repor o zoom"
-    }
+    },
+    "clipping": {
+      "badge_highlight": "Altas luzes cortadas: {percent}% dos pixels",
+      "badge_shadow": "Sombras cortadas: {percent}% dos pixels"
+    },
+    "channel_clip_highlight_range": "% de altas luzes cortadas",
+    "channel_clip_shadow_range": "% de sombras cortadas"
   },
   "composition_patterns": {
     "none": "Nenhum",
@@ -2294,7 +2314,13 @@
     "caption_error": "Falha ao gerar legenda",
     "translating_caption": "Traduzindo...",
     "location": "Localização",
-    "social_crop": "Recorte social"
+    "social_crop": "Recorte social",
+    "set": {
+      "title": "Grupo",
+      "ev_span": "Intervalo EV",
+      "kind_duplicate": "Duplicata",
+      "open_in_gallery": "Abrir este grupo na galeria"
+    }
   },
   "photo": {
     "category_override": {
@@ -2466,6 +2492,20 @@
       "save_failed": "Não foi possível guardar as definições",
       "redetect_started": "Deteção iniciada; corre em segundo plano",
       "redetect_failed": "Não foi possível iniciar a deteção"
+    }
+  },
+  "histogram": {
+    "mode": {
+      "label": "Canais do histograma",
+      "luminance": "Lum",
+      "rgb": "RGB",
+      "red": "R",
+      "green": "G",
+      "blue": "B"
+    },
+    "clipping": {
+      "shadow": "Sombras cortadas: {channels}",
+      "highlight": "Altas luzes cortadas: {channels}"
     }
   }
 }

--- a/i18n/translations/pt.json
+++ b/i18n/translations/pt.json
@@ -543,7 +543,8 @@
     "access_denied": "Acesso negado",
     "edition_expired": "O modo de edição já não está ativo - desbloqueie Edição e tente novamente",
     "server_error": "Erro no servidor — tente novamente",
-    "action_failed": "Ação falhou — alteração revertida"
+    "action_failed": "Ação falhou — alteração revertida",
+    "server_detail": "Mensagem do servidor:"
   },
   "language": {
     "en": "Inglês",
@@ -2319,7 +2320,8 @@
       "title": "Grupo",
       "ev_span": "Intervalo EV",
       "kind_duplicate": "Duplicata",
-      "open_in_gallery": "Abrir este grupo na galeria"
+      "open_in_gallery": "Abrir este grupo na galeria",
+      "member_position": "Quadro {position} de {count}"
     }
   },
   "photo": {

--- a/models/aesthetic_head.py
+++ b/models/aesthetic_head.py
@@ -1,0 +1,83 @@
+"""CLIP-MLP aesthetic head (LAION improved-aesthetic-predictor).
+
+The single definition of this model. It previously existed twice — once here in
+the shape the checkpoint actually has, once in the scorer as a 768->256->1 stub
+loaded with ``strict=False`` — and the stub silently matched none of the
+checkpoint's tensors, so ``legacy``/``8gb`` scans scored every photo with an
+untrained head.
+
+Contract, both halves of which the checkpoint depends on:
+
+* input is the **L2-normalized** 768-dim ViT-L-14 embedding. Raw CLIP features
+  have an L2 norm around 19, and feeding those saturates half the library at the
+  top of the scale.
+* output is an AVA-style 1-10 rating, so Facet's 0-10 aesthetic column is that
+  value clamped — not rescaled.
+"""
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from models.weights import AESTHETIC_MLP_WEIGHTS_URL, download_weights, pretrained_model_path
+
+logger = logging.getLogger("facet.models")
+
+AESTHETIC_HEAD_WEIGHTS_FILENAME = 'aesthetic_predictor_weights.pth'
+AESTHETIC_HEAD_EMBEDDING_DIM = 768
+AESTHETIC_SCORE_MIN = 0.0
+AESTHETIC_SCORE_MAX = 10.0
+
+
+class AestheticMLP(nn.Module):
+    """The predictor's architecture, matching the checkpoint's ``layers.*`` keys."""
+
+    def __init__(self, input_size: int = AESTHETIC_HEAD_EMBEDDING_DIM):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(input_size, 1024),
+            nn.Dropout(0.2),
+            nn.Linear(1024, 128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 64),
+            nn.Dropout(0.1),
+            nn.Linear(64, 16),
+            nn.Linear(16, 1),
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+
+def load_aesthetic_head(device: str = 'cpu') -> AestheticMLP:
+    """Build the head and load its checkpoint strictly.
+
+    ``strict=True`` because a partially-loaded head produces plausible-looking
+    scores from untrained weights: a scan that stops is recoverable, a library
+    scored with noise is not.
+    """
+    weights_path = pretrained_model_path(AESTHETIC_HEAD_WEIGHTS_FILENAME)
+    if not weights_path.exists():
+        download_weights(AESTHETIC_MLP_WEIGHTS_URL, weights_path)
+
+    head = AestheticMLP()
+    state_dict = torch.load(weights_path, map_location=device)
+    try:
+        head.load_state_dict(state_dict, strict=True)
+    except RuntimeError as ex:
+        raise RuntimeError(
+            f"Aesthetic head checkpoint at {weights_path} does not match the model: {ex}. "
+            f"Delete the file to re-download it."
+        ) from ex
+
+    logger.info("CLIP-MLP aesthetic head loaded: %s", weights_path)
+    return head.to(device).eval()
+
+
+def score_aesthetic(head, features_normalized) -> np.ndarray:
+    """Score L2-normalized CLIP embeddings, clamped to Facet's 0-10 scale."""
+    with torch.no_grad():
+        raw = head(features_normalized.float()).cpu().numpy().flatten()
+    return np.clip(raw, AESTHETIC_SCORE_MIN, AESTHETIC_SCORE_MAX)

--- a/models/aesthetic_head.py
+++ b/models/aesthetic_head.py
@@ -21,7 +21,9 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from models.weights import AESTHETIC_MLP_WEIGHTS_URL, download_weights, pretrained_model_path
+from models.weights import (
+    AESTHETIC_MLP_WEIGHTS_SHA256, AESTHETIC_MLP_WEIGHTS_URL, download_weights, pretrained_model_path,
+)
 
 logger = logging.getLogger("facet.models")
 
@@ -60,10 +62,10 @@ def load_aesthetic_head(device: str = 'cpu') -> AestheticMLP:
     """
     weights_path = pretrained_model_path(AESTHETIC_HEAD_WEIGHTS_FILENAME)
     if not weights_path.exists():
-        download_weights(AESTHETIC_MLP_WEIGHTS_URL, weights_path)
+        download_weights(AESTHETIC_MLP_WEIGHTS_URL, weights_path, sha256=AESTHETIC_MLP_WEIGHTS_SHA256)
 
     head = AestheticMLP()
-    state_dict = torch.load(weights_path, map_location=device)
+    state_dict = torch.load(weights_path, map_location=device, weights_only=True)
     try:
         head.load_state_dict(state_dict, strict=True)
     except RuntimeError as ex:

--- a/models/composition_patterns.py
+++ b/models/composition_patterns.py
@@ -1,0 +1,18 @@
+"""Composition pattern labels used by SAMP-Net's spatial pooling strategies.
+
+Kept out of ``models/samp_net.py`` (which imports torch at module scope) so
+read-only CLI paths such as ``--list-models`` can report the pattern count
+without pulling in the ML stack.
+"""
+
+# 8 composition patterns based on spatial pooling strategies
+COMPOSITION_PATTERNS = [
+    'global',           # 0: Global average pooling
+    'horizontal',       # 1: Upper/lower halves
+    'vertical',         # 2: Left/right halves
+    'triangular',       # 3: Triangular regions
+    'surround',         # 4: Center vs surroundings
+    'quarter',          # 5: 2x2 grid
+    'cross',            # 6: Cross divisions
+    'rule_of_thirds',   # 7: 3x3 composition grid
+]

--- a/models/model_manager.py
+++ b/models/model_manager.py
@@ -9,7 +9,6 @@ import logging
 import os
 import sys
 from typing import Dict, List
-from pathlib import Path
 
 logger = logging.getLogger("facet.models")
 
@@ -239,7 +238,8 @@ class ModelManager:
             model = model.to(self.device).eval()
 
             # Load MLP head
-            mlp = self._load_aesthetic_mlp()
+            from models.aesthetic_head import load_aesthetic_head
+            mlp = load_aesthetic_head(self.device)
 
             self.models['clip_aesthetic'] = {
                 'model': model,
@@ -252,43 +252,6 @@ class ModelManager:
         except Exception as e:
             logger.error("Failed to load CLIP+MLP: %s", e)
             return None
-
-    def _load_aesthetic_mlp(self):
-        """Load the MLP head for aesthetic prediction."""
-        import torch.nn as nn
-        import urllib.request
-
-        class AestheticMLP(nn.Module):
-            def __init__(self, input_size=768):
-                super().__init__()
-                self.layers = nn.Sequential(
-                    nn.Linear(input_size, 1024),
-                    nn.Dropout(0.2),
-                    nn.Linear(1024, 128),
-                    nn.Dropout(0.2),
-                    nn.Linear(128, 64),
-                    nn.Dropout(0.1),
-                    nn.Linear(64, 16),
-                    nn.Linear(16, 1)
-                )
-
-            def forward(self, x):
-                return self.layers(x)
-
-        mlp = AestheticMLP()
-        weights_path = Path("aesthetic_predictor_weights.pth")
-
-        if not weights_path.exists():
-            logger.info("Downloading aesthetic MLP weights...")
-            url = "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/sac%2Blogos%2Bava1-l14-linearMSE.pth"
-            urllib.request.urlretrieve(url, weights_path)
-
-        _torch = _ensure_torch()
-        state_dict = _torch.load(weights_path, map_location=self.device)
-        mlp.load_state_dict(state_dict)
-        mlp = mlp.to(self.device).eval()
-
-        return mlp
 
     def is_using_qwen_composition(self) -> bool:
         """Check if Qwen2-VL is the configured composition model."""

--- a/models/samp_net.py
+++ b/models/samp_net.py
@@ -12,6 +12,7 @@ import logging
 import os
 import numpy as np
 import urllib.request
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -19,6 +20,8 @@ import torch.nn.functional as F
 import torchvision.transforms as transforms
 import torchvision.models as models
 from PIL import Image
+
+from models.weights import download_weights
 
 logger = logging.getLogger("facet.samp_net")
 
@@ -84,6 +87,7 @@ COMPOSITION_PATTERNS = [
 WEIGHTS_RELEASE_BASE_URL = "https://github.com/ncoevoet/facet/releases/download/model-weights-v1"
 U2NETP_WEIGHTS_URL = f"{WEIGHTS_RELEASE_BASE_URL}/u2netp.pth"
 SAMPNET_WEIGHTS_URL = f"{WEIGHTS_RELEASE_BASE_URL}/samp_net.pth"
+SAMPNET_WEIGHTS_SHA256 = "d3d02f36967734fd6f0d2770380a04b777b5cd800a9ba68d4ccc9656f6fef603"
 
 
 # =============================================================================
@@ -898,19 +902,19 @@ class SAMPNetScorer:
         self.saliency_detector.ensure_loaded()
 
     def _download_weights(self):
-        """Download SAMP-Net weights if not present."""
+        """Fetch the pinned SAMP-Net checkpoint if it is not already on disk.
+
+        The download is checksum-verified and installed atomically by
+        ``models.weights.download_weights``, so a 404 page, a truncated
+        transfer or a substituted asset is discarded instead of being unpickled
+        on the next run.
+        """
         if os.path.exists(self.model_path):
             return
 
-        os.makedirs(os.path.dirname(self.model_path), exist_ok=True)
-
-        logger.info("Downloading SAMP-Net weights to %s...", self.model_path)
         try:
-            urllib.request.urlretrieve(SAMPNET_WEIGHTS_URL, self.model_path)
-            # A 404/error page saved as .pth would poison the next load
-            if os.path.getsize(self.model_path) < 1_000_000:
-                os.remove(self.model_path)
-                raise Exception("download resulted in an invalid file (too small)")
+            download_weights(SAMPNET_WEIGHTS_URL, Path(self.model_path),
+                             sha256=SAMPNET_WEIGHTS_SHA256)
             logger.info("SAMP-Net download complete.")
         except Exception as e:
             # Composition is one signal among many; ModelManager catches the
@@ -936,7 +940,7 @@ class SAMPNetScorer:
         # Load checkpoint
         try:
             logger.info("Loading SAMP-Net weights from %s...", self.model_path)
-            checkpoint = torch.load(self.model_path, map_location=self.device, weights_only=False)
+            checkpoint = torch.load(self.model_path, map_location=self.device, weights_only=True)
 
             # Handle different checkpoint formats
             if 'model_state_dict' in checkpoint:

--- a/models/samp_net.py
+++ b/models/samp_net.py
@@ -21,6 +21,7 @@ import torchvision.transforms as transforms
 import torchvision.models as models
 from PIL import Image
 
+from models.composition_patterns import COMPOSITION_PATTERNS
 from models.weights import download_weights
 
 logger = logging.getLogger("facet.samp_net")
@@ -69,18 +70,6 @@ def _manual_adaptive_avg_pool2d(
             )
         rows.append(torch.stack(columns, dim=-1))
     return torch.stack(rows, dim=-2)
-
-# 8 composition patterns based on spatial pooling strategies
-COMPOSITION_PATTERNS = [
-    'global',           # 0: Global average pooling
-    'horizontal',       # 1: Upper/lower halves
-    'vertical',         # 2: Left/right halves
-    'triangular',       # 3: Triangular regions
-    'surround',         # 4: Center vs surroundings
-    'quarter',          # 5: 2x2 grid
-    'cross',            # 6: Cross divisions
-    'rule_of_thirds',   # 7: 3x3 composition grid
-]
 
 # Weight download URLs
 # Note: U2-Net-P weights must be downloaded from Google Drive

--- a/models/weights.py
+++ b/models/weights.py
@@ -6,20 +6,26 @@ different directories, and the Docker image's working directory is not a mounted
 volume, so a CWD-relative destination re-downloads the same file over and over.
 """
 
+import hashlib
 import logging
 import os
 import tempfile
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger("facet.models")
 
 PRETRAINED_MODELS_DIR = Path(__file__).resolve().parent.parent / 'pretrained_models'
 
+# Pinned to the commit that added the file (the only one that has ever touched
+# it) rather than `main`, so the download can't silently change out from under
+# a checksum-verified deploy.
 AESTHETIC_MLP_WEIGHTS_URL = (
-    "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/"
-    "sac%2Blogos%2Bava1-l14-linearMSE.pth"
+    "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/"
+    "61f2f07a2b16be5ffb40a10ba5adae4a74c9d0d9/sac%2Blogos%2Bava1-l14-linearMSE.pth"
 )
+AESTHETIC_MLP_WEIGHTS_SHA256 = "21dd590f3ccdc646f0d53120778b296013b096a035a2718c9cb0d511bff0f1e0"
 
 
 def pretrained_model_path(filename: str) -> Path:
@@ -27,12 +33,21 @@ def pretrained_model_path(filename: str) -> Path:
     return PRETRAINED_MODELS_DIR / filename
 
 
-def download_weights(url: str, destination: Path):
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, 'rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_weights(url: str, destination: Path, sha256: Optional[str] = None):
     """Download ``url`` to ``destination``, atomically.
 
     The fetch goes to a unique temporary file in the destination directory and is
     then moved into place, so a second scan racing on the same missing file can
-    never load a half-written checkpoint.
+    never load a half-written checkpoint. When ``sha256`` is given, a mismatched
+    download is discarded rather than installed.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Downloading model weights to %s...", destination)
@@ -40,6 +55,13 @@ def download_weights(url: str, destination: Path):
     os.close(fd)
     try:
         urllib.request.urlretrieve(url, temp_path)
+        if sha256 is not None:
+            digest = _sha256_file(temp_path)
+            if digest != sha256:
+                raise ValueError(
+                    f"Downloaded {url} has SHA-256 {digest}, expected {sha256}. "
+                    f"Refusing to install a checkpoint that doesn't match."
+                )
         os.replace(temp_path, destination)
     finally:
         if os.path.exists(temp_path):

--- a/models/weights.py
+++ b/models/weights.py
@@ -1,0 +1,46 @@
+"""Filesystem home for auto-downloaded model weights.
+
+``pretrained_models/`` is resolved against the repository root rather than the
+process working directory: ``facet.py`` and ``viewer.py`` are launched from
+different directories, and the Docker image's working directory is not a mounted
+volume, so a CWD-relative destination re-downloads the same file over and over.
+"""
+
+import logging
+import os
+import tempfile
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger("facet.models")
+
+PRETRAINED_MODELS_DIR = Path(__file__).resolve().parent.parent / 'pretrained_models'
+
+AESTHETIC_MLP_WEIGHTS_URL = (
+    "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/"
+    "sac%2Blogos%2Bava1-l14-linearMSE.pth"
+)
+
+
+def pretrained_model_path(filename: str) -> Path:
+    """Absolute path of a weights file inside ``pretrained_models/``."""
+    return PRETRAINED_MODELS_DIR / filename
+
+
+def download_weights(url: str, destination: Path):
+    """Download ``url`` to ``destination``, atomically.
+
+    The fetch goes to a unique temporary file in the destination directory and is
+    then moved into place, so a second scan racing on the same missing file can
+    never load a half-written checkpoint.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Downloading model weights to %s...", destination)
+    fd, temp_path = tempfile.mkstemp(dir=str(destination.parent), suffix='.part')
+    os.close(fd)
+    try:
+        urllib.request.urlretrieve(url, temp_path)
+        os.replace(temp_path, destination)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/processing/batch_processor.py
+++ b/processing/batch_processor.py
@@ -449,6 +449,8 @@ class BatchProcessor:
                     # New columns for scoring improvements
                     'shadow_clipped': histogram_data.get('shadow_clipped', 0),
                     'highlight_clipped': histogram_data.get('highlight_clipped', 0),
+                    'channel_clip_shadow_pct': histogram_data.get('channel_clip_shadow_pct'),
+                    'channel_clip_highlight_pct': histogram_data.get('channel_clip_highlight_pct'),
                     'is_silhouette': is_silhouette,
                     'is_group_portrait': face_res.get('is_group_portrait', 0),
                     'leading_lines_score': leading_lines_data.get('leading_lines_score', 0),

--- a/processing/multi_pass.py
+++ b/processing/multi_pass.py
@@ -332,9 +332,19 @@ class ChunkedMultiPassProcessor:
             models.append(tagging_entry[0])
         # else: CLIP tagging uses clip embeddings, no extra model needed
 
-        # Composition model (SAMP-Net if configured)
-        if profile.get('composition_model') == 'samp-net':
+        # Composition model. SAMP-Net is the only one with a multi-pass pass;
+        # qwen2-vl-2b runs a per-photo VLM generation and exists for
+        # `processing.mode: "single-pass"` only. Say so instead of silently
+        # leaving composition to the rule-based fallback, which is what made the
+        # 24gb profile ship without any composition model on the default path.
+        composition_model = profile.get('composition_model', 'rule-based')
+        if composition_model == 'samp-net':
             models.append('samp_net')
+        elif composition_model not in ('rule-based', 'none'):
+            logger.warning(
+                "Composition model '%s' has no multi-pass pass; composition falls back to the "
+                "rule-based analyzer. Set composition_model to 'samp-net', or "
+                "processing.mode to 'single-pass'.", composition_model)
 
         # Face analysis
         models.append('insightface')
@@ -718,12 +728,13 @@ class ChunkedMultiPassProcessor:
 
             # Get aesthetic scores using MLP head (only available with 768-dim ViT-L-14)
             if hasattr(self.scorer, 'aesthetic_head') and self.scorer.aesthetic_head is not None:
-                scores = self.scorer.aesthetic_head(features.float()).cpu().numpy().flatten()
+                from models.aesthetic_head import score_aesthetic
+                scores = score_aesthetic(self.scorer.aesthetic_head, features_normalized)
 
         for i, path in enumerate(paths):
             results[path]['clip_embedding'] = embeddings[i].astype(np.float32).tobytes()
             if hasattr(self.scorer, 'aesthetic_head') and self.scorer.aesthetic_head is not None:
-                results[path]['aesthetic'] = max(0.0, min(10.0, (float(scores[i]) + 1) * 5))
+                results[path]['aesthetic'] = float(scores[i])
 
     def _pass_samp_net(self, scorer: Any, images: Dict, results: Dict):
         """SAMP-Net pass: composition patterns and scores."""
@@ -1075,6 +1086,8 @@ class ChunkedMultiPassProcessor:
                 'histogram_bimodality': float(histogram.get('bimodality', 0)),
                 'shadow_clipped': histogram.get('shadow_clipped', 0),
                 'highlight_clipped': histogram.get('highlight_clipped', 0),
+                'channel_clip_shadow_pct': histogram.get('channel_clip_shadow_pct'),
+                'channel_clip_highlight_pct': histogram.get('channel_clip_highlight_pct'),
                 'dynamic_range_stops': dynamic_range.get('dynamic_range_stops', 0),
                 'noise_sigma': noise.get('noise_sigma', 0),
                 'contrast_score': contrast.get('contrast_score', 5.0),
@@ -1279,6 +1292,8 @@ def run_single_pass(paths: List[str], pass_name: str, scorer, model_manager) -> 
 
 def list_available_models():
     """Print list of available models and their requirements."""
+    from models.samp_net import COMPOSITION_PATTERNS
+
     logger.info("Available Models:")
     logger.info("=" * 70)
 
@@ -1312,7 +1327,8 @@ def list_available_models():
     logger.info("COMPOSITION MODELS")
     logger.info("-" * 70)
     logger.info("  %-15s %-8s %-8s CPU rule-based analysis", "rule-based", "0GB", "--")
-    logger.info("  %-15s %-8s %-8s Neural network (14 patterns)", "samp-net", "~2GB", "--")
+    logger.info("  %-15s %-8s %-8s Neural network (%d patterns)",
+                "samp-net", "~2GB", "--", len(COMPOSITION_PATTERNS))
 
     logger.info("-" * 70)
     logger.info("FACE ANALYSIS")

--- a/processing/multi_pass.py
+++ b/processing/multi_pass.py
@@ -1292,7 +1292,7 @@ def run_single_pass(paths: List[str], pass_name: str, scorer, model_manager) -> 
 
 def list_available_models():
     """Print list of available models and their requirements."""
-    from models.samp_net import COMPOSITION_PATTERNS
+    from models.composition_patterns import COMPOSITION_PATTERNS
 
     logger.info("Available Models:")
     logger.info("=" * 70)

--- a/processing/scorer.py
+++ b/processing/scorer.py
@@ -118,7 +118,6 @@ cv2 = None
 imagehash = None
 Image = None
 ExifTags = None
-ImageOps = None
 BytesIO = None
 ThreadPoolExecutor = None
 as_completed = None
@@ -142,12 +141,12 @@ SAMPNetScorer = None
 
 def _load_image_modules():
     """Load image processing modules only when needed."""
-    global cv2, imagehash, Image, ExifTags, ImageOps, BytesIO, ThreadPoolExecutor, as_completed
+    global cv2, imagehash, Image, ExifTags, BytesIO, ThreadPoolExecutor, as_completed
     global TechnicalAnalyzer, CompositionAnalyzer, FaceAnalyzer, ImageCache
     if cv2 is None:
         import cv2 as _cv2
         import imagehash as _imagehash
-        from PIL import Image as _Image, ExifTags as _ExifTags, ImageOps as _ImageOps
+        from PIL import Image as _Image, ExifTags as _ExifTags
         from io import BytesIO as _BytesIO
         from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor, as_completed as _as_completed
         from analyzers import TechnicalAnalyzer as _TechnicalAnalyzer
@@ -158,7 +157,6 @@ def _load_image_modules():
         imagehash = _imagehash
         Image = _Image
         ExifTags = _ExifTags
-        ImageOps = _ImageOps
         BytesIO = _BytesIO
         ThreadPoolExecutor = _ThreadPoolExecutor
         as_completed = _as_completed

--- a/processing/scorer.py
+++ b/processing/scorer.py
@@ -22,7 +22,7 @@ import functools
 import re as _re
 from pathlib import Path
 from db import init_database, get_connection
-from db.render_version import CURRENT_RENDER_VERSION
+from db.render_version import DISPLAY_RENDER_VERSION
 from db.schema import FACES_UPSERT_SQL, face_upsert_row
 from db.scoring_overrides import get_photo_scoring_overrides
 from db.vec import sync_vec_batch
@@ -77,7 +77,7 @@ def _photos_partial_upsert(computed_columns):
     thumbnail this pass never rebuilt.
     """
     insert_cols = list(_PARTIAL_CORE_COLUMNS) + list(computed_columns)
-    placeholders = [f":{c}" for c in insert_cols] + ["datetime('now')", str(CURRENT_RENDER_VERSION)]
+    placeholders = [f":{c}" for c in insert_cols] + ["datetime('now')", str(DISPLAY_RENDER_VERSION)]
     all_cols = insert_cols + ['scanned_at', 'render_version']
     updates = ', '.join(f"{c}=excluded.{c}" for c in computed_columns)
     return (
@@ -2399,7 +2399,7 @@ class Facet:
                         :qrealign_score, :aesthetic_v25, :deqa_score,
                         :subject_sharpness, :subject_prominence, :subject_placement, :bg_separation, :subject_bbox,
                         :form_symmetry, :form_balance, :form_edge_entropy, :form_fractal, :color_harmony,
-                        :gps_latitude, :gps_longitude, datetime('now'), {CURRENT_RENDER_VERSION}
+                        :gps_latitude, :gps_longitude, datetime('now'), {DISPLAY_RENDER_VERSION}
                     )
                 '''), res)
 

--- a/processing/scorer.py
+++ b/processing/scorer.py
@@ -15,7 +15,6 @@ if _project_dir not in sys.path:
     sys.path.insert(0, _project_dir)
 
 import numpy as np
-import struct
 import warnings
 import json
 import logging
@@ -23,10 +22,12 @@ import functools
 import re as _re
 from pathlib import Path
 from db import init_database, get_connection
+from db.render_version import CURRENT_RENDER_VERSION
 from db.schema import FACES_UPSERT_SQL, face_upsert_row
 from db.scoring_overrides import get_photo_scoring_overrides
 from db.vec import sync_vec_batch
 from processing.progress import emit_progress
+from utils.histogram import unpack_histogram
 
 
 @functools.lru_cache(maxsize=8)
@@ -68,15 +69,16 @@ def _photos_partial_upsert(computed_columns):
     """Build a partial UPSERT that writes ONLY the columns a restricted pass computed.
 
     A ``--pass X`` / ``--recompute-*`` backfill runs one model, so only its
-    columns should change. New identity/EXIF, ``thumbnail`` and ``scanned_at``
-    are inserted for a genuinely new file but excluded from the conflict update,
-    so an existing row keeps everything the pass did not touch — no reset of
-    ``scanned_at`` (``--force-since`` reads it), no thumbnail re-encode, no NULLing
-    of another pass's data.
+    columns should change. New identity/EXIF, ``thumbnail``, ``scanned_at`` and
+    ``render_version`` are inserted for a genuinely new file but excluded from the
+    conflict update, so an existing row keeps everything the pass did not touch —
+    no reset of ``scanned_at`` (``--force-since`` reads it), no thumbnail
+    re-encode, no NULLing of another pass's data, and no stamp claiming a
+    thumbnail this pass never rebuilt.
     """
     insert_cols = list(_PARTIAL_CORE_COLUMNS) + list(computed_columns)
-    placeholders = [f":{c}" for c in insert_cols] + ["datetime('now')"]
-    all_cols = insert_cols + ['scanned_at']
+    placeholders = [f":{c}" for c in insert_cols] + ["datetime('now')", str(CURRENT_RENDER_VERSION)]
+    all_cols = insert_cols + ['scanned_at', 'render_version']
     updates = ', '.join(f"{c}=excluded.{c}" for c in computed_columns)
     return (
         f"INSERT INTO photos ({', '.join(all_cols)}) "
@@ -106,7 +108,8 @@ logger = logging.getLogger("facet.scorer")
 
 # Import shared utilities (lightweight, no cv2/torch dependency)
 from utils import (
-    get_tag_params, detect_silhouette, tags_to_string, RAW_EXTENSIONS,
+    get_tag_params, detect_silhouette, tags_to_string,
+    load_image_from_path, thumbnail_source,
 )
 from utils.image_transforms import generate_photo_thumbnail
 
@@ -129,6 +132,8 @@ torch = None
 F = None
 open_clip = None
 BatchProcessor = None
+load_aesthetic_head = None
+score_aesthetic = None
 
 # Lazy imports for new model manager
 ModelManager = None
@@ -164,7 +169,7 @@ def _load_image_modules():
 
 def _load_gpu_modules():
     """Load torch and related modules only when needed."""
-    global torch, F, open_clip, BatchProcessor
+    global torch, F, open_clip, BatchProcessor, load_aesthetic_head, score_aesthetic
     if torch is None:
         # Import device policy first so the MPS fallback environment variable
         # is present before torch initialises its Metal backend.
@@ -173,10 +178,14 @@ def _load_gpu_modules():
         import torch.nn.functional as _F
         import open_clip as _open_clip
         from processing.batch_processor import BatchProcessor as _BatchProcessor
+        from models.aesthetic_head import load_aesthetic_head as _load_aesthetic_head_fn
+        from models.aesthetic_head import score_aesthetic as _score_aesthetic
         torch = _torch
         F = _F
         open_clip = _open_clip
         BatchProcessor = _BatchProcessor
+        load_aesthetic_head = _load_aesthetic_head_fn
+        score_aesthetic = _score_aesthetic
 
 
 def _load_model_manager_modules():
@@ -906,19 +915,7 @@ class Facet:
             self.aesthetic_head = None
             return
 
-        weights_path = 'aesthetic_predictor_weights.pth'
-        if not os.path.exists(weights_path):
-            url = "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/sac%2Blogos%2Bava1-l14-linearMSE.pth"
-            import urllib.request
-            urllib.request.urlretrieve(url, weights_path)
-
-        self.aesthetic_head = torch.nn.Sequential(
-            torch.nn.Linear(768, 256),
-            torch.nn.ReLU(),
-            torch.nn.Linear(256, 1)
-        )
-        self.aesthetic_head.load_state_dict(torch.load(weights_path, map_location=self.device), strict=False)
-        self.aesthetic_head = self.aesthetic_head.to(self.device).eval()
+        self.aesthetic_head = load_aesthetic_head(self.device)
 
     @property
     def uses_transformers_backend(self):
@@ -967,20 +964,15 @@ class Facet:
         if self.aesthetic_head is None:
             return 5.0  # No MLP head — aesthetic comes from TOPIQ in multi-pass
 
-        features, _ = self._encode_images(image_pil)
-        with torch.no_grad():
-            raw_score = float(self.aesthetic_head(features.float()).cpu().numpy()[0][0])
-        aesthetic_score = max(0.0, min(10.0, (raw_score + 1) * 5))
-        return aesthetic_score
+        _, features_normalized = self._encode_images(image_pil)
+        return float(score_aesthetic(self.aesthetic_head, features_normalized)[0])
 
     def get_aesthetic_with_embedding(self, image_pil):
         """Calculate aesthetic score and return CLIP/SigLIP embedding for storage."""
-        features, features_normalized = self._encode_images(image_pil)
+        _, features_normalized = self._encode_images(image_pil)
 
         if self.aesthetic_head is not None:
-            with torch.no_grad():
-                raw_score = float(self.aesthetic_head(features.float()).cpu().numpy()[0][0])
-            aesthetic_score = max(0.0, min(10.0, (raw_score + 1) * 5))
+            aesthetic_score = float(score_aesthetic(self.aesthetic_head, features_normalized)[0])
         else:
             aesthetic_score = 5.0  # Aesthetic comes from TOPIQ, not CLIP MLP
 
@@ -1001,12 +993,9 @@ class Facet:
         # Only works with 768-dim embeddings (ViT-L-14)
         if len(embedding) != 768:
             return None
+        # Stored embeddings are already L2-normalized, which is what the head expects
         features = torch.tensor(embedding).unsqueeze(0).to(self.device)
-        with torch.no_grad():
-            # Ensure float32 for MLP head
-            raw_score = float(self.aesthetic_head(features.float()).cpu().numpy()[0][0])
-            aesthetic_score = max(0.0, min(10.0, (raw_score + 1) * 5))
-        return aesthetic_score
+        return float(score_aesthetic(self.aesthetic_head, features)[0])
 
     def get_aesthetic_and_quality(self, pil_img):
         """
@@ -1029,15 +1018,14 @@ class Facet:
         """
         n = len(pil_images)
 
-        features, features_normalized = self._encode_images(pil_images, clip_inputs)
+        _, features_normalized = self._encode_images(pil_images, clip_inputs)
         embeddings = features_normalized.cpu().numpy()
 
         if self.aesthetic_head is not None:
-            with torch.no_grad():
-                clip_scores = self.aesthetic_head(features.float()).cpu().numpy().flatten()
+            clip_scores = score_aesthetic(self.aesthetic_head, features_normalized)
             results = []
             for i in range(n):
-                clip_aesthetic = max(0.0, min(10.0, (float(clip_scores[i]) + 1) * 5))
+                clip_aesthetic = float(clip_scores[i])
                 clip_embedding = embeddings[i].astype(np.float32).tobytes()
                 results.append((clip_aesthetic, clip_embedding, None, 'clip-mlp'))
         else:
@@ -1421,6 +1409,8 @@ class Facet:
                 # New columns for scoring improvements
                 'shadow_clipped': histogram_data.get('shadow_clipped', 0),
                 'highlight_clipped': histogram_data.get('highlight_clipped', 0),
+                'channel_clip_shadow_pct': histogram_data.get('channel_clip_shadow_pct'),
+                'channel_clip_highlight_pct': histogram_data.get('channel_clip_highlight_pct'),
                 'is_silhouette': is_silhouette,
                 'is_group_portrait': face_res.get('is_group_portrait', 0),
                 'leading_lines_score': leading_lines_data.get('leading_lines_score', 0),
@@ -1601,12 +1591,14 @@ class Facet:
                 row_dict['is_group_portrait'] = new_is_group
 
                 # Recompute exposure_score from stored histogram if available
-                histogram_data = row_dict.get('histogram_data')
-                if histogram_data and len(histogram_data) == 256 * 4:
-                    hist = struct.unpack('256f', histogram_data)
-                    total = sum(hist)
+                decoded_histogram = unpack_histogram(row_dict.get('histogram_data'))
+                if decoded_histogram is not None:
+                    hist = decoded_histogram['luma']
+                    total = float(hist.sum())
                     if total > 0:
-                        norm_hist = [h / total for h in hist]
+                        # Back to plain floats: the per-bin loops below are far
+                        # slower over NumPy scalars, and this runs per row.
+                        norm_hist = (hist / total).tolist()
                         mean_luminance = sum(i * norm_hist[i] for i in range(256)) / 255.0
                         variance = sum(((i / 255.0 - mean_luminance) ** 2) * norm_hist[i] for i in range(256))
                         spread = (variance ** 0.5) * 255.0
@@ -2341,7 +2333,8 @@ class Facet:
 
         # Phase 1: Pre-generate thumbnails (CPU work, no DB lock held)
         for res, pil_img in results_with_images:
-            res['thumbnail'] = generate_photo_thumbnail(pil_img)
+            res['thumbnail'] = generate_photo_thumbnail(
+                thumbnail_source(res['path'], pil_img))
 
         # Phase 2: Collect all face records for batch insert (including thumbnails,
         # landmarks and per-face quality signals — shared upsert: see db.schema)
@@ -2363,9 +2356,11 @@ class Facet:
                 res.setdefault('aesthetic_v25', None)
                 res.setdefault('deqa_score', None)
                 res.setdefault('subject_bbox', None)
+                res.setdefault('channel_clip_shadow_pct', None)
+                res.setdefault('channel_clip_highlight_pct', None)
                 for form_col in FORM_METRIC_COLUMNS:
                     res.setdefault(form_col, None)
-                conn.execute(_photos_upsert('''
+                conn.execute(_photos_upsert(f'''
                     INSERT OR REPLACE INTO photos (
                         path, filename, category, image_width, image_height,
                         date_taken, camera_model, lens_model, iso, f_stop,
@@ -2375,7 +2370,9 @@ class Facet:
                         clip_embedding, raw_sharpness_variance, histogram_data, histogram_spread,
                         mean_luminance, histogram_bimodality, power_point_score, raw_color_entropy,
                         raw_eye_sharpness, config_version,
-                        shadow_clipped, highlight_clipped, is_silhouette, is_group_portrait, leading_lines_score,
+                        shadow_clipped, highlight_clipped,
+                        channel_clip_shadow_pct, channel_clip_highlight_pct,
+                        is_silhouette, is_group_portrait, leading_lines_score,
                         face_confidence, is_monochrome, mean_saturation,
                         dynamic_range_stops, noise_sigma, contrast_score, tags,
                         quality_score, topiq_score, composition_explanation, scoring_model, composition_pattern,
@@ -2383,7 +2380,7 @@ class Facet:
                         qrealign_score, aesthetic_v25, deqa_score,
                         subject_sharpness, subject_prominence, subject_placement, bg_separation, subject_bbox,
                         form_symmetry, form_balance, form_edge_entropy, form_fractal, color_harmony,
-                        gps_latitude, gps_longitude, scanned_at
+                        gps_latitude, gps_longitude, scanned_at, render_version
                     )
                     VALUES (
                         :path, :filename, :category, :image_width, :image_height,
@@ -2394,7 +2391,9 @@ class Facet:
                         :clip_embedding, :raw_sharpness_variance, :histogram_data, :histogram_spread,
                         :mean_luminance, :histogram_bimodality, :power_point_score, :raw_color_entropy,
                         :raw_eye_sharpness, :config_version,
-                        :shadow_clipped, :highlight_clipped, :is_silhouette, :is_group_portrait, :leading_lines_score,
+                        :shadow_clipped, :highlight_clipped,
+                        :channel_clip_shadow_pct, :channel_clip_highlight_pct,
+                        :is_silhouette, :is_group_portrait, :leading_lines_score,
                         :face_confidence, :is_monochrome, :mean_saturation,
                         :dynamic_range_stops, :noise_sigma, :contrast_score, :tags,
                         :quality_score, :topiq_score, :composition_explanation, :scoring_model, :composition_pattern,
@@ -2402,7 +2401,7 @@ class Facet:
                         :qrealign_score, :aesthetic_v25, :deqa_score,
                         :subject_sharpness, :subject_prominence, :subject_placement, :bg_separation, :subject_bbox,
                         :form_symmetry, :form_balance, :form_edge_entropy, :form_fractal, :color_harmony,
-                        :gps_latitude, :gps_longitude, datetime('now')
+                        :gps_latitude, :gps_longitude, datetime('now'), {CURRENT_RENDER_VERSION}
                     )
                 '''), res)
 
@@ -2465,7 +2464,8 @@ class Facet:
         new_paths = self.filter_unscanned_paths([res['path'] for res, _, _ in batch])
         for res, pil_img, _ in batch:
             if res['path'] in new_paths:
-                res['thumbnail'] = generate_photo_thumbnail(pil_img)
+                res['thumbnail'] = generate_photo_thumbnail(
+                    thumbnail_source(res['path'], pil_img))
             else:
                 res['thumbnail'] = None
 
@@ -2786,38 +2786,17 @@ def process_bursts(db_path, config_path='scoring_config.json'):
 
 
 def process_single_photo(photo_path, scorer):
-    """Worker function to handle image loading and metadata extraction."""
-    try:
-        photo = Path(photo_path)
-        # Handle RAW files
-        if photo.suffix.lower() in RAW_EXTENSIONS:
-            import rawpy
-            current_pil = None
-            with rawpy.imread(str(photo)) as raw:
-                try:
-                    thumb = raw.extract_thumb()
-                    if thumb.format == rawpy.ThumbFormat.JPEG:
-                        current_pil = Image.open(BytesIO(thumb.data))
-                        current_pil = ImageOps.exif_transpose(current_pil)
-                    else:
-                        current_pil = Image.fromarray(thumb.data)
-                except Exception:
-                    pass  # Don't use corrupted raw object
-            # If thumbnail extraction failed, reopen file for demosaic
-            if current_pil is None:
-                with rawpy.imread(str(photo)) as raw:
-                    rgb = raw.postprocess(use_camera_wb=True, no_auto_bright=False,
-                                          output_color=rawpy.ColorSpace.sRGB, output_bps=8)
-                    current_pil = Image.fromarray(rgb)
-        else:
-            current_pil = Image.open(photo)
-            current_pil = ImageOps.exif_transpose(current_pil)
-            if current_pil.mode != 'RGB':
-                current_pil = current_pil.convert('RGB')
+    """Worker function to handle image loading and metadata extraction.
 
-        img_cv = cv2.cvtColor(np.array(current_pil), cv2.COLOR_RGB2BGR)
+    Loads through the same metrics-profile decode a scan uses, so a --dry-run
+    preview reports the scores the scan would actually store.
+    """
+    try:
+        current_pil, img_cv = load_image_from_path(photo_path)
+        if current_pil is None:
+            return None, f"could not load {photo_path}"
         # Run the scoring (The AI parts will still use the GPU lock)
-        res = scorer.score_photo_from_pil(current_pil, img_cv, str(photo))
+        res = scorer.score_photo_from_pil(current_pil, img_cv, str(photo_path))
         return res, current_pil
     except Exception as e:
         return None, str(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ filterwarnings = [
     "ignore::DeprecationWarning:pydantic",
     "ignore::DeprecationWarning:pkg_resources",
 ]
+markers = [
+    "raw_brand_samples: real-file coverage for non-Canon RAW brands (decodes 20-30MB fixtures; skips cleanly when fixtures are absent)",
+]
 
 [tool.mypy]
 # Advisory type checking only — the CI mypy step is non-blocking

--- a/scoring_config.default.json
+++ b/scoring_config.default.json
@@ -35,7 +35,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -102,7 +114,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.5,
@@ -162,7 +186,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.1,
@@ -215,7 +251,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -277,7 +325,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -312,7 +372,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -349,7 +421,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.419,
@@ -388,7 +472,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.901,
@@ -423,7 +519,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.3
@@ -465,7 +573,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.171,
@@ -556,7 +676,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -601,7 +733,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.328,
@@ -725,7 +869,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.417,
@@ -773,7 +929,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.93,
@@ -866,7 +1034,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -913,7 +1093,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {
@@ -958,7 +1150,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.512,
@@ -1010,7 +1214,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "tags": {
         "architecture": [
@@ -1099,7 +1315,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.922,
@@ -1144,7 +1372,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {}
@@ -1177,7 +1417,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1222,7 +1474,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 0.3,
@@ -1271,7 +1535,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.72,
@@ -1320,7 +1596,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "noise_tolerance_multiplier": 1.5,
@@ -1385,7 +1673,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1427,7 +1727,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1469,7 +1781,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.216,
@@ -1516,7 +1840,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.3,
@@ -1594,7 +1930,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.463,
@@ -1702,7 +2050,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {},
       "tags": {}
@@ -1737,7 +2097,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.3
@@ -1773,7 +2145,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {
         "bonus": 0.2
@@ -1809,7 +2193,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {}
     },
@@ -1843,7 +2239,19 @@
         "subject_sharpness_percent": 0,
         "subject_prominence_percent": 0,
         "subject_placement_percent": 0,
-        "bg_separation_percent": 0
+        "bg_separation_percent": 0,
+        "face_sharpness_percent": 0,
+        "power_point_percent": 0,
+        "saturation_percent": 0,
+        "noise_percent": 0,
+        "qrealign_percent": 0,
+        "aesthetic_v25_percent": 0,
+        "deqa_percent": 0,
+        "symmetry_percent": 0,
+        "balance_percent": 0,
+        "edge_entropy_percent": 0,
+        "fractal_percent": 0,
+        "color_harmony_percent": 0
       },
       "modifiers": {}
     }
@@ -2054,6 +2462,13 @@
       "photo_quality": 80,
       "face_padding_ratio": 0.3
     }
+  },
+  "raw_decode": {
+    "bright": 1.62,
+    "prefer_embedded_preview": true,
+    "preview_min_sensor_ratio": 0.5,
+    "viewer_concurrency": 3,
+    "faithful_bracket_render": true
   },
   "burst_detection": {
     "similarity_threshold_percent": 70,
@@ -2841,7 +3256,7 @@
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": [
           "topiq_iaa",
@@ -2870,25 +3285,7 @@
       "similarity_threshold_percent": 22
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none",
-        "center",
-        "rule_of_thirds",
-        "golden_ratio",
-        "triangle",
-        "horizontal",
-        "vertical",
-        "diagonal",
-        "symmetric",
-        "curved",
-        "radial",
-        "vanishing_point",
-        "pattern",
-        "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     },
     "qwen2_5_vl_7b": {
       "model_path": "Qwen/Qwen2.5-VL-7B-Instruct",
@@ -3162,6 +3559,23 @@
         "step_px": 8
       }
     },
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    },
     "face_thumbnails": {
       "output_size_px": 64,
       "jpeg_quality": 80,
@@ -3194,6 +3608,7 @@
       "hide_panoramas": true,
       "hide_details": true,
       "tooltip_mode": "hover",
+      "panel_activation": "both",
       "hide_rejected": true,
       "sort": "aggregate",
       "sort_direction": "DESC",
@@ -3204,7 +3619,6 @@
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_semantic_search": true,
       "show_albums": true,
       "show_critique": true,

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -2475,6 +2475,13 @@
       "face_padding_ratio": 0.3
     }
   },
+  "raw_decode": {
+    "bright": 1.62,
+    "prefer_embedded_preview": true,
+    "preview_min_sensor_ratio": 0.5,
+    "viewer_concurrency": 3,
+    "faithful_bracket_render": true
+  },
   "burst_detection": {
     "similarity_threshold_percent": 70,
     "time_window_minutes": 0.8,
@@ -3287,7 +3294,7 @@
       "24gb": {
         "aesthetic_model": "topiq",
         "clip_config": "clip",
-        "composition_model": "qwen2-vl-2b",
+        "composition_model": "samp-net",
         "tagging_model": "qwen3.5-4b",
         "supplementary_pyiqa": [
           "topiq_iaa",
@@ -3316,25 +3323,7 @@
       "similarity_threshold_percent": 22
     },
     "samp_net": {
-      "model_path": "pretrained_models/samp_net.pth",
-      "download_url": "https://github.com/bcmi/Image-Composition-Assessment-with-SAMP/releases/download/v1.0/samp_net.pth",
-      "input_size": 384,
-      "patterns": [
-        "none",
-        "center",
-        "rule_of_thirds",
-        "golden_ratio",
-        "triangle",
-        "horizontal",
-        "vertical",
-        "diagonal",
-        "symmetric",
-        "curved",
-        "radial",
-        "vanishing_point",
-        "pattern",
-        "fill_frame"
-      ]
+      "model_path": "pretrained_models/samp_net.pth"
     },
     "qwen2_5_vl_7b": {
       "model_path": "Qwen/Qwen2.5-VL-7B-Instruct",
@@ -3609,6 +3598,23 @@
         "step_px": 8
       }
     },
+    "badges": {
+      "favorite": true,
+      "star_rating": true,
+      "rejected": true,
+      "sequence_kind": true,
+      "sequence_override_pending": true,
+      "keeper_hint": true,
+      "best_of_burst": true,
+      "clipping_highlight": true,
+      "clipping_shadow": false
+    },
+    "clipping": {
+      "badge_percent": 5,
+      "indicator_percent": 1,
+      "histogram_mode": "rgb",
+      "tooltip_histogram_mode": "luma"
+    },
     "face_thumbnails": {
       "output_size_px": 64,
       "jpeg_quality": 80,
@@ -3641,6 +3647,7 @@
       "hide_panoramas": true,
       "hide_details": true,
       "tooltip_mode": "hover",
+      "panel_activation": "both",
       "hide_rejected": true,
       "sort": "aggregate",
       "sort_direction": "DESC",
@@ -3651,7 +3658,6 @@
       "show_similar_button": true,
       "show_merge_suggestions": true,
       "show_rating_controls": true,
-      "show_rating_badge": true,
       "show_semantic_search": true,
       "show_albums": true,
       "show_critique": true,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,6 @@ MINIMAL_VIEWER_CONFIG: dict = {
         "show_similar_button": True,
         "show_merge_suggestions": True,
         "show_rating_controls": True,
-        "show_rating_badge": True,
         "show_folders": True,
     },
     "dropdowns": {"max_cameras": 50, "max_lenses": 50, "max_persons": 50, "max_tags": 20},

--- a/tests/test_a2_db_and_comparisons_migration.py
+++ b/tests/test_a2_db_and_comparisons_migration.py
@@ -186,6 +186,44 @@ class TestSubmitComparisonPerUser:
         assert rows == [("b",)]  # single row, updated — not duplicated
 
 
+class TestGetStatisticsKeys:
+    """Regression: comparison-ab-tab.component.ts declared a
+    ``photos_with_learned_scores`` field that ``ComparisonManager.get_statistics``
+    has never returned (``git log -S`` over every .py file is empty) -- pin the
+    real key set so a client interface can never again drift ahead of the
+    actual API contract.
+    """
+
+    def _fresh_db(self, tmp_path):
+        db_path = str(tmp_path / "stats.db")
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executemany("INSERT INTO photos (path) VALUES (?)",
+                         [("/p/a",), ("/p/b",)])
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_returns_exactly_the_documented_keys(self, tmp_path):
+        from comparison.comparison_manager import ComparisonManager
+
+        db_path = self._fresh_db(tmp_path)
+        mgr = ComparisonManager(db_path)
+        mgr.submit_comparison("/p/a", "/p/b", "a", category="portrait")
+
+        stats = mgr.get_statistics()
+
+        assert "photos_with_learned_scores" not in stats
+        assert set(stats.keys()) == {
+            "total_comparisons",
+            "winner_breakdown",
+            "category_breakdown",
+            "unique_photos_compared",
+            "recent_optimization_runs",
+        }
+
+
 class TestRecordCullingPairsNullSafe:
     def _burst_conn(self, tmp_path):
         db_path = str(tmp_path / "cull.db")

--- a/tests/test_aesthetic_head.py
+++ b/tests/test_aesthetic_head.py
@@ -1,0 +1,220 @@
+"""Tests for ``models.aesthetic_head`` — the CLIP-MLP aesthetic predictor.
+
+The bug these lock out: the scorer built its own 768->256->1 stub and loaded the
+published checkpoint into it with ``strict=False``. Not one tensor matched, the
+mismatch was swallowed, and ``legacy``/``8gb`` scans scored every photo with an
+untrained head (measured: a near-constant 5.01, sd 0.03). A test that merely
+called the loader and checked it did not raise would have passed throughout.
+
+So these assert the three things that were actually wrong: the architecture is
+the checkpoint's, a mismatch fails loudly, and the scores are the trained head's
+rather than a random head's.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+import torch.nn as nn  # noqa: E402
+
+from models.aesthetic_head import (  # noqa: E402
+    AestheticMLP,
+    load_aesthetic_head,
+    score_aesthetic,
+)
+
+# Key -> shape of the published checkpoint
+# (sac+logos+ava1-l14-linearMSE.pth, LAION improved-aesthetic-predictor).
+# Ground truth for the architecture: the head must be loadable from exactly this.
+PUBLISHED_CHECKPOINT_SHAPES = {
+    'layers.0.weight': (1024, 768),
+    'layers.0.bias': (1024,),
+    'layers.2.weight': (128, 1024),
+    'layers.2.bias': (128,),
+    'layers.4.weight': (64, 128),
+    'layers.4.bias': (64,),
+    'layers.6.weight': (16, 64),
+    'layers.6.bias': (16,),
+    'layers.7.weight': (1, 16),
+    'layers.7.bias': (1,),
+}
+
+# The head the scorer used to build. Every one of its keys is unexpected and
+# every checkpoint key is missing -- which strict=False silently tolerated.
+LEGACY_STUB_SHAPES = {
+    '0.weight': (256, 768),
+    '0.bias': (256,),
+    '2.weight': (1, 256),
+    '2.bias': (1,),
+}
+
+
+def _state_dict(shapes, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    return {
+        key: torch.rand(shape, generator=generator) * 0.01
+        for key, shape in shapes.items()
+    }
+
+
+@pytest.fixture
+def weights_dir(tmp_path, monkeypatch):
+    """Redirect the weights directory so no test touches the real checkout."""
+    from models import aesthetic_head, weights
+    directory = tmp_path / "pretrained_models"
+    directory.mkdir()
+    monkeypatch.setattr(weights, 'PRETRAINED_MODELS_DIR', directory)
+    monkeypatch.setattr(
+        aesthetic_head, 'download_weights',
+        mock.Mock(side_effect=AssertionError("test must not download weights")))
+    return directory
+
+
+def _write_checkpoint(weights_dir, shapes, seed=0):
+    from models.aesthetic_head import AESTHETIC_HEAD_WEIGHTS_FILENAME
+    state_dict = _state_dict(shapes, seed=seed)
+    torch.save(state_dict, weights_dir / AESTHETIC_HEAD_WEIGHTS_FILENAME)
+    return state_dict
+
+
+class TestArchitectureMatchesTheCheckpoint:
+    """The single most direct guard: the model's own keys ARE the checkpoint's."""
+
+    def test_parameter_names_and_shapes_are_the_published_ones(self):
+        actual = {key: tuple(tensor.shape) for key, tensor in AestheticMLP().state_dict().items()}
+        assert actual == PUBLISHED_CHECKPOINT_SHAPES
+
+    def test_the_old_stub_shape_is_not_what_we_build(self):
+        assert set(AestheticMLP().state_dict()) != set(LEGACY_STUB_SHAPES)
+
+
+class TestStrictLoading:
+    def test_loads_every_tensor_from_a_matching_checkpoint(self, weights_dir):
+        state_dict = _write_checkpoint(weights_dir, PUBLISHED_CHECKPOINT_SHAPES)
+
+        head = load_aesthetic_head('cpu')
+        missing, unexpected = head.load_state_dict(state_dict, strict=False)
+
+        assert list(missing) == []
+        assert list(unexpected) == []
+        for key, tensor in head.state_dict().items():
+            assert torch.equal(tensor, state_dict[key]), key
+
+    def test_scores_come_from_the_checkpoint_not_from_random_init(self, weights_dir):
+        state_dict = _write_checkpoint(weights_dir, PUBLISHED_CHECKPOINT_SHAPES, seed=3)
+        reference = AestheticMLP()
+        reference.load_state_dict(state_dict, strict=True)
+        reference.eval()
+        untrained = AestheticMLP().eval()
+        features = torch.nn.functional.normalize(torch.randn(8, 768), dim=-1)
+
+        head = load_aesthetic_head('cpu')
+        loaded_scores = score_aesthetic(head, features)
+
+        assert loaded_scores == pytest.approx(score_aesthetic(reference, features))
+        assert loaded_scores != pytest.approx(score_aesthetic(untrained, features))
+
+    def test_a_mismatched_checkpoint_raises_with_both_key_lists(self, weights_dir):
+        _write_checkpoint(weights_dir, LEGACY_STUB_SHAPES)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            load_aesthetic_head('cpu')
+
+        message = str(excinfo.value)
+        assert 'Missing key(s)' in message and 'layers.0.weight' in message
+        assert 'Unexpected key(s)' in message and '0.weight' in message
+
+
+class TestScoreMapping:
+    """The head emits an AVA-style 1-10 rating, so Facet's column is it, clamped.
+
+    The old call sites applied ``(raw + 1) * 5``, which on the correctly loaded
+    head pins 100% of real photos at exactly 10.0 (measured on 2000 library
+    embeddings: raw mean 5.47, range 3.59-7.11).
+    """
+
+    class _ConstantHead(nn.Module):
+        def __init__(self, value):
+            super().__init__()
+            self.value = value
+
+        def forward(self, x):
+            return torch.full((x.shape[0], 1), self.value)
+
+    def test_a_rating_passes_through_unscaled(self):
+        assert score_aesthetic(self._ConstantHead(5.47), torch.zeros(1, 768)) == pytest.approx([5.47], abs=1e-5)
+
+    def test_scores_are_clamped_to_the_zero_ten_scale(self):
+        assert score_aesthetic(self._ConstantHead(19.0), torch.zeros(2, 768)) == pytest.approx([10.0, 10.0])
+        assert score_aesthetic(self._ConstantHead(-4.0), torch.zeros(2, 768)) == pytest.approx([0.0, 0.0])
+
+
+class TestMultiPassFeedsNormalizedFeatures:
+    """The default scan path must hand the head unit-norm embeddings.
+
+    Raw ViT-L-14 features have an L2 norm around 19; feeding those to the trained
+    head saturated 52% of a real sample at 10.0.
+    """
+
+    class _SpyHead(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.seen_norms = []
+
+        def forward(self, x):
+            self.seen_norms.extend(x.norm(dim=-1).tolist())
+            return torch.full((x.shape[0], 1), 6.25)
+
+    def test_pass_clip_normalizes_before_scoring_and_stores_the_rating(self):
+        from processing.multi_pass import ChunkedMultiPassProcessor
+
+        spy_head = self._SpyHead()
+        scorer = mock.MagicMock()
+        scorer.aesthetic_head = spy_head
+        model_manager = mock.MagicMock()
+        model_manager.detect_vram.return_value = 8.0
+        model_manager.device = 'cpu'
+        proc = ChunkedMultiPassProcessor(scorer=scorer, model_manager=model_manager, config={})
+
+        clip_model = mock.MagicMock()
+        clip_model.encode_image.return_value = torch.tensor([[3.0, 4.0], [0.0, 19.0]])
+        model_dict = {
+            'model': clip_model,
+            'preprocess': lambda img: torch.zeros(3, 2, 2),
+            'backend': 'open_clip',
+        }
+        images = {'a.jpg': {'pil': object()}, 'b.jpg': {'pil': object()}}
+        results = {'a.jpg': {}, 'b.jpg': {}}
+
+        proc._pass_clip(model_dict, images, results)
+
+        assert spy_head.seen_norms == pytest.approx([1.0, 1.0])
+        assert results['a.jpg']['aesthetic'] == pytest.approx(6.25)
+        assert results['b.jpg']['aesthetic'] == pytest.approx(6.25)
+
+
+class TestPublishedCheckpointIfPresent:
+    """Runs against the real file when it has been downloaded; skips otherwise."""
+
+    def test_real_checkpoint_loads_strictly_and_scores_non_degenerately(self):
+        from models.aesthetic_head import AESTHETIC_HEAD_WEIGHTS_FILENAME
+        from models.weights import pretrained_model_path
+
+        weights_path = pretrained_model_path(AESTHETIC_HEAD_WEIGHTS_FILENAME)
+        if not weights_path.exists():
+            pytest.skip("published aesthetic checkpoint not downloaded")
+
+        head = load_aesthetic_head('cpu')
+        missing, unexpected = head.load_state_dict(
+            torch.load(weights_path, map_location='cpu'), strict=False)
+        assert list(missing) == [] and list(unexpected) == []
+
+        torch.manual_seed(0)
+        scores = score_aesthetic(head, torch.nn.functional.normalize(torch.randn(32, 768), dim=-1))
+        assert scores.std() > 0.05
+        assert 1.0 < scores.mean() < 9.0

--- a/tests/test_aesthetic_head.py
+++ b/tests/test_aesthetic_head.py
@@ -13,6 +13,7 @@ rather than a random head's.
 
 from __future__ import annotations
 
+import pickle
 from unittest import mock
 
 import pytest
@@ -128,6 +129,26 @@ class TestStrictLoading:
         message = str(excinfo.value)
         assert 'Missing key(s)' in message and 'layers.0.weight' in message
         assert 'Unexpected key(s)' in message and '0.weight' in message
+
+
+class TestWeightsOnlyLoad:
+    """The checkpoint is fetched over the network with no signature, so the
+    unpickler must not execute arbitrary code it happens to contain.
+    """
+
+    class _CodeExecutionPayload:
+        def __reduce__(self):
+            return (eval, ("1 + 1",))
+
+    def test_a_checkpoint_carrying_executable_pickle_data_is_rejected(self, weights_dir):
+        from models.aesthetic_head import AESTHETIC_HEAD_WEIGHTS_FILENAME
+
+        state_dict = _state_dict(PUBLISHED_CHECKPOINT_SHAPES)
+        state_dict['payload'] = self._CodeExecutionPayload()
+        torch.save(state_dict, weights_dir / AESTHETIC_HEAD_WEIGHTS_FILENAME)
+
+        with pytest.raises(pickle.UnpicklingError):
+            load_aesthetic_head('cpu')
 
 
 class TestScoreMapping:

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -15,6 +15,7 @@ import pytest
 from analyzers.composition import CompositionAnalyzer
 from analyzers.face import FaceAnalyzer
 from analyzers.technical import TechnicalAnalyzer
+from utils.histogram import HISTOGRAM_BLOB_SIZE
 
 
 # ---------------------------------------------------------------------------
@@ -397,8 +398,8 @@ class TestHistogramData:
     def test_histogram_bytes_length(self):
         img = np.full((10, 10, 3), 50, dtype=np.uint8)
         out = TechnicalAnalyzer.get_histogram_data(img)
-        # 256 float32s = 1024 bytes
-        assert len(out['histogram_bytes']) == 256 * 4
+        # 4 channels x 256 uint16 bins = 2048 bytes
+        assert len(out['histogram_bytes']) == HISTOGRAM_BLOB_SIZE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -16,7 +16,7 @@ from unittest import mock
 import pytest
 
 import api.config as api_config
-from api.config import map_disk_path
+from api.config import load_viewer_config, map_disk_path
 
 _MOD = "api.config"
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -1409,3 +1409,20 @@ class TestExistingConfigBackupsAreTightened:
         assert len(secret) == api_config._SECRET_BYTES * 2
         assert _mode_of(api_config.secret_path()) == 0o600
         assert _mode_of(backup) == 0o664
+
+
+class TestViewerFeatureDefaults:
+    """``load_viewer_config`` is the single merge point both ``/api/config``
+    and ``/api/auth/status`` read their ``features`` dict from. A key present
+    in neither this function's defaults nor the shipped config JSON reads as
+    off everywhere, even when the feature itself defaults to enabled
+    server-side (see ``api/routers/portfolio.py``'s own ``True`` default).
+    """
+
+    def test_show_portfolio_export_defaults_true_on_a_config_missing_it(self):
+        viewer = load_viewer_config({"viewer": {"features": {}}})
+        assert viewer["features"]["show_portfolio_export"] is True
+
+    def test_show_portfolio_export_defaults_true_on_an_empty_config(self):
+        viewer = load_viewer_config({})
+        assert viewer["features"]["show_portfolio_export"] is True

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -9,6 +9,7 @@ from calibrate import (
     build_metric_matrix,
     load_current_category_weights,
     log_run_to_db,
+    optimize_modifiers,
     optimize_weights,
 )
 from db.schema import init_database
@@ -128,3 +129,58 @@ class TestLogRunToDbUsesRealBaseline:
         ).fetchone()
         conn.close()
         assert json.loads(row[0]) == {"aesthetic": 0.5, "comp_score": 0.5}
+
+
+class TestOptimizeModifiersReadsThePenaltiesBlock:
+    """Regression: optimize_modifiers must read the shipped 'penalties' config
+    block, not a 'penalty_settings' key that has never existed in any shipped
+    config. Under the bug, config_data.get('penalty_settings', {}) is always
+    {} regardless of what an install tunes 'penalties' to, so it silently
+    falls back to hardcoded literals that happen to match the shipped values.
+    """
+
+    def _rows(self):
+        # Oversaturation is the only active penalty (noise_sigma and
+        # histogram_bimodality are 0 for every row). aesthetic=10 for every
+        # row keeps the simulated score off the simulate() clip(0, 10) floor
+        # after a penalty is subtracted. mean_saturation crosses the tuned
+        # threshold (0.5) for half the rows but crosses the hardcoded
+        # fallback (0.9) for only one -- so the two thresholds bucket the
+        # rows differently and must produce different SRCCs.
+        saturations = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+        mos_values = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+        return [
+            {
+                "aesthetic": 10.0, "mos": mos, "mean_saturation": sat,
+                "noise_sigma": 0.0, "histogram_bimodality": 0.0,
+                "shadow_clipped": 0.0, "highlight_clipped": 0.0,
+            }
+            for sat, mos in zip(saturations, mos_values)
+        ]
+
+    def _write_config(self, tmp_path, name, penalties):
+        cfg = tmp_path / name
+        body = {"categories": [{
+            "name": "test_cat",
+            "weights": {"aesthetic_percent": 100},
+            "modifiers": {},
+        }]}
+        if penalties is not None:
+            body["penalties"] = penalties
+        cfg.write_text(json.dumps(body))
+        return str(cfg)
+
+    def test_tuned_oversaturation_threshold_changes_srcc_before(self, tmp_path):
+        rows = self._rows()
+        default_cfg = self._write_config(tmp_path, "default.json", None)
+        tuned_cfg = self._write_config(
+            tmp_path, "tuned.json",
+            {"oversaturation_threshold": 0.5, "oversaturation_penalty_points": 5.0},
+        )
+
+        default_result = optimize_modifiers(rows, "test_cat", default_cfg)
+        tuned_result = optimize_modifiers(rows, "test_cat", tuned_cfg)
+
+        assert default_result is not None
+        assert tuned_result is not None
+        assert tuned_result["srcc_before"] != pytest.approx(default_result["srcc_before"])

--- a/tests/test_channel_clipping.py
+++ b/tests/test_channel_clipping.py
@@ -1,0 +1,268 @@
+"""Per-channel clipping: the stored columns, the backfill, and the gallery filter.
+
+The invariant every test here defends is that NULL means *unknown*, never
+*clean*. A library holds a long tail of rows whose histogram is still the
+legacy luminance-only blob; those have no per-channel data to derive from, so
+deriving 0% for them would state a fact nobody measured — and would make them
+answer "show me photos with no clipping".
+
+Mirrors tests/test_extended_iqa_gallery.py's harness for the endpoint half.
+"""
+
+import sqlite3
+import struct
+from contextlib import asynccontextmanager, contextmanager
+from unittest import mock
+
+import aiosqlite
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from api import create_app
+from api.auth import get_optional_user
+from api.db_helpers import PHOTO_OPTIONAL_COLS
+from api.routers.gallery import SCORE_RANGE_COLUMNS
+from db.maintenance import backfill_channel_clipping
+from db.schema import init_database
+from utils.histogram import HISTOGRAM_BINS, pack_histogram
+
+CLIPPING_COLUMNS = ("channel_clip_shadow_pct", "channel_clip_highlight_pct")
+
+
+def _blob(highlight_share=0.0, shadow_share=0.0, channel=1):
+    """A current-format blob whose given channel clips by the requested share.
+
+    ``channel`` indexes pack_histogram's arguments: 1=R, 2=G, 3=B.
+    """
+    total = 10000.0
+    channels = [np.zeros(HISTOGRAM_BINS) for _ in range(4)]
+    for counts in channels:
+        counts[128] = total
+    clipped = channels[channel]
+    clipped[128] = total * (1 - highlight_share - shadow_share)
+    clipped[255] = total * highlight_share
+    clipped[0] = total * shadow_share
+    return pack_histogram(*channels)
+
+
+def _legacy_blob():
+    counts = np.zeros(HISTOGRAM_BINS)
+    counts[255] = 1.0
+    return struct.pack('256f', *counts)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def test_clipping_columns_are_served_by_the_gallery():
+    for col in CLIPPING_COLUMNS:
+        assert col in PHOTO_OPTIONAL_COLS, f"{col} missing from PHOTO_OPTIONAL_COLS"
+
+
+def test_clipping_columns_are_registered_as_range_filters():
+    by_col = {c[0]: c for c in SCORE_RANGE_COLUMNS}
+    assert by_col["channel_clip_shadow_pct"][1:3] == (
+        "min_channel_clip_shadow", "max_channel_clip_shadow")
+    assert by_col["channel_clip_highlight_pct"][1:3] == (
+        "min_channel_clip_highlight", "max_channel_clip_highlight")
+
+
+def test_the_backfill_flag_takes_the_library_lock():
+    from facet import LIBRARY_JOB_ARGS
+
+    assert 'backfill_clipping' in LIBRARY_JOB_ARGS
+
+
+def test_the_scan_upsert_writes_the_columns():
+    """A column absent from the INSERT list is silently NULLed on every rescan,
+    which is exactly how this data would quietly disappear."""
+    import inspect
+
+    from processing.scorer import Facet
+
+    source = inspect.getsource(Facet.save_photos_batch)
+    for col in CLIPPING_COLUMNS:
+        assert col in source, f"{col} missing from the photos upsert"
+        assert f":{col}" in source, f"{col} has no bound parameter in the upsert"
+
+
+# ---------------------------------------------------------------------------
+# Backfill
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def clipping_db(tmp_path):
+    db_path = str(tmp_path / "clip.db")
+    init_database(db_path)
+    conn = sqlite3.connect(db_path)
+    rows = [
+        ("/c/blown.jpg", _blob(highlight_share=0.30, channel=3)),
+        ("/c/mild.jpg", _blob(highlight_share=0.02, channel=1)),
+        ("/c/crushed.jpg", _blob(shadow_share=0.12, channel=1)),
+        ("/c/clean.jpg", _blob()),
+        ("/c/legacy.jpg", _legacy_blob()),
+        ("/c/nohist.jpg", None),
+    ]
+    for path, blob in rows:
+        conn.execute(
+            "INSERT INTO photos (path, filename, aggregate, histogram_data) VALUES (?, ?, 5.0, ?)",
+            (path, path.rsplit('/', 1)[-1], blob))
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _clipping(db_path):
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT path, channel_clip_shadow_pct, channel_clip_highlight_pct FROM photos").fetchall()
+    conn.close()
+    return {r[0]: (r[1], r[2]) for r in rows}
+
+
+class TestBackfill:
+    def test_derives_the_columns_from_stored_blobs(self, clipping_db):
+        assert backfill_channel_clipping(clipping_db, verbose=False) == 4
+        values = _clipping(clipping_db)
+        assert values["/c/blown.jpg"][1] == pytest.approx(30.0, abs=0.05)
+        assert values["/c/mild.jpg"][1] == pytest.approx(2.0, abs=0.05)
+        assert values["/c/crushed.jpg"][0] == pytest.approx(12.0, abs=0.05)
+
+    def test_a_photo_with_no_clipping_is_zero_not_null(self, clipping_db):
+        backfill_channel_clipping(clipping_db, verbose=False)
+        assert _clipping(clipping_db)["/c/clean.jpg"] == (0.0, 0.0)
+
+    def test_a_legacy_row_stays_unknown(self, clipping_db):
+        backfill_channel_clipping(clipping_db, verbose=False)
+        assert _clipping(clipping_db)["/c/legacy.jpg"] == (None, None)
+
+    def test_a_row_with_no_histogram_stays_unknown(self, clipping_db):
+        backfill_channel_clipping(clipping_db, verbose=False)
+        assert _clipping(clipping_db)["/c/nohist.jpg"] == (None, None)
+
+    def test_is_resumable_and_claims_no_row_twice(self, clipping_db):
+        assert backfill_channel_clipping(clipping_db, verbose=False) == 4
+        # A second run finds nothing left: the legacy rows must not be re-read
+        # forever just because their columns are still NULL.
+        assert backfill_channel_clipping(clipping_db, verbose=False) == 0
+
+    def test_resumes_after_an_interrupted_run(self, clipping_db):
+        assert backfill_channel_clipping(clipping_db, batch_size=1, verbose=False) == 4
+        conn = sqlite3.connect(clipping_db)
+        conn.execute("UPDATE photos SET channel_clip_highlight_pct = NULL, "
+                     "channel_clip_shadow_pct = NULL WHERE path = '/c/mild.jpg'")
+        conn.commit()
+        conn.close()
+        assert backfill_channel_clipping(clipping_db, verbose=False) == 1
+        assert _clipping(clipping_db)["/c/mild.jpg"][1] == pytest.approx(2.0, abs=0.05)
+
+    def test_batches_smaller_than_the_row_count_still_finish(self, clipping_db):
+        assert backfill_channel_clipping(clipping_db, batch_size=2, verbose=False) == 4
+
+
+# ---------------------------------------------------------------------------
+# Gallery filter
+# ---------------------------------------------------------------------------
+
+def _async_conn_factory(db_path):
+    @asynccontextmanager
+    async def factory():
+        c = await aiosqlite.connect(db_path)
+        c.row_factory = aiosqlite.Row
+        try:
+            yield c
+        finally:
+            await c.close()
+    return factory
+
+
+def _sync_conn_factory(db_path):
+    @contextmanager
+    def factory():
+        c = sqlite3.connect(db_path)
+        c.row_factory = sqlite3.Row
+        try:
+            yield c
+        finally:
+            c.close()
+    return factory
+
+
+_VIEWER_CONFIG = {
+    "display": {"tags_per_photo": 5},
+    "pagination": {"default_per_page": 64, "max_per_page": 200},
+    "defaults": {
+        "sort": "aggregate", "sort_direction": "DESC",
+        "hide_blinks": False, "hide_bursts": False,
+        "hide_duplicates": False, "type": "",
+    },
+    "dropdowns": {"min_photos_for_person": 2, "max_persons": 100},
+    "quality_thresholds": {},
+    "features": {},
+}
+
+
+@pytest.fixture()
+def filtered_db(clipping_db):
+    backfill_channel_clipping(clipping_db, verbose=False)
+    conn = sqlite3.connect(clipping_db)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(photos)")}
+    conn.close()
+    return clipping_db, cols
+
+
+def _run(db_path, cols, query):
+    app = create_app()
+    app.dependency_overrides[get_optional_user] = lambda: None
+    with (
+        mock.patch("api.routers.gallery.get_db", _sync_conn_factory(db_path)),
+        mock.patch("api.routers.gallery.get_async_db", _async_conn_factory(db_path)),
+        mock.patch("api.routers.gallery.VIEWER_CONFIG", _VIEWER_CONFIG),
+        mock.patch("api.db_helpers._existing_columns_cache", cols),
+        mock.patch.dict("api.config._count_cache", {}, clear=True),
+    ):
+        return TestClient(app).get(query)
+
+
+class TestGalleryFilter:
+    def test_the_columns_are_returned_to_the_client(self, filtered_db):
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos")
+        assert resp.status_code == 200
+        photos = {p["path"]: p for p in resp.json()["photos"]}
+        assert photos["/c/blown.jpg"]["channel_clip_highlight_pct"] == pytest.approx(30.0, abs=0.05)
+        # Unknown must travel as null, so the client can tell it from clean.
+        assert photos["/c/legacy.jpg"]["channel_clip_highlight_pct"] is None
+
+    def test_a_minimum_returns_only_photos_above_it(self, filtered_db):
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos?min_channel_clip_highlight=5")
+        assert resp.status_code == 200
+        assert {p["path"] for p in resp.json()["photos"]} == {"/c/blown.jpg"}
+
+    def test_a_lower_minimum_widens_the_set(self, filtered_db):
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos?min_channel_clip_highlight=1")
+        assert {p["path"] for p in resp.json()["photos"]} == {"/c/blown.jpg", "/c/mild.jpg"}
+
+    def test_the_shadow_filter_is_independent_of_the_highlight_one(self, filtered_db):
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos?min_channel_clip_shadow=5")
+        assert {p["path"] for p in resp.json()["photos"]} == {"/c/crushed.jpg"}
+
+    def test_an_unmeasured_photo_is_never_returned_as_clipped(self, filtered_db):
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos?min_channel_clip_highlight=0")
+        assert "/c/legacy.jpg" not in {p["path"] for p in resp.json()["photos"]}
+
+    def test_an_unmeasured_photo_is_never_returned_as_clean_either(self, filtered_db):
+        """The failure this guards: treating NULL as 0 would hand every
+        un-migrated row to a "photos with clean highlights" filter."""
+        db_path, cols = filtered_db
+        resp = _run(db_path, cols, "/api/photos?max_channel_clip_highlight=1")
+        paths = {p["path"] for p in resp.json()["photos"]}
+        assert "/c/legacy.jpg" not in paths
+        assert "/c/nohist.jpg" not in paths
+        assert paths == {"/c/clean.jpg", "/c/crushed.jpg"}

--- a/tests/test_cull.py
+++ b/tests/test_cull.py
@@ -146,6 +146,9 @@ class TestCullApply:
         assert body["excluded_by_state"] == 1
 
     def test_move_outside_allowlist_403(self, client, tmp_path):
+        """The 403 names the config key and the resolved roots so a container
+        user hitting 'Cull to folder' can fix their own config instead of
+        getting a bare 'Access denied' (see discussion #106)."""
         path = _make_file(tmp_path, "a.jpg")
         db = _db(tmp_path, [(path, 1)])
         allowed = str(tmp_path / "allowed")
@@ -160,6 +163,9 @@ class TestCullApply:
             })
         assert resp.status_code == 403
         assert os.path.isfile(path)  # never moved
+        detail = resp.json()["detail"]
+        assert "viewer.export.allowed_target_dirs" in detail
+        assert allowed in detail
 
     def test_move_requires_target_dir(self, client, tmp_path):
         path = _make_file(tmp_path, "a.jpg")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -297,6 +297,9 @@ class TestAlbumExport:
 
         assert resp.status_code == 403
         assert not os.path.exists(os.path.join(evil, "a.jpg"))
+        detail = resp.json()["detail"]
+        assert "viewer.export.allowed_target_dirs" in detail
+        assert allowed in detail
 
     def test_copy_disabled_without_allowlist(self, client, tmp_path):
         """With no allowed roots configured, copy/symlink export is fail-closed."""
@@ -315,6 +318,9 @@ class TestAlbumExport:
             )
 
         assert resp.status_code == 403
+        detail = resp.json()["detail"]
+        assert "viewer.export.allowed_target_dirs" in detail
+        assert "none configured" in detail
 
     def test_copy_dest_confined_to_target(self, client, tmp_path):
         """Copied files land inside (and only inside) the validated target_dir."""

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -851,6 +851,35 @@ class TestGallerySetScopeFilter:
         paths = self._fetch(tmp_path, self._ALL_HIDE_TOGGLES)
         assert paths == {"/plain.jpg", "/b-base.jpg", "/p-b.jpg", "/burst-b.jpg", "/dup-a.jpg"}
 
+    def test_bracket_scope_excludes_a_panorama_sharing_the_same_group_id(self, tmp_path):
+        """The bracket and panorama detection passes own disjoint rows but
+        each renumbers its own groups from 1 every run, so a bracket and a
+        panorama can legitimately share sequence_group_id=1 at the same
+        time on real data. The scope filter must key on the
+        (sequence_kind, sequence_group_id) PAIR -- if sequence_kind were
+        ever dropped from the WHERE clause, this query would silently pull
+        in the panorama's frames too.
+        """
+        colliding_group_id = [
+            _photo("/b-under.jpg", "2024:06:15 12:00:00",
+                   sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=-2.0),
+            _photo("/b-base.jpg", "2024:06:15 12:00:01",
+                   sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=0.0),
+            _photo("/b-over.jpg", "2024:06:15 12:00:02",
+                   sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=2.0),
+            _photo("/p-a.jpg", "2024:06:15 13:00:00",
+                   sequence_group_id=1, sequence_kind="panorama", is_sequence_lead=0),
+            _photo("/p-b.jpg", "2024:06:15 13:00:01",
+                   sequence_group_id=1, sequence_kind="panorama", is_sequence_lead=1),
+            _photo("/p-c.jpg", "2024:06:15 13:00:02",
+                   sequence_group_id=1, sequence_kind="panorama", is_sequence_lead=0),
+        ]
+        paths = self._fetch(
+            tmp_path, f"sequence_kind=bracket&sequence_group_id=1&{self._ALL_HIDE_TOGGLES}",
+            photos=colliding_group_id,
+        )
+        assert paths == {"/b-under.jpg", "/b-base.jpg", "/b-over.jpg"}
+
     def test_bracket_scope_survives_hide_bursts_when_the_set_is_also_a_burst(self, tmp_path):
         """A real AEB set fired in continuous drive mode is grouped as BOTH a
         bracket (by the sequence pass) and a burst (by the burst pass), with
@@ -938,11 +967,13 @@ class TestPhotoSetEndpoint:
         assert resp.json() == {"kind": None, "group_id": None, "count": 0, "ev_span": None, "members": []}
 
     def test_bracket_set_orders_by_distance_from_base_and_reports_ev_span(self, tmp_path):
+        """The span is darkest-to-brightest, not the largest offset: this set is
+        shot at -2/0/+1, which covers three stops and never reaches +2."""
         data = self._fetch(tmp_path, "/b-base.jpg").json()
         assert data["kind"] == "bracket"
         assert data["group_id"] == 1
         assert data["count"] == 3
-        assert data["ev_span"] == 2.0
+        assert data["ev_span"] == 3.0
         assert [m["path"] for m in data["members"]] == ["/b-base.jpg", "/b-over.jpg", "/b-under.jpg"]
         base = next(m for m in data["members"] if m["path"] == "/b-base.jpg")
         assert base["is_lead"] is True

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -760,3 +760,233 @@ class TestGallerySequenceOverrideFilter:
             tmp_path, "sequence_override=any&hide_panoramas=1")}
         assert "/killed.jpg" in paths  # it is its own set's lead
         assert paths == {"/killed.jpg", "/forced-a.jpg", "/forced-b.jpg"}
+
+
+# ---------------------------------------------------------------------------
+# Photo Set Scope (GET /api/photos?sequence_kind=...&sequence_group_id=...
+#                                  |burst_group_id=...|duplicate_group_id=...)
+# ---------------------------------------------------------------------------
+
+class TestGallerySetScopeFilter:
+    """The photo-detail "open this set in the gallery" action.
+
+    Never round-tripped through the URL client-side (sequence_group_id is
+    renumbered from 1 on every detection pass), but server-side it must both
+    narrow to the one set AND suppress EVERY hide toggle, not just the one
+    matching the scope's own kind -- without that, the default hide toggles
+    (all on) would collapse the filtered gallery back down to a single lead
+    tile. A photo can belong to a bracket AND a burst AND a duplicate group
+    at once (an AEB set fired in continuous drive mode is grouped as both a
+    bracket and a burst), so suppressing only the matching toggle is
+    insufficient by construction -- see
+    test_bracket_scope_survives_hide_bursts_when_the_set_is_also_a_burst.
+    """
+
+    _PHOTOS = [
+        _photo("/plain.jpg", "2024:06:15 11:00:00"),
+        _photo("/b-under.jpg", "2024:06:15 12:00:00",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=-2.0),
+        _photo("/b-base.jpg", "2024:06:15 12:00:01",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=0.0),
+        _photo("/b-over.jpg", "2024:06:15 12:00:02",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=2.0),
+        _photo("/p-a.jpg", "2024:06:15 13:00:00",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=0),
+        _photo("/p-b.jpg", "2024:06:15 13:00:01",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=1),
+        _photo("/p-c.jpg", "2024:06:15 13:00:02",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=0),
+        _photo("/burst-a.jpg", "2024:06:15 14:00:00", burst_group_id=5, is_burst_lead=0),
+        _photo("/burst-b.jpg", "2024:06:15 14:00:01", burst_group_id=5, is_burst_lead=1),
+        _photo("/dup-a.jpg", "2024:06:15 15:00:00", duplicate_group_id=9, is_duplicate_lead=1),
+        _photo("/dup-b.jpg", "2024:06:15 15:00:01", duplicate_group_id=9, is_duplicate_lead=0),
+    ]
+
+    _ALL_HIDE_TOGGLES = "hide_bursts=1&hide_duplicates=1&hide_brackets=1&hide_panoramas=1"
+
+    def _fetch(self, tmp_path, query, photos=None):
+        db_path = str(tmp_path / "test.db")
+        _make_db(db_path, photos if photos is not None else self._PHOTOS)
+        app = _create_app_no_auth()
+        with (
+            mock.patch("api.routers.gallery.get_db", _conn_factory(db_path)),
+            mock.patch("api.routers.gallery.get_async_db", _async_conn_factory(db_path)),
+            mock.patch("api.routers.gallery.VIEWER_CONFIG", _VIEWER_CONFIG),
+            mock.patch("api.db_helpers._existing_columns_cache", _TEST_PHOTOS_COLUMNS),
+            mock.patch.dict("api.config._count_cache", {}, clear=True),
+        ):
+            resp = TestClient(app).get(f"/api/photos?page=1&per_page=50&{query}")
+        assert resp.status_code == 200
+        return {p["path"] for p in resp.json()["photos"]}
+
+    def test_bracket_scope_returns_every_frame_with_default_hide_toggles(self, tmp_path):
+        paths = self._fetch(
+            tmp_path, f"sequence_kind=bracket&sequence_group_id=1&{self._ALL_HIDE_TOGGLES}")
+        assert paths == {"/b-under.jpg", "/b-base.jpg", "/b-over.jpg"}
+
+    def test_panorama_scope_returns_every_frame_with_default_hide_toggles(self, tmp_path):
+        paths = self._fetch(
+            tmp_path, f"sequence_kind=panorama&sequence_group_id=2&{self._ALL_HIDE_TOGGLES}")
+        assert paths == {"/p-a.jpg", "/p-b.jpg", "/p-c.jpg"}
+
+    def test_burst_scope_returns_every_frame_with_default_hide_toggles(self, tmp_path):
+        paths = self._fetch(tmp_path, f"burst_group_id=5&{self._ALL_HIDE_TOGGLES}")
+        assert paths == {"/burst-a.jpg", "/burst-b.jpg"}
+
+    def test_duplicate_scope_returns_every_frame_with_default_hide_toggles(self, tmp_path):
+        paths = self._fetch(tmp_path, f"duplicate_group_id=9&{self._ALL_HIDE_TOGGLES}")
+        assert paths == {"/dup-a.jpg", "/dup-b.jpg"}
+
+    def test_scope_narrows_to_only_that_set(self, tmp_path):
+        """Every hide toggle is suppressed while scoped, but the WHERE clause
+        narrowing to the scoped set's own id is unaffected -- unrelated sets
+        stay scoped out even though their hide toggles are also off."""
+        paths = self._fetch(tmp_path, f"burst_group_id=5&{self._ALL_HIDE_TOGGLES}")
+        assert "/b-under.jpg" not in paths
+        assert "/p-a.jpg" not in paths
+        assert "/dup-a.jpg" not in paths
+        assert "/plain.jpg" not in paths
+
+    def test_unscoped_request_still_collapses_every_set_to_its_lead(self, tmp_path):
+        paths = self._fetch(tmp_path, self._ALL_HIDE_TOGGLES)
+        assert paths == {"/plain.jpg", "/b-base.jpg", "/p-b.jpg", "/burst-b.jpg", "/dup-a.jpg"}
+
+    def test_bracket_scope_survives_hide_bursts_when_the_set_is_also_a_burst(self, tmp_path):
+        """A real AEB set fired in continuous drive mode is grouped as BOTH a
+        bracket (by the sequence pass) and a burst (by the burst pass), with
+        none of the sequence-lead frames necessarily the burst lead. Scoping
+        to the bracket must suppress hide_bursts too, or hide_bursts=1 (on by
+        default) collapses the set to its one burst-lead frame.
+        """
+        overlapping = [
+            _photo("/ab-1.jpg", "2024:06:15 18:00:00", sequence_group_id=4, sequence_kind="bracket",
+                   sequence_ev_offset=-2.0, burst_group_id=20, is_burst_lead=0),
+            _photo("/ab-2.jpg", "2024:06:15 18:00:01", sequence_group_id=4, sequence_kind="bracket",
+                   sequence_ev_offset=-1.0, burst_group_id=20, is_burst_lead=0),
+            _photo("/ab-3.jpg", "2024:06:15 18:00:02", sequence_group_id=4, sequence_kind="bracket",
+                   sequence_ev_offset=0.0, burst_group_id=20, is_burst_lead=1),
+            _photo("/ab-4.jpg", "2024:06:15 18:00:03", sequence_group_id=4, sequence_kind="bracket",
+                   sequence_ev_offset=1.0, burst_group_id=20, is_burst_lead=0),
+            _photo("/ab-5.jpg", "2024:06:15 18:00:04", sequence_group_id=4, sequence_kind="bracket",
+                   sequence_ev_offset=2.0, burst_group_id=20, is_burst_lead=0),
+        ]
+        paths = self._fetch(
+            tmp_path, f"sequence_kind=bracket&sequence_group_id=4&{self._ALL_HIDE_TOGGLES}",
+            photos=overlapping,
+        )
+        assert paths == {"/ab-1.jpg", "/ab-2.jpg", "/ab-3.jpg", "/ab-4.jpg", "/ab-5.jpg"}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/photo/set
+# ---------------------------------------------------------------------------
+
+class TestPhotoSetEndpoint:
+    """GET /api/photo/set -- resolve the set a photo belongs to, keyed on path.
+
+    Priority is sequence, then burst, then duplicate, resolved from the
+    photo's own row -- see .claude/patterns/panorama-detection.md.
+    """
+
+    _PHOTOS = [
+        _photo("/lone.jpg", "2024:06:15 10:00:00"),
+        _photo("/b-under.jpg", "2024:06:15 12:00:00",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=-2.0, is_sequence_lead=0),
+        _photo("/b-base.jpg", "2024:06:15 12:00:01",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=0.0, is_sequence_lead=1),
+        _photo("/b-over.jpg", "2024:06:15 12:00:02",
+               sequence_group_id=1, sequence_kind="bracket", sequence_ev_offset=1.0, is_sequence_lead=0),
+        _photo("/p-a.jpg", "2024:06:15 13:00:02",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=0),
+        _photo("/p-b.jpg", "2024:06:15 13:00:00",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=1),
+        _photo("/p-c.jpg", "2024:06:15 13:00:01",
+               sequence_group_id=2, sequence_kind="panorama", is_sequence_lead=0),
+        _photo("/burst-a.jpg", "2024:06:15 14:00:01", burst_group_id=5, is_burst_lead=0),
+        _photo("/burst-b.jpg", "2024:06:15 14:00:00", burst_group_id=5, is_burst_lead=1),
+        _photo("/dup-a.jpg", "2024:06:15 15:00:00", duplicate_group_id=9, is_duplicate_lead=1),
+        _photo("/dup-b.jpg", "2024:06:15 15:00:01", duplicate_group_id=9, is_duplicate_lead=0),
+        # A sequence AND a burst group -- sequence must win.
+        _photo("/seq-over-burst.jpg", "2024:06:15 16:00:00",
+               sequence_group_id=3, sequence_kind="bracket", sequence_ev_offset=0.0, is_sequence_lead=1,
+               burst_group_id=7),
+        _photo("/seq-over-burst-sibling.jpg", "2024:06:15 16:00:01",
+               sequence_group_id=3, sequence_kind="bracket", sequence_ev_offset=1.0, is_sequence_lead=0),
+        # A burst AND a duplicate group -- burst must win.
+        _photo("/burst-over-dup.jpg", "2024:06:15 17:00:00", burst_group_id=11, is_burst_lead=1,
+               duplicate_group_id=13),
+        _photo("/burst-over-dup-sibling.jpg", "2024:06:15 17:00:01", burst_group_id=11, is_burst_lead=0),
+    ]
+
+    def _fetch(self, tmp_path, path):
+        db_path = str(tmp_path / "test.db")
+        _make_db(db_path, self._PHOTOS)
+        app = _create_app_no_auth()
+        with (
+            mock.patch("api.routers.gallery.get_async_db", _async_conn_factory(db_path)),
+            mock.patch("api.db_helpers._existing_columns_cache", _TEST_PHOTOS_COLUMNS),
+        ):
+            return TestClient(app, raise_server_exceptions=False).get(f"/api/photo/set?path={path}")
+
+    def test_photo_not_found(self, tmp_path):
+        resp = self._fetch(tmp_path, "/nonexistent.jpg")
+        assert resp.status_code == 404
+
+    def test_a_photo_in_no_set_reports_an_empty_result(self, tmp_path):
+        resp = self._fetch(tmp_path, "/lone.jpg")
+        assert resp.status_code == 200
+        assert resp.json() == {"kind": None, "group_id": None, "count": 0, "ev_span": None, "members": []}
+
+    def test_bracket_set_orders_by_distance_from_base_and_reports_ev_span(self, tmp_path):
+        data = self._fetch(tmp_path, "/b-base.jpg").json()
+        assert data["kind"] == "bracket"
+        assert data["group_id"] == 1
+        assert data["count"] == 3
+        assert data["ev_span"] == 2.0
+        assert [m["path"] for m in data["members"]] == ["/b-base.jpg", "/b-over.jpg", "/b-under.jpg"]
+        base = next(m for m in data["members"] if m["path"] == "/b-base.jpg")
+        assert base["is_lead"] is True
+        assert base["ev_offset"] == 0.0
+        under = next(m for m in data["members"] if m["path"] == "/b-under.jpg")
+        assert under["ev_offset"] == -2.0
+        assert under["is_lead"] is False
+
+    def test_panorama_set_orders_by_capture_time_and_has_no_ev_span(self, tmp_path):
+        data = self._fetch(tmp_path, "/p-a.jpg").json()
+        assert data["kind"] == "panorama"
+        assert data["group_id"] == 2
+        assert data["count"] == 3
+        assert data["ev_span"] is None
+        assert [m["path"] for m in data["members"]] == ["/p-b.jpg", "/p-c.jpg", "/p-a.jpg"]
+        lead = next(m for m in data["members"] if m["path"] == "/p-b.jpg")
+        assert lead["is_lead"] is True
+
+    def test_burst_set_orders_by_capture_time_and_has_no_ev_span(self, tmp_path):
+        data = self._fetch(tmp_path, "/burst-a.jpg").json()
+        assert data["kind"] == "burst"
+        assert data["group_id"] == 5
+        assert data["count"] == 2
+        assert data["ev_span"] is None
+        assert [m["path"] for m in data["members"]] == ["/burst-b.jpg", "/burst-a.jpg"]
+        lead = next(m for m in data["members"] if m["path"] == "/burst-b.jpg")
+        assert lead["is_lead"] is True
+
+    def test_duplicate_set(self, tmp_path):
+        data = self._fetch(tmp_path, "/dup-b.jpg").json()
+        assert data["kind"] == "duplicate"
+        assert data["group_id"] == 9
+        assert data["count"] == 2
+        lead = next(m for m in data["members"] if m["path"] == "/dup-a.jpg")
+        assert lead["is_lead"] is True
+
+    def test_sequence_takes_precedence_over_burst(self, tmp_path):
+        data = self._fetch(tmp_path, "/seq-over-burst.jpg").json()
+        assert data["kind"] == "bracket"
+        assert data["group_id"] == 3
+        assert {m["path"] for m in data["members"]} == {"/seq-over-burst.jpg", "/seq-over-burst-sibling.jpg"}
+
+    def test_burst_takes_precedence_over_duplicate(self, tmp_path):
+        data = self._fetch(tmp_path, "/burst-over-dup.jpg").json()
+        assert data["kind"] == "burst"
+        assert data["group_id"] == 11
+        assert {m["path"] for m in data["members"]} == {"/burst-over-dup.jpg", "/burst-over-dup-sibling.jpg"}

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,0 +1,514 @@
+"""Tests for the stored per-photo histogram: packing, the two on-disk formats,
+the ``/api/photo/histogram`` endpoint and the colour-similarity consumer.
+
+The library that motivated this change holds ~127k rows in the legacy
+1024-byte format, so "both formats decode" is not a nicety — it is the normal
+state of a database for as long as a full rescan takes.
+"""
+
+import sqlite3
+import struct
+from contextlib import contextmanager
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from analyzers.technical import TechnicalAnalyzer
+from api.routers.gallery import _find_similar_color
+from utils.histogram import (
+    HISTOGRAM_BINS, HISTOGRAM_BLOB_SIZE, LEGACY_HISTOGRAM_BLOB_SIZE,
+    clip_percents, display_channels, downsample_bins, max_clip_percents,
+    pack_histogram, unpack_histogram,
+)
+
+_MODULE = "api.routers.histogram"
+
+
+def _legacy_blob(counts):
+    """A pre-RGB blob: 256 float32 luminance bins normalised to sum 1."""
+    counts = np.asarray(counts, dtype=np.float64)
+    total = counts.sum()
+    normalized = counts / total if total else counts
+    return struct.pack('256f', *normalized)
+
+
+def _spike(index, height=1000.0, bins=HISTOGRAM_BINS):
+    counts = np.zeros(bins)
+    counts[index] = height
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Packing / decoding
+# ---------------------------------------------------------------------------
+
+class TestPackUnpack:
+    def test_blob_is_four_uint16_channels(self):
+        blob = pack_histogram(_spike(0), _spike(1), _spike(2), _spike(3))
+        assert len(blob) == HISTOGRAM_BLOB_SIZE == 2048
+
+    def test_round_trips_channel_order_and_shape(self):
+        blob = pack_histogram(_spike(10), _spike(20), _spike(30), _spike(40))
+        decoded = unpack_histogram(blob)
+        assert decoded['luma'].argmax() == 10
+        red, green, blue = decoded['rgb']
+        assert (red.argmax(), green.argmax(), blue.argmax()) == (20, 30, 40)
+
+    def test_one_scale_factor_preserves_relative_channel_heights(self):
+        blob = pack_histogram(_spike(0, 100), _spike(0, 400), _spike(0, 200), _spike(0, 50))
+        decoded = unpack_histogram(blob)
+        red, green, blue = decoded['rgb']
+        assert red.max() == pytest.approx(65535, rel=1e-4)
+        assert decoded['luma'].max() / red.max() == pytest.approx(0.25, rel=1e-3)
+        assert green.max() / red.max() == pytest.approx(0.5, rel=1e-3)
+        assert blue.max() / red.max() == pytest.approx(0.125, rel=1e-3)
+
+    def test_all_zero_histogram_packs_without_dividing_by_zero(self):
+        zeros = np.zeros(HISTOGRAM_BINS)
+        decoded = unpack_histogram(pack_histogram(zeros, zeros, zeros, zeros))
+        assert decoded['luma'].sum() == 0
+
+    def test_legacy_blob_decodes_as_luminance_only(self):
+        blob = _legacy_blob(_spike(77))
+        assert len(blob) == LEGACY_HISTOGRAM_BLOB_SIZE == 1024
+        decoded = unpack_histogram(blob)
+        assert decoded['rgb'] is None
+        assert decoded['luma'].argmax() == 77
+        assert decoded['luma'].sum() == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize("blob", [None, b'', b'\x00' * 999, b'\x00' * 4096])
+    def test_missing_or_unknown_length_returns_none(self, blob):
+        assert unpack_histogram(blob) is None
+
+
+class TestDownsampleBins:
+    def test_sums_adjacent_bins(self):
+        counts = np.arange(HISTOGRAM_BINS, dtype=np.float64)
+        out = downsample_bins(counts, 64)
+        assert out.shape == (64,)
+        assert out.sum() == counts.sum()
+        assert out[0] == 0 + 1 + 2 + 3
+
+    def test_full_resolution_is_a_passthrough(self):
+        counts = np.arange(HISTOGRAM_BINS, dtype=np.float64)
+        assert np.array_equal(downsample_bins(counts, HISTOGRAM_BINS), counts)
+
+    def test_rejects_a_non_divisor(self):
+        with pytest.raises(ValueError):
+            downsample_bins(np.zeros(HISTOGRAM_BINS), 50)
+
+
+class TestDisplayChannels:
+    def test_normalizes_every_channel_by_one_global_max(self):
+        decoded = unpack_histogram(
+            pack_histogram(_spike(100, 100), _spike(100, 400), _spike(100, 200), _spike(100, 50))
+        )
+        out = display_channels(decoded, bins=HISTOGRAM_BINS)
+        assert max(out['r']) == pytest.approx(1.0, abs=1e-3)
+        assert max(out['luma']) == pytest.approx(0.25, abs=1e-3)
+        assert max(out['g']) == pytest.approx(0.5, abs=1e-3)
+        assert max(out['b']) == pytest.approx(0.125, abs=1e-3)
+
+    def test_never_stretches_a_near_empty_channel_to_full_height(self):
+        decoded = unpack_histogram(
+            pack_histogram(_spike(80, 1000), _spike(80, 1000), _spike(80, 1000), _spike(80, 1))
+        )
+        out = display_channels(decoded, bins=HISTOGRAM_BINS)
+        assert max(out['b']) < 0.01
+
+    def test_legacy_histogram_reports_luma_only(self):
+        out = display_channels(unpack_histogram(_legacy_blob(_spike(12))), bins=64)
+        assert out['r'] is None and out['g'] is None and out['b'] is None
+        assert len(out['luma']) == 64
+        assert max(out['luma']) == 1.0
+
+    def test_respects_the_requested_bin_count(self):
+        decoded = unpack_histogram(pack_histogram(*[_spike(3)] * 4))
+        assert len(display_channels(decoded, bins=32)['luma']) == 32
+
+
+# ---------------------------------------------------------------------------
+# Analyzer output
+# ---------------------------------------------------------------------------
+
+class TestAnalyzerChannels:
+    def test_channels_track_the_actual_colours(self):
+        # Left half saturated red, right half saturated blue (image_cv is BGR).
+        img = np.zeros((20, 20, 3), dtype=np.uint8)
+        img[:, :10] = (0, 0, 255)
+        img[:, 10:] = (255, 0, 0)
+
+        decoded = unpack_histogram(TechnicalAnalyzer.get_histogram_data(img)['histogram_bytes'])
+        red, green, blue = decoded['rgb']
+
+        # Half the pixels are fully saturated in red, half in blue.
+        assert red[255] == red[0] == red.max()
+        assert blue[255] == blue[0] == blue.max()
+        # No pixel has any green, so its single bin holds the whole frame and is
+        # the tallest bin anywhere -- the one that sets the shared scale factor.
+        assert green.argmax() == 0
+        assert green[0] == 65535
+        assert red.max() == pytest.approx(65535 / 2, rel=1e-3)
+
+    def test_monochrome_frame_gives_identical_channels(self):
+        img = np.full((20, 20, 3), 128, dtype=np.uint8)
+        decoded = unpack_histogram(TechnicalAnalyzer.get_histogram_data(img)['histogram_bytes'])
+        red, green, blue = decoded['rgb']
+        assert np.array_equal(red, green) and np.array_equal(green, blue)
+        assert np.array_equal(decoded['luma'], red)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+def _db_cm(db_path):
+    @contextmanager
+    def _cm():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+    return _cm
+
+
+def _seed(tmp_path, rows):
+    db = str(tmp_path / "hist.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE photos (path TEXT PRIMARY KEY, histogram_data BLOB, "
+        "filename TEXT, mean_saturation REAL, mean_luminance REAL, is_monochrome INTEGER, "
+        "date_taken TEXT, aggregate REAL, aesthetic REAL)"
+    )
+    for path, blob in rows:
+        conn.execute(
+            "INSERT INTO photos (path, histogram_data, filename, mean_saturation, "
+            "mean_luminance, is_monochrome, date_taken, aggregate, aesthetic) "
+            "VALUES (?, ?, ?, 0.2, 0.5, 0, '2026-01-01', 7.0, 7.0)",
+            (path, blob, path.lstrip('/')),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+class TestHistogramEndpoint:
+    def test_serves_all_four_channels_for_a_current_row(self, regular_client, tmp_path):
+        blob = pack_histogram(
+            _spike(100, 100), _spike(100, 400), _spike(100, 200), _spike(100, 50))
+        db = _seed(tmp_path, [("/a.jpg", blob)])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/a.jpg"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["bins"] == 64
+        assert len(body["luma"]) == len(body["r"]) == 64
+        assert max(body["r"]) == pytest.approx(1.0, abs=1e-3)
+        assert max(body["luma"]) == pytest.approx(0.25, abs=1e-3)
+
+    def test_legacy_row_serves_luminance_with_null_channels(self, regular_client, tmp_path):
+        db = _seed(tmp_path, [("/a.jpg", _legacy_blob(_spike(200)))])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/a.jpg"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["r"] is None and body["g"] is None and body["b"] is None
+        assert body["luma"].index(1.0) == 200 * 64 // 256
+
+    def test_row_without_a_histogram_404s_so_the_client_can_fall_back(
+            self, regular_client, tmp_path):
+        db = _seed(tmp_path, [("/a.jpg", None)])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/a.jpg"})
+        assert resp.status_code == 404
+
+    def test_unknown_photo_404s(self, regular_client, tmp_path):
+        db = _seed(tmp_path, [("/a.jpg", _legacy_blob(_spike(1)))])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/nope.jpg"})
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("bins", [7, 0, 512])
+    def test_rejects_a_bin_count_that_does_not_divide_256(
+            self, regular_client, tmp_path, bins):
+        db = _seed(tmp_path, [("/a.jpg", _legacy_blob(_spike(1)))])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get(
+                "/api/photo/histogram", params={"path": "/a.jpg", "bins": bins})
+        assert resp.status_code == 400
+
+    def test_serves_the_full_stored_resolution_on_request(self, regular_client, tmp_path):
+        db = _seed(tmp_path, [("/a.jpg", pack_histogram(*[_spike(9)] * 4))])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get(
+                "/api/photo/histogram", params={"path": "/a.jpg", "bins": 256})
+        assert resp.status_code == 200
+        assert len(resp.json()["luma"]) == HISTOGRAM_BINS
+
+
+# ---------------------------------------------------------------------------
+# Colour similarity keeps working across both formats
+# ---------------------------------------------------------------------------
+
+# An identical colour photo scores 0.9, not 1.0: the last tenth is the
+# monochrome bonus, which two colour photos never earn.
+_PERFECT_COLOUR_MATCH = 0.9
+
+
+class TestColorSimilarityAcrossFormats:
+    def _conn(self, tmp_path, rows):
+        conn = sqlite3.connect(_seed(tmp_path, rows))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _run(self, conn, source_blob):
+        source = {
+            'histogram_data': source_blob, 'is_monochrome': 0,
+            'mean_saturation': 0.2, 'mean_luminance': 0.5,
+        }
+        return _find_similar_color(conn, source, '/src.jpg', 0.0, '1=1', [])
+
+    def test_legacy_source_matches_legacy_candidate(self, tmp_path):
+        blob = _legacy_blob(_spike(100))
+        conn = self._conn(tmp_path, [("/src.jpg", blob), ("/same.jpg", blob)])
+        results, reason = self._run(conn, blob)
+        assert reason is None
+        assert results[0]['path'] == '/same.jpg'
+        assert results[0]['similarity'] == pytest.approx(_PERFECT_COLOUR_MATCH, abs=1e-3)
+
+    def test_current_source_matches_current_candidate(self, tmp_path):
+        blob = pack_histogram(_spike(100), _spike(10), _spike(20), _spike(30))
+        conn = self._conn(tmp_path, [("/src.jpg", blob), ("/same.jpg", blob)])
+        results, reason = self._run(conn, blob)
+        assert reason is None
+        assert results[0]['similarity'] == pytest.approx(_PERFECT_COLOUR_MATCH, abs=1e-3)
+
+    def test_mixed_formats_still_score_the_same_luminance_as_a_match(self, tmp_path):
+        counts = _spike(100)
+        legacy = _legacy_blob(counts)
+        current = pack_histogram(counts, _spike(10), _spike(20), _spike(30))
+        conn = self._conn(tmp_path, [("/src.jpg", legacy), ("/current.jpg", current)])
+        results, _ = self._run(conn, legacy)
+        assert results[0]['path'] == '/current.jpg'
+        assert results[0]['similarity'] == pytest.approx(_PERFECT_COLOUR_MATCH, abs=1e-3)
+
+    def test_different_luminance_still_separates(self, tmp_path):
+        dark = pack_histogram(*[_spike(5)] * 4)
+        bright = pack_histogram(*[_spike(250)] * 4)
+        conn = self._conn(tmp_path, [("/src.jpg", dark), ("/bright.jpg", bright)])
+        results, _ = self._run(conn, dark)
+        assert results[0]['similarity'] < 0.5
+
+    def test_source_without_a_histogram_reports_the_reason(self, tmp_path):
+        conn = self._conn(tmp_path, [("/src.jpg", None)])
+        assert self._run(conn, None) == ([], 'no_histogram')
+
+    def test_candidate_with_a_corrupt_blob_is_skipped_not_fatal(self, tmp_path):
+        blob = _legacy_blob(_spike(100))
+        conn = self._conn(tmp_path, [("/src.jpg", blob), ("/bad.jpg", b'\x00' * 7)])
+        results, reason = self._run(conn, blob)
+        assert reason is None
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# --recompute-average re-derives exposure_score from the stored blob
+# ---------------------------------------------------------------------------
+
+# The columns update_all_aggregates reads back for a photo; only the histogram
+# and the fields the exposure formula consumes matter here.
+_RECOMPUTE_ROW = {
+    'aesthetic': 7.0, 'face_count': 0, 'face_ratio': 0.0, 'tech_sharpness': 7.0,
+    'color_score': 7.0, 'exposure_score': 0.0, 'comp_score': 6.0,
+    'is_silhouette': 0, 'histogram_bimodality': 1.0, 'is_monochrome': 0,
+    'tags': '', 'mean_luminance': 0.5, 'quality_score': 5.0,
+}
+
+
+def _recomputed_exposure(tmp_path, name, blob):
+    from db import get_connection, init_database
+    from processing.scorer import Facet
+
+    db_path = str(tmp_path / f'{name}.db')
+    init_database(db_path)
+    columns = ['path', 'histogram_data'] + list(_RECOMPUTE_ROW.keys())
+    values = [f'/{name}.jpg', blob] + list(_RECOMPUTE_ROW.values())
+    with get_connection(db_path, row_factory=False) as conn:
+        conn.execute(
+            f"INSERT INTO photos ({','.join(columns)}) "
+            f"VALUES ({','.join('?' * len(columns))})", values)
+        conn.commit()
+
+    Facet(db_path=db_path, lightweight=True).update_all_aggregates(use_embeddings=False)
+    with get_connection(db_path, row_factory=False) as conn:
+        return conn.execute(
+            "SELECT exposure_score FROM photos WHERE path = ?", (f'/{name}.jpg',)
+        ).fetchone()[0]
+
+
+class TestRecomputeReadsBothFormats:
+    def test_both_formats_of_one_distribution_recompute_the_same_score(self, tmp_path):
+        counts = np.zeros(HISTOGRAM_BINS)
+        counts[60:140] = 500.0
+        legacy = _recomputed_exposure(tmp_path, 'legacy', _legacy_blob(counts))
+        current = _recomputed_exposure(
+            tmp_path, 'current', pack_histogram(counts, counts, counts, counts))
+        assert legacy == pytest.approx(current, abs=1e-3)
+
+    def test_a_crushed_frame_still_scores_below_a_well_exposed_one(self, tmp_path):
+        dark = np.zeros(HISTOGRAM_BINS)
+        dark[:10] = 5000.0
+        even = np.full(HISTOGRAM_BINS, 100.0)
+        assert (_recomputed_exposure(tmp_path, 'dark', pack_histogram(dark, dark, dark, dark))
+                < _recomputed_exposure(tmp_path, 'even', pack_histogram(even, even, even, even)))
+
+
+# ---------------------------------------------------------------------------
+# Per-channel clipping: derivation, the NULL-means-unknown rule, and drawing
+# ---------------------------------------------------------------------------
+
+def _frame(pixels_bgr):
+    """A 100x100 BGR frame from a list of (count, (b, g, r)) runs."""
+    flat = np.zeros((10000, 3), dtype=np.uint8)
+    offset = 0
+    for count, colour in pixels_bgr:
+        flat[offset:offset + count] = colour
+        offset += count
+    return flat.reshape(100, 100, 3)
+
+
+class TestClipPercents:
+    def test_derived_fractions_match_a_direct_pixel_count(self):
+        # 1200 pixels blown out in blue only, 700 crushed in red only.
+        img = _frame([
+            (1200, (255, 40, 40)),
+            (700, (90, 90, 0)),
+            (8100, (120, 130, 140)),
+        ])
+        flat = img.reshape(-1, 3)
+        total = flat.shape[0]
+        blue, green, red = flat[:, 0], flat[:, 1], flat[:, 2]
+
+        measured = TechnicalAnalyzer.get_histogram_data(img)
+        derived = clip_percents(unpack_histogram(measured['histogram_bytes']))
+
+        for name, channel in (('r', red), ('g', green), ('b', blue)):
+            assert derived['highlight'][name] == pytest.approx(
+                (channel == 255).sum() / total * 100, abs=1e-3)
+            assert derived['shadow'][name] == pytest.approx(
+                (channel == 0).sum() / total * 100, abs=1e-3)
+
+        # The columns the scan stores are the worst channel of each direction.
+        assert measured['channel_clip_highlight_pct'] == pytest.approx(12.0, abs=1e-4)
+        assert measured['channel_clip_shadow_pct'] == pytest.approx(7.0, abs=1e-4)
+
+    def test_a_single_blown_channel_is_invisible_to_luminance(self):
+        # Deep red: R is pinned at 255 while luma sits near 76, so a luma-only
+        # reading reports nothing at all. This is the whole point of the column.
+        img = _frame([(10000, (0, 0, 255))])
+        derived = clip_percents(unpack_histogram(
+            TechnicalAnalyzer.get_histogram_data(img)['histogram_bytes']))
+        assert derived['highlight']['r'] == pytest.approx(100.0, abs=1e-3)
+        assert derived['highlight']['luma'] == 0.0
+
+    def test_the_stored_columns_take_the_worst_channel_not_luma(self):
+        img = _frame([(2000, (255, 0, 0)), (8000, (100, 110, 120))])
+        measured = TechnicalAnalyzer.get_histogram_data(img)
+        assert measured['channel_clip_highlight_pct'] == pytest.approx(20.0, abs=1e-3)
+
+    def test_exactly_bin_255_counts_never_a_band_below_it(self):
+        # 254 is a hot highlight but it is not clipped: it still holds detail.
+        img = _frame([(5000, (254, 254, 254)), (5000, (1, 1, 1))])
+        measured = TechnicalAnalyzer.get_histogram_data(img)
+        assert measured['channel_clip_highlight_pct'] == 0.0
+        assert measured['channel_clip_shadow_pct'] == 0.0
+
+    def test_the_coarse_luma_flags_are_left_alone(self):
+        # shadow_clipped/highlight_clipped are bands on luminance and feed
+        # exposure_score; the new columns must not have changed them.
+        img = _frame([(5000, (255, 255, 255)), (5000, (0, 0, 0))])
+        measured = TechnicalAnalyzer.get_histogram_data(img)
+        assert measured['shadow_clipped'] == 1
+        assert measured['highlight_clipped'] == 1
+        assert measured['channel_clip_shadow_pct'] == pytest.approx(50.0, abs=1e-3)
+
+    def test_a_legacy_blob_is_unknown_not_clean(self):
+        legacy = unpack_histogram(_legacy_blob(_spike(200)))
+        assert clip_percents(legacy) is None
+        assert max_clip_percents(legacy) == (None, None)
+
+    def test_a_missing_blob_is_unknown_too(self):
+        assert clip_percents(unpack_histogram(None)) is None
+        assert max_clip_percents(unpack_histogram(None)) == (None, None)
+
+    def test_survives_the_uint16_packing_of_a_dominant_spike(self):
+        # 40% of pixels on bin 255 sets the packing scale; the interior bins are
+        # squeezed hard, and the RATIO must still come back.
+        counts = np.zeros(HISTOGRAM_BINS)
+        counts[255] = 4000.0
+        counts[60:140] = 12.5
+        blob = pack_histogram(counts, counts, counts, counts)
+        assert max_clip_percents(unpack_histogram(blob))[1] == pytest.approx(80.0, abs=0.05)
+
+
+class TestInteriorNormalization:
+    def _clipped_decoded(self):
+        """A frame whose bin-255 spike dwarfs a real, readable tonal curve."""
+        counts = np.zeros(HISTOGRAM_BINS)
+        counts[255] = 10000.0
+        counts[100] = 300.0
+        counts[101] = 150.0
+        return unpack_histogram(pack_histogram(counts, counts, counts, counts))
+
+    def test_a_dominant_clip_spike_no_longer_flattens_the_curve(self):
+        out = display_channels(self._clipped_decoded(), bins=HISTOGRAM_BINS)
+        # Against the spike this bin was 3% of full height -- a hairline.
+        assert out['luma'][100] == pytest.approx(1.0, abs=1e-3)
+        assert out['luma'][101] == pytest.approx(0.5, abs=1e-3)
+
+    def test_both_clipping_bins_are_dropped_from_the_curve(self):
+        out = display_channels(self._clipped_decoded(), bins=HISTOGRAM_BINS)
+        assert out['luma'][255] == 0.0
+        assert out['luma'][0] == 0.0
+
+    def test_the_shared_scale_across_channels_is_kept(self):
+        # Only the interior maximum may set the scale, and it is still ONE
+        # maximum for all four channels -- per-channel maxima would invent a cast.
+        blob = pack_histogram(
+            _spike(90, 100), _spike(90, 400), _spike(90, 200), _spike(90, 50))
+        out = display_channels(unpack_histogram(blob), bins=HISTOGRAM_BINS)
+        assert max(out['r']) == pytest.approx(1.0, abs=1e-3)
+        assert max(out['g']) == pytest.approx(0.5, abs=1e-3)
+        assert max(out['b']) == pytest.approx(0.125, abs=1e-3)
+
+    def test_an_all_clipped_frame_draws_a_flat_line_instead_of_dividing_by_zero(self):
+        counts = np.zeros(HISTOGRAM_BINS)
+        counts[255] = 5000.0
+        out = display_channels(unpack_histogram(pack_histogram(*[counts] * 4)), bins=64)
+        assert set(out['luma']) == {0.0}
+
+
+class TestHistogramEndpointClipping:
+    def test_serves_the_percentages_for_a_current_row(self, regular_client, tmp_path):
+        counts = np.zeros(HISTOGRAM_BINS)
+        counts[255] = 100.0
+        counts[50] = 900.0
+        blob = pack_histogram(counts, counts, counts, np.zeros(HISTOGRAM_BINS))
+        db = _seed(tmp_path, [("/a.jpg", blob)])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/a.jpg"})
+        assert resp.status_code == 200
+        clipped = resp.json()["clipped"]
+        assert clipped["highlight"]["r"] == pytest.approx(10.0, abs=1e-2)
+        assert clipped["shadow"]["r"] == 0.0
+
+    def test_a_legacy_row_reports_null_so_the_client_shows_no_markers(
+            self, regular_client, tmp_path):
+        db = _seed(tmp_path, [("/a.jpg", _legacy_blob(_spike(200)))])
+        with mock.patch(f"{_MODULE}.get_db", _db_cm(db)):
+            resp = regular_client.get("/api/photo/histogram", params={"path": "/a.jpg"})
+        assert resp.status_code == 200
+        assert resp.json()["clipped"] is None

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -354,3 +354,39 @@ class TestWeightsDestination:
 
         assert destination.read_bytes() == b'second'
         assert list(tmp_path.glob('*.part')) == []
+
+    def test_a_matching_checksum_installs_the_file(self, tmp_path):
+        import hashlib
+
+        from models import weights
+
+        destination = tmp_path / 'weights.pth'
+
+        def fake_urlretrieve(url, path):
+            with open(path, 'wb') as handle:
+                handle.write(b'payload')
+
+        with mock.patch.object(weights.urllib.request, 'urlretrieve', fake_urlretrieve):
+            weights.download_weights(
+                'https://example.invalid/w.pth', destination,
+                sha256=hashlib.sha256(b'payload').hexdigest())
+
+        assert destination.read_bytes() == b'payload'
+
+    def test_a_mismatched_checksum_is_rejected_and_leaves_no_partial_file(self, tmp_path):
+        from models import weights
+
+        destination = tmp_path / 'weights.pth'
+
+        def fake_urlretrieve(url, path):
+            with open(path, 'wb') as handle:
+                handle.write(b'tampered')
+
+        with mock.patch.object(weights.urllib.request, 'urlretrieve', fake_urlretrieve):
+            with pytest.raises(ValueError):
+                weights.download_weights(
+                    'https://example.invalid/w.pth', destination,
+                    sha256='0' * 64)
+
+        assert not destination.exists()
+        assert list(tmp_path.glob('*.part')) == []

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -298,3 +298,59 @@ class TestLoadedModelsTracking:
         assert 'vlm_tagger' not in manager.models
         assert 'vlm_tagger' not in manager._cpu_cache
         fake_model.cpu.assert_called_once()
+
+
+class TestWeightsDestination:
+    """Auto-downloaded weights must land in ``pretrained_models/``, not the CWD.
+
+    ``aesthetic_predictor_weights.pth`` used to be written to the process working
+    directory, so it was re-downloaded whenever facet.py and viewer.py ran from
+    different directories -- and on every Docker container recreation, since the
+    image's WORKDIR is not a mounted volume.
+    """
+
+    def test_path_is_absolute_and_independent_of_the_working_directory(self, tmp_path, monkeypatch):
+        from models.weights import pretrained_model_path
+
+        before = pretrained_model_path('aesthetic_predictor_weights.pth')
+        monkeypatch.chdir(tmp_path)
+        after = pretrained_model_path('aesthetic_predictor_weights.pth')
+
+        assert after.is_absolute()
+        assert after == before
+        assert after.parent.name == 'pretrained_models'
+        assert tmp_path not in after.parents
+
+    def test_download_is_atomic_and_leaves_no_partial_file(self, tmp_path):
+        from models import weights
+
+        destination = tmp_path / 'nested' / 'weights.pth'
+        observed = {}
+
+        def fake_urlretrieve(url, path):
+            observed['temp_path'] = path
+            with open(path, 'wb') as handle:
+                handle.write(b'payload')
+
+        with mock.patch.object(weights.urllib.request, 'urlretrieve', fake_urlretrieve):
+            weights.download_weights('https://example.invalid/w.pth', destination)
+
+        assert destination.read_bytes() == b'payload'
+        assert observed['temp_path'] != str(destination)
+        assert list(destination.parent.glob('*.part')) == []
+
+    def test_download_of_an_existing_file_is_idempotent(self, tmp_path):
+        from models import weights
+
+        destination = tmp_path / 'weights.pth'
+        destination.write_bytes(b'first')
+
+        def fake_urlretrieve(url, path):
+            with open(path, 'wb') as handle:
+                handle.write(b'second')
+
+        with mock.patch.object(weights.urllib.request, 'urlretrieve', fake_urlretrieve):
+            weights.download_weights('https://example.invalid/w.pth', destination)
+
+        assert destination.read_bytes() == b'second'
+        assert list(tmp_path.glob('*.part')) == []

--- a/tests/test_multi_pass.py
+++ b/tests/test_multi_pass.py
@@ -147,6 +147,83 @@ class TestTaggingModelRouting:
         assert proc._pass_vlm_tagger.called
 
 
+SHIPPED_CONFIGS = ("scoring_config.json", "scoring_config.default.json")
+
+# Composition model string in a profile -> the model name the multi-pass path
+# selects and dispatches for it. A profile configured with anything else gets no
+# composition model at all on the default scan path.
+MULTI_PASS_COMPOSITION_MODELS = {"samp-net": "samp_net"}
+
+
+def _shipped_config_path(config_name):
+    from pathlib import Path
+    return Path(__file__).resolve().parent.parent / config_name
+
+
+def _shipped_profiles(config_name):
+    import json
+    config = json.loads(_shipped_config_path(config_name).read_text())
+    return config["models"]["profiles"]
+
+
+def _processor_for_shipped_profile(config_name, profile_name):
+    from config import ScoringConfig
+    from models.model_manager import ModelManager
+
+    config = ScoringConfig(str(_shipped_config_path(config_name)))
+    config.config["models"]["vram_profile"] = profile_name
+    scorer = mock.MagicMock()
+    scorer.config = config
+    proc = ChunkedMultiPassProcessor(scorer, ModelManager(config), config.config)
+    proc.available_vram = {"legacy": 0.0, "8gb": 8.0, "16gb": 16.0, "24gb": 24.0}[profile_name]
+    return proc
+
+
+class TestShippedProfileCompositionRouting:
+    """Regression guard: composition must run on the DEFAULT (multi-pass) scan path.
+
+    The shipped 24gb profile was configured with ``qwen2-vl-2b``, which
+    ``_select_models`` never selected and ``_run_model_pass`` never dispatched --
+    only the single-pass scorer loaded it. A default scan on 24gb therefore ran no
+    composition model at all: comp_score silently came from the CPU rule-based
+    analyzer and composition_pattern stayed NULL. Exercising single-pass only would
+    reproduce that blind spot, so these run the multi-pass selection.
+    """
+
+    @pytest.mark.parametrize("config_name", SHIPPED_CONFIGS)
+    @pytest.mark.parametrize("profile_name", ["legacy", "8gb", "16gb", "24gb"])
+    def test_profile_composition_model_is_selected_and_dispatched(self, config_name, profile_name):
+        profile = _shipped_profiles(config_name)[profile_name]
+        composition_model = profile.get("composition_model")
+        assert composition_model in MULTI_PASS_COMPOSITION_MODELS, (
+            f"{config_name} profile '{profile_name}' configures composition_model "
+            f"'{composition_model}', which the default multi-pass path cannot run"
+        )
+        expected = MULTI_PASS_COMPOSITION_MODELS[composition_model]
+
+        proc = _processor_for_shipped_profile(config_name, profile_name)
+        assert expected in proc._select_models()
+
+        proc._pass_samp_net = mock.MagicMock()
+        proc._run_model_pass(expected, model=None, images={}, results={})
+        assert proc._pass_samp_net.called
+
+    @pytest.mark.parametrize("profile_name", ["legacy", "8gb", "16gb", "24gb"])
+    def test_selected_composition_model_survives_pass_grouping(self, profile_name):
+        proc = _processor_for_shipped_profile("scoring_config.json", profile_name)
+        models = proc._select_models()
+        groups = proc.model_manager.group_passes_by_vram(models, proc.available_vram)
+        assert any("samp_net" in group for group in groups)
+
+    def test_composition_model_without_a_pass_is_reported(self, caplog):
+        proc = _make_with_profile("clip", available_vram=24.0)
+        proc.model_manager._profile["composition_model"] = "qwen2-vl-2b"
+        with caplog.at_level("WARNING", logger="facet.multi_pass"):
+            models = proc._select_models()
+        assert "samp_net" not in models
+        assert "qwen2-vl-2b" in caplog.text
+
+
 class _SpyScorer:
     """Records the metrics dict handed to calculate_aggregate_logic."""
 
@@ -210,3 +287,31 @@ class TestComputeAggregatesHonorsOverride:
         assert metrics['category_override'] == 'sports'
         assert results[photo_path]['category'] == 'spy-category'
         assert results[photo_path]['aggregate'] == 7.5
+
+
+class TestCompositionPatternVocabulary:
+    """The pattern vocabulary is the model's, and --list-models must report it.
+
+    scoring_config.json carried a 14-name ``samp_net.patterns`` list nothing read
+    and the model never emits, and --list-models advertised "14 patterns" to
+    match it. The authoritative set is the 8 SAMP-Net actually predicts -- the
+    same 8 the maintainer's 126,661-photo library contains.
+    """
+
+    def test_the_model_emits_exactly_eight_patterns(self):
+        from models.samp_net import COMPOSITION_PATTERNS
+
+        assert COMPOSITION_PATTERNS == [
+            'global', 'horizontal', 'vertical', 'triangular',
+            'surround', 'quarter', 'cross', 'rule_of_thirds',
+        ]
+
+    def test_list_models_reports_the_model_s_own_pattern_count(self, caplog):
+        from models.samp_net import COMPOSITION_PATTERNS
+        from processing.multi_pass import list_available_models
+
+        with caplog.at_level("INFO", logger="facet.multi_pass"):
+            list_available_models()
+
+        assert f"({len(COMPOSITION_PATTERNS)} patterns)" in caplog.text
+        assert "14 patterns" not in caplog.text

--- a/tests/test_raw_brands.py
+++ b/tests/test_raw_brands.py
@@ -27,10 +27,13 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import rawpy
 from PIL import Image
 
-from utils.image_loading import (
+# rawpy is an optional dependency; skip this whole module (rather than
+# error collection) on environments that don't install it.
+rawpy = pytest.importorskip("rawpy")
+
+from utils.image_loading import (  # noqa: E402
     DISPLAY_PREVIEW_MIN_LONG_EDGE,
     extract_raw_preview,
     load_display_image,

--- a/tests/test_raw_brands.py
+++ b/tests/test_raw_brands.py
@@ -1,0 +1,260 @@
+"""Real-file coverage for non-Canon RAW brands (ARW/DNG/NEF/ORF/PEF/RAF/RW2/SRW).
+
+The maintainer's library is 100% Canon CR2/CR3, so every other brand is
+normally exercised only through ``tests/test_raw_decode.py``'s stubbed rawpy.
+This module decodes eight real fixture files instead, to catch anything
+brand-specific the stubs cannot: an unusual preview codec, a sensor that
+needs a 90-degree rotation, a LibRaw quirk on truncated input.
+
+Fixtures live at the repo root (``sample.arw`` etc.), are gitignored, and are
+not present in CI or a fresh clone — every test below skips (never fails)
+when its file is missing. Point ``FACET_RAW_SAMPLE_DIR`` elsewhere to use a
+different fixture location.
+
+Runtime: ~15-20s. ``TestMetricsProfileIsBrandAgnostic`` and
+``TestPreviewOrientationMatchesTheDemosaic`` share one cached full demosaic
+per brand; ``TestPreviewGateSplitsBrandsAtTheConfiguredDefault``'s
+above-the-ratio case forces a second, uncached demosaic per brand to prove
+the fallback actually lands on the sensor-sized image. Every other class
+works from the embedded preview or a cheap ``rawpy.imread`` header read. Run
+just this module with ``pytest tests/test_raw_brands.py``, or exclude it
+with ``pytest -m "not raw_brand_samples"``.
+"""
+
+import functools
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rawpy
+from PIL import Image
+
+from utils.image_loading import (
+    DISPLAY_PREVIEW_MIN_LONG_EDGE,
+    extract_raw_preview,
+    load_display_image,
+    load_image_from_path,
+    thumbnail_source,
+)
+
+pytestmark = pytest.mark.raw_brand_samples
+
+BRAND_SAMPLE_FILES = [
+    "sample.arw", "sample.dng", "sample.nef", "sample.orf",
+    "sample.pef", "sample.raf", "sample.rw2", "sample.srw",
+]
+
+# Measured with rawpy 0.26.1 against the fixtures this module targets
+# (embedded-preview long edge / sensor long edge). Recorded so a future
+# LibRaw/rawpy upgrade shows up as an intentional diff here instead of a
+# silent behaviour change elsewhere in the decode path.
+_MEASURED_PREVIEW_RATIOS = {
+    "sample.nef": 0.995,
+    "sample.pef": 0.994,
+    "sample.srw": 0.980,
+    "sample.rw2": 0.524,
+    "sample.orf": 0.488,
+    "sample.raf": 0.389,
+    "sample.arw": 0.294,
+    "sample.dng": 0.295,
+}
+# LibRaw's choice of which embedded IFD to read as "the" preview is an
+# implementation detail that can shift release to release. This only needs
+# to catch a gross regression (a preview collapsing to an icon, or jumping
+# to full-size), not pin the exact figure.
+_RATIO_TOLERANCE = 0.15
+
+_DEFAULT_MIN_SENSOR_RATIO = 0.5  # raw_decode.preview_min_sensor_ratio's shipped default
+# ORF (~0.49) and RW2 (~0.52) sit inside this margin of the default, so a
+# LibRaw/rawpy upgrade could flip either — do not assert either side of the
+# split for them; the ratio-straddle test below still covers the gate
+# mechanism itself for both.
+_BOUNDARY_SAFETY_MARGIN = 0.03
+_STRADDLE_MARGIN = 0.1
+
+
+def _sample_dir():
+    return Path(os.environ.get("FACET_RAW_SAMPLE_DIR", Path(__file__).resolve().parent.parent))
+
+
+def _require_sample(filename):
+    path = _sample_dir() / filename
+    if not path.exists():
+        pytest.skip(f"{filename} not found under {path.parent} (set FACET_RAW_SAMPLE_DIR)")
+    return path
+
+
+def _sensor_dims(path):
+    with rawpy.imread(str(path)) as raw:
+        return raw.sizes.width, raw.sizes.height
+
+
+def _measure_preview_ratio(path):
+    preview = extract_raw_preview(path)
+    assert preview is not None, f"expected an embedded preview in {path}"
+    return max(preview.size) / max(_sensor_dims(path))
+
+
+def _is_portrait(size):
+    width, height = size
+    return height > width
+
+
+@functools.lru_cache(maxsize=None)
+def _decode_metrics_cached(path_str):
+    """Full metrics-profile demosaic, cached so the two classes that both
+    need it (dimensions, orientation) pay for it only once per brand."""
+    return load_image_from_path(path_str)
+
+
+class TestMetricsProfileIsBrandAgnostic:
+    """load_image_from_path is the pixel space stored face bboxes and
+    image_width/image_height are expressed in — the most important
+    invariant here is that it never drifts to the preview's size."""
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_demosaic_matches_sensor_dimensions_not_the_preview(self, filename):
+        path = _require_sample(filename)
+        sensor_dims = sorted(_sensor_dims(path))
+
+        pil_img, img_cv = _decode_metrics_cached(str(path))
+
+        assert pil_img is not None, f"{filename} failed to decode"
+        assert pil_img.mode == 'RGB'
+        # Sorted rather than positional: LibRaw rotates 90/270-degree sensors
+        # (sizes.flip in {5, 6}) during postprocess, swapping width/height —
+        # sample.nef is one such case. The set of edges must still match the
+        # sensor's, never the preview's (see the ratio table above: none of
+        # our 8 previews is pixel-identical to its sensor).
+        assert sorted(pil_img.size) == sensor_dims
+        assert sorted((img_cv.shape[1], img_cv.shape[0])) == sensor_dims
+
+
+class TestThumbnailSourcing:
+    """All 8 fixture previews exceed the 640px thumbnail gate, so every
+    brand should yield a usable preview-sourced image without a second
+    full demosaic."""
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_every_brand_yields_a_usable_preview_sourced_image(self, filename):
+        path = _require_sample(filename)
+        placeholder = Image.new('RGB', (8, 8))
+
+        result = thumbnail_source(path, placeholder)
+
+        assert result is not placeholder
+        assert result.mode == 'RGB'
+        assert max(result.size) > DISPLAY_PREVIEW_MIN_LONG_EDGE
+        assert min(result.size) > 0
+        assert np.asarray(result).std() > 0
+
+
+class TestPreviewGateSplitsBrandsAtTheConfiguredDefault:
+    """The /image route reads raw_decode.preview_min_sensor_ratio (default
+    0.5, see api/raw_processing.py) and passes it straight through to
+    load_display_image. Checked two ways: directly, at the real default,
+    for whichever brands are unambiguously on one side of it; and via a
+    ratio-straddle that exercises the gate mechanism itself for every
+    brand, including the two that sit close enough to 0.5 to be brittle."""
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_matches_the_shipped_default_away_from_the_boundary(self, filename):
+        path = _require_sample(filename)
+        ratio = _measure_preview_ratio(path)
+        if abs(ratio - _DEFAULT_MIN_SENSOR_RATIO) < _BOUNDARY_SAFETY_MARGIN:
+            pytest.skip(f"{filename} ratio={ratio:.3f} is within "
+                       f"{_BOUNDARY_SAFETY_MARGIN} of the {_DEFAULT_MIN_SENSOR_RATIO} "
+                       "default; covered by the straddle test instead")
+        sensor_dims = sorted(_sensor_dims(path))
+
+        display = load_display_image(path, min_preview_sensor_ratio=_DEFAULT_MIN_SENSOR_RATIO)
+
+        serves_preview = sorted(display.size) != sensor_dims
+        assert serves_preview == (ratio > _DEFAULT_MIN_SENSOR_RATIO)
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_gate_straddles_each_files_own_measured_ratio(self, filename):
+        """Drives the ratio explicitly per file instead of asserting a fixed
+        side of 0.5, so a LibRaw/rawpy change to any one brand's preview
+        size — not just ORF/RW2's — cannot turn into a spurious failure."""
+        path = _require_sample(filename)
+        ratio = _measure_preview_ratio(path)
+        sensor_dims = sorted(_sensor_dims(path))
+        below = max(0.0, ratio - _STRADDLE_MARGIN)
+        above = min(1.0, ratio + _STRADDLE_MARGIN)
+
+        serves_preview = load_display_image(path, min_preview_sensor_ratio=below)
+        falls_back = load_display_image(path, min_preview_sensor_ratio=above)
+
+        assert sorted(falls_back.size) == sensor_dims
+        assert sorted(serves_preview.size) != sensor_dims
+
+
+class TestPreviewOrientationMatchesTheDemosaic:
+    """unpack_thumb performs no rotation and some previews carry no EXIF —
+    a genuine risk that a preview-sourced display image ends up sideways
+    relative to the demosaic. sample.nef (flip=5, rotated 90 degrees by
+    LibRaw during postprocess) is the one fixture among these 8 that
+    actually exercises a non-trivial rotation."""
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_portrait_stays_portrait(self, filename):
+        path = _require_sample(filename)
+        pil_img, _ = _decode_metrics_cached(str(path))
+        assert pil_img is not None
+
+        display = load_display_image(path)
+
+        assert display is not None
+        assert _is_portrait(display.size) == _is_portrait(pil_img.size)
+
+
+class TestDegeneratePaths:
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_truncated_file_never_raises(self, filename, tmp_path):
+        path = _require_sample(filename)
+        truncated = tmp_path / f"truncated{path.suffix}"
+        truncated.write_bytes(path.read_bytes()[:4096])
+
+        result = load_display_image(str(truncated))
+
+        if result is not None:
+            assert result.mode == 'RGB'
+            assert result.size[0] > 0 and result.size[1] > 0
+
+    def test_severely_truncated_rw2_degrades_to_a_black_frame_not_none(self, tmp_path):
+        """Unlike the other 7 brands (which return None at this truncation
+        size — see test_truncated_file_never_raises), RW2 does not error on
+        either extract_thumb or postprocess: LibRaw opens the header fine,
+        finds no thumbnail, then silently zero-fills the demosaic instead of
+        raising. Documented explicitly so a future "RW2 truncation -> None"
+        assumption doesn't sneak in unverified."""
+        path = _require_sample("sample.rw2")
+        truncated = tmp_path / "truncated.rw2"
+        truncated.write_bytes(path.read_bytes()[:4096])
+
+        result = load_display_image(str(truncated))
+
+        assert result is not None
+        assert np.asarray(result).max() == 0
+
+    @pytest.mark.parametrize("filename", BRAND_SAMPLE_FILES)
+    def test_missing_file_returns_none(self, filename, tmp_path):
+        _require_sample(filename)  # only run brands actually available on this host
+        missing = tmp_path / f"gone{Path(filename).suffix}"
+
+        assert load_display_image(str(missing)) is None
+
+
+class TestMeasuredPreviewRatios:
+    @pytest.mark.parametrize("filename, expected", list(_MEASURED_PREVIEW_RATIOS.items()))
+    def test_ratio_is_in_the_ballpark_of_the_recorded_value(self, filename, expected):
+        path = _require_sample(filename)
+
+        ratio = _measure_preview_ratio(path)
+
+        assert abs(ratio - expected) < _RATIO_TOLERANCE, (
+            f"{filename}: measured ratio {ratio:.3f} drifted more than "
+            f"{_RATIO_TOLERANCE} from the recorded {expected}"
+        )

--- a/tests/test_raw_decode.py
+++ b/tests/test_raw_decode.py
@@ -1,0 +1,597 @@
+"""RAW decode profiles: faithful metrics demosaic vs camera-preview display.
+
+LibRaw's ``no_auto_bright``/``adjust_maximum_thr`` defaults are per-frame
+adaptive terms that rescale every frame until it clips at the same place, so a
+bracket rendered through them comes out equalised and the exposure ladder the
+scoring engine measures is gone. These tests pin the two profiles apart: the
+metrics profile every score is computed from, and the display profile the
+stored thumbnail and the viewer show — which must never redefine the pixel
+space stored face boxes live in.
+"""
+
+import io
+import sys
+import threading
+import types
+
+import numpy as np
+import pytest
+from PIL import Image, ImageOps
+
+from config import ScoringConfig
+from utils import image_loading
+from utils.image_loading import (
+    BRACKETED_SEQUENCE_KINDS,
+    FAITHFUL_BRIGHT,
+    configure_raw_decode_profile,
+    configure_raw_decoding,
+    extract_raw_preview,
+    load_display_image,
+    load_image_from_path,
+    raw_postprocess_kwargs,
+    renders_faithfully,
+    thumbnail_source,
+)
+
+DEMOSAIC_SIZE = (2000, 1500)
+BIG_PREVIEW_SIZE = (1960, 1470)
+SMALL_PREVIEW_SIZE = (320, 240)
+
+
+@pytest.fixture(autouse=True)
+def _reset_decode_profile():
+    yield
+    image_loading._raw_decode_settings = None
+    image_loading._viewer_semaphore = None
+    configure_raw_decoding(concurrency=image_loading._auto_decode_concurrency(),
+                           timeout_seconds=0)
+
+
+def _jpeg_bytes(size, colour=90):
+    buf = io.BytesIO()
+    Image.new('RGB', size, (colour, colour, colour)).save(buf, format='JPEG')
+    return buf.getvalue()
+
+
+class _StubRaw:
+    def __init__(self, thumb, flip=0):
+        self._thumb = thumb
+        self.sizes = types.SimpleNamespace(
+            width=DEMOSAIC_SIZE[0], height=DEMOSAIC_SIZE[1], flip=flip)
+        self.postprocess_kwargs = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def extract_thumb(self):
+        if isinstance(self._thumb, Exception):
+            raise self._thumb
+        return self._thumb
+
+    def postprocess(self, **kwargs):
+        self.postprocess_kwargs = kwargs
+        return np.zeros((DEMOSAIC_SIZE[1], DEMOSAIC_SIZE[0], 3), dtype=np.uint8)
+
+
+def _install_stub_rawpy(monkeypatch, thumb, flip=0):
+    """Register a rawpy stand-in and return the raw object every imread yields."""
+    raw = _StubRaw(thumb, flip=flip)
+    stub = types.ModuleType("rawpy")
+    stub.imread = lambda path: raw
+    stub.ThumbFormat = types.SimpleNamespace(JPEG="jpeg", BITMAP="bitmap")
+    stub.ColorSpace = types.SimpleNamespace(sRGB="srgb")
+    monkeypatch.setitem(sys.modules, "rawpy", stub)
+    monkeypatch.setattr(image_loading, "_decode_timeout", 0.0)
+    return raw
+
+
+def _jpeg_thumb(size):
+    return types.SimpleNamespace(format="jpeg", data=_jpeg_bytes(size))
+
+
+def _raw_file(tmp_path, name="shot.cr3"):
+    path = tmp_path / name
+    path.write_bytes(b"fake")
+    return str(path)
+
+
+class TestMetricsProfile:
+    def test_disables_every_per_frame_adaptive_term(self, monkeypatch):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile({'bright': 1.62})
+
+        kwargs = raw_postprocess_kwargs()
+
+        assert kwargs['no_auto_bright'] is True
+        assert kwargs['adjust_maximum_thr'] == 0.0
+        assert kwargs['use_camera_wb'] is True
+        assert kwargs['bright'] == 1.62
+
+    def test_configured_bright_reaches_the_decode(self, monkeypatch, tmp_path):
+        raw = _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile({'bright': 1.2})
+
+        load_image_from_path(_raw_file(tmp_path))
+
+        assert raw.postprocess_kwargs['bright'] == 1.2
+        assert raw.postprocess_kwargs['no_auto_bright'] is True
+        assert raw.postprocess_kwargs['adjust_maximum_thr'] == 0.0
+
+    def test_auto_bright_restores_the_pre_fix_rendering(self, monkeypatch):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile({'bright': 1.62})
+
+        kwargs = raw_postprocess_kwargs(auto_bright=True)
+
+        assert kwargs['no_auto_bright'] is False
+        assert kwargs['adjust_maximum_thr'] == 0.75
+        assert kwargs['bright'] == 1.0
+
+
+class TestDisplayImage:
+    def test_prefers_the_camera_preview(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == BIG_PREVIEW_SIZE
+
+    def test_falls_back_when_the_preview_is_too_small(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(SMALL_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == DEMOSAIC_SIZE
+
+    def test_falls_back_when_the_codec_is_unsupported(self, monkeypatch, tmp_path):
+        """Recent Canon CR3 embed an H.265 preview LibRaw refuses to unpack."""
+        _install_stub_rawpy(monkeypatch, RuntimeError("unsupported thumbnail"))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == DEMOSAIC_SIZE
+
+    def test_falls_back_when_the_preview_bytes_are_corrupt(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, types.SimpleNamespace(format="jpeg", data=b"nope"))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == DEMOSAIC_SIZE
+
+    def test_accepts_a_bitmap_preview(self, monkeypatch, tmp_path):
+        bitmap = np.full((BIG_PREVIEW_SIZE[1], BIG_PREVIEW_SIZE[0], 3), 80, dtype=np.uint8)
+        _install_stub_rawpy(monkeypatch,
+                            types.SimpleNamespace(format="bitmap", data=bitmap))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == BIG_PREVIEW_SIZE
+
+    def test_preference_can_be_turned_off(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile({'prefer_embedded_preview': False})
+
+        assert load_display_image(_raw_file(tmp_path)).size == DEMOSAIC_SIZE
+
+    def test_sensor_ratio_gate_rejects_a_partial_preview(self, monkeypatch, tmp_path):
+        """The /image endpoint demosaics rather than upscale a small preview."""
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb((800, 600)))
+        configure_raw_decode_profile()
+        path = _raw_file(tmp_path)
+
+        assert load_display_image(path, min_preview_sensor_ratio=0.5).size == DEMOSAIC_SIZE
+        assert load_display_image(path).size == (800, 600)
+
+    def test_non_raw_is_loaded_upright_and_rgb(self, tmp_path):
+        path = tmp_path / "shot.jpg"
+        Image.new('L', (120, 80), 60).save(path)
+
+        img = load_display_image(str(path))
+
+        assert img.mode == 'RGB'
+        assert img.size == (120, 80)
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert load_display_image(str(tmp_path / "gone.cr3")) is None
+
+
+class TestBracketedFramesRenderUncorrected:
+    """A bracket exists to capture highlight headroom in its +EV frames, and
+    both display corrections compress highlights: the preview through the
+    camera's tone curve, the demosaic through the uniform ``bright`` gain. A
+    bracketed frame therefore gets neither."""
+
+    def test_a_bracket_ignores_the_preview_and_demosaics_with_no_gain(self, monkeypatch, tmp_path):
+        raw = _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        img = load_display_image(_raw_file(tmp_path), min_preview_sensor_ratio=0.5,
+                                 sequence_kind='bracket')
+
+        assert img.size == DEMOSAIC_SIZE
+        assert raw.postprocess_kwargs['bright'] == FAITHFUL_BRIGHT
+
+    def test_an_hdr_panorama_is_bracketed_at_every_position(self, monkeypatch, tmp_path):
+        raw = _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        img = load_display_image(_raw_file(tmp_path), sequence_kind='hdr_panorama')
+
+        assert img.size == DEMOSAIC_SIZE
+        assert raw.postprocess_kwargs['bright'] == FAITHFUL_BRIGHT
+
+    def test_a_plain_panorama_is_not_bracketed(self, monkeypatch, tmp_path):
+        """Stitched frames share one exposure — there is no ladder to protect."""
+        raw = _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        img = load_display_image(_raw_file(tmp_path), sequence_kind='panorama')
+
+        assert img.size == BIG_PREVIEW_SIZE
+        assert raw.postprocess_kwargs is None
+
+    def test_a_photo_in_no_set_keeps_the_display_path(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+
+        assert load_display_image(_raw_file(tmp_path)).size == BIG_PREVIEW_SIZE
+
+    def test_the_behaviour_can_be_turned_off(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile({'faithful_bracket_render': False})
+
+        assert load_display_image(_raw_file(tmp_path), sequence_kind='bracket').size \
+            == BIG_PREVIEW_SIZE
+
+    def test_the_uncorrected_render_still_disables_every_adaptive_term(self, monkeypatch, tmp_path):
+        """No gain must not be confused with LibRaw's own auto-brightness."""
+        raw = _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile()
+
+        load_display_image(_raw_file(tmp_path), sequence_kind='bracket')
+
+        assert raw.postprocess_kwargs['no_auto_bright'] is True
+        assert raw.postprocess_kwargs['adjust_maximum_thr'] == 0.0
+        assert raw.postprocess_kwargs['use_camera_wb'] is True
+
+    def test_the_kinds_match_the_detection_passes_that_write_them(self):
+        """Pinned so a rename in either pass cannot silently drop a kind here."""
+        from utils.panorama import HDR_PANORAMA, PANORAMA
+        from utils.sequence import BRACKET
+
+        assert BRACKETED_SEQUENCE_KINDS == {BRACKET, HDR_PANORAMA}
+        assert PANORAMA not in BRACKETED_SEQUENCE_KINDS
+
+    def test_the_metrics_decode_keeps_the_configured_gain(self, monkeypatch, tmp_path):
+        """The scoring pixel space must not follow a display decision."""
+        raw = _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile({'bright': 1.62})
+        path = _raw_file(tmp_path)
+
+        load_display_image(path, sequence_kind='bracket')
+        assert raw.postprocess_kwargs['bright'] == FAITHFUL_BRIGHT
+
+        pil_img, _ = load_image_from_path(path)
+
+        assert raw.postprocess_kwargs['bright'] == 1.62
+        assert pil_img.size == DEMOSAIC_SIZE
+
+    def test_the_predicate_reads_the_config_at_call_time(self):
+        configure_raw_decode_profile()
+        assert renders_faithfully('bracket') is True
+        assert renders_faithfully('panorama') is False
+        assert renders_faithfully(None) is False
+
+
+class TestFaceDetectionSpaceIsUnchanged:
+    """``load_image_from_path`` must keep returning the demosaic.
+
+    Stored face boxes and ``image_width``/``image_height`` index that array, so
+    a preview-sourced buffer reaching it silently moves every box.
+    """
+
+    def test_metrics_loader_ignores_the_preview(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+        path = _raw_file(tmp_path)
+
+        pil_img, img_cv = load_image_from_path(path)
+
+        assert pil_img.size == DEMOSAIC_SIZE
+        assert img_cv.shape[:2] == (DEMOSAIC_SIZE[1], DEMOSAIC_SIZE[0])
+        assert load_display_image(path).size != pil_img.size
+
+
+class TestThumbnailSource:
+    def test_raw_thumbnail_comes_from_the_preview(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, _jpeg_thumb(BIG_PREVIEW_SIZE))
+        configure_raw_decode_profile()
+        decoded = Image.new('RGB', DEMOSAIC_SIZE)
+
+        assert thumbnail_source(_raw_file(tmp_path), decoded).size == BIG_PREVIEW_SIZE
+
+    def test_preview_less_raw_reuses_the_decode_it_was_given(self, monkeypatch, tmp_path):
+        """Never pay for a second demosaic just to build a thumbnail."""
+        raw = _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile()
+        decoded = Image.new('RGB', DEMOSAIC_SIZE)
+
+        assert thumbnail_source(_raw_file(tmp_path), decoded) is decoded
+        assert raw.postprocess_kwargs is None
+
+    def test_non_raw_reuses_the_decode_it_was_given(self, tmp_path):
+        decoded = Image.new('RGB', (10, 10))
+
+        assert thumbnail_source(str(tmp_path / "shot.jpg"), decoded) is decoded
+
+
+class TestPreviewOrientation:
+    """``unpack_thumb`` rotates nothing, and some previews carry no EXIF."""
+
+    @pytest.mark.parametrize("exif_orientation,libraw_flip", [(1, 0), (3, 3), (6, 6), (8, 5)])
+    def test_host_flip_matches_the_exif_rotation(self, exif_orientation, libraw_flip):
+        arr = np.zeros((60, 100, 3), dtype=np.uint8)
+        arr[:10, :20] = 255
+        buf = io.BytesIO()
+        source = Image.fromarray(arr)
+        exif = source.getexif()
+        exif[274] = exif_orientation
+        source.save(buf, format='JPEG', exif=exif, quality=100)
+        tagged = Image.open(buf)
+        tagged.load()
+
+        by_exif = ImageOps.exif_transpose(tagged)
+        by_flip = image_loading._upright_preview(Image.fromarray(np.asarray(tagged)),
+                                                 libraw_flip)
+
+        assert by_flip.size == by_exif.size
+        assert np.array_equal(np.asarray(by_flip), np.asarray(by_exif))
+
+    def test_preview_without_exif_follows_the_host_file(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch,
+                            types.SimpleNamespace(format="bitmap",
+                                                  data=np.zeros((1470, 1960, 3), dtype=np.uint8)),
+                            flip=6)
+
+        assert extract_raw_preview(_raw_file(tmp_path)).size == (1470, 1960)
+
+
+class TestDefaultsMatchTheShippedConfig:
+    """A fallback that drifts from the shipped config renders a second library
+    differently from the first."""
+
+    def test_fallback_matches_documented_defaults(self, tmp_path):
+        config_path = tmp_path / "scoring_config.json"
+        config_path.write_text('{"categories": [{"name": "default", "priority": 999, "filters": {}}]}')
+
+        settings = ScoringConfig(config_path=str(config_path), validate=False).get_raw_decode_settings()
+
+        assert settings == {'bright': 1.62, 'prefer_embedded_preview': True,
+                            'preview_min_sensor_ratio': 0.5, 'viewer_concurrency': 3,
+                            'faithful_bracket_render': True}
+
+    def test_shipped_config_matches_the_fallback(self):
+        assert ScoringConfig(validate=False).get_raw_decode_settings() == {
+            'bright': 1.62, 'prefer_embedded_preview': True,
+            'preview_min_sensor_ratio': 0.5, 'viewer_concurrency': 3,
+            'faithful_bracket_render': True}
+
+
+class TestViewerDecodeBudget:
+    """The /image path draws from its own semaphore so a viewer request never
+    queues behind a scan or CLI job holding the library one."""
+
+    def test_viewer_and_library_semaphores_are_independent_objects(self):
+        configure_raw_decoding(concurrency=2)
+
+        assert image_loading._get_viewer_semaphore() is not image_loading._raw_semaphore
+
+    def test_viewer_budget_is_sized_from_config(self):
+        configure_raw_decode_profile({'viewer_concurrency': 5})
+        image_loading._viewer_semaphore = None
+
+        assert image_loading._get_viewer_semaphore()._value == 5
+
+    def test_configure_raw_decoding_rebuilds_both_budgets(self):
+        old_library = image_loading._raw_semaphore
+        old_viewer = image_loading._get_viewer_semaphore()
+
+        configure_raw_decoding(concurrency=2)
+
+        assert image_loading._raw_semaphore is not old_library
+        assert image_loading._raw_semaphore._value == 2
+        assert image_loading._viewer_semaphore is not old_viewer
+
+    def test_convert_rawpy_uses_the_viewer_budget(self, monkeypatch, tmp_path):
+        from api import raw_processing
+
+        captured = {}
+
+        def fake_load_display_image(path, min_preview_sensor_ratio=0.0, decode_budget='library',
+                                    sequence_kind=None):
+            captured['decode_budget'] = decode_budget
+            return Image.new('RGB', (4, 4))
+
+        monkeypatch.setattr(image_loading, 'load_display_image', fake_load_display_image)
+
+        raw_processing._convert_rawpy(str(tmp_path / "shot.cr3"), 90)
+
+        assert captured['decode_budget'] == 'viewer'
+
+    def test_facet_style_callers_default_to_the_library_budget(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile()
+        recorded = {}
+        real_decode_raw = image_loading._decode_raw
+
+        def spy(photo, use_thumbnail, started_event=None, decode_budget='library', bright=None):
+            recorded['decode_budget'] = decode_budget
+            return real_decode_raw(photo, use_thumbnail, started_event, decode_budget, bright)
+
+        monkeypatch.setattr(image_loading, '_decode_raw', spy)
+
+        load_display_image(_raw_file(tmp_path))
+
+        assert recorded['decode_budget'] == 'library'
+
+    def test_viewer_decode_proceeds_while_the_library_semaphore_is_saturated(self, monkeypatch, tmp_path):
+        _install_stub_rawpy(monkeypatch, RuntimeError("no thumb"))
+        configure_raw_decode_profile()
+        configure_raw_decoding(concurrency=1)
+        image_loading._raw_semaphore.acquire()
+        try:
+            result = {}
+
+            def run():
+                result['img'] = load_display_image(_raw_file(tmp_path), decode_budget='viewer')
+
+            t = threading.Thread(target=run)
+            t.start()
+            t.join(timeout=5)
+
+            assert not t.is_alive(), "viewer decode blocked behind the saturated library semaphore"
+            assert result['img'] is not None
+        finally:
+            image_loading._raw_semaphore.release()
+
+
+class _StubRowDb:
+    """Minimal ``get_db()`` stand-in returning one fixed photo row."""
+
+    def __init__(self, row):
+        self.row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, *_args):
+        return types.SimpleNamespace(fetchone=lambda: self.row)
+
+
+class TestEverySurfaceAgrees:
+    """Every surface that renders a RAW must render a bracket the same way, so
+    the sequence kind has to reach ``/image``, ``--refresh-thumbnails`` and the
+    download alike. Sequence detection runs after a scan, so none of them can be
+    replaced by doing this at scan time."""
+
+    def test_the_image_endpoint_renders_with_the_rows_sequence_kind(self, monkeypatch, tmp_path):
+        from fastapi.testclient import TestClient
+
+        from api import create_app
+
+        raw_file = tmp_path / 'frame.CR3'
+        raw_file.write_bytes(b'raw')
+        seen = {}
+
+        def _record(path, mtime, quality, sequence_kind):
+            seen['sequence_kind'] = sequence_kind
+            return b'jpeg-payload'
+
+        monkeypatch.setattr('api.routers.thumbnails._convert_raw_cached', _record)
+        monkeypatch.setattr('api.routers.thumbnails.resolve_photo_disk_path',
+                            lambda p: str(raw_file))
+        monkeypatch.setattr('api.routers.thumbnails.get_db',
+                            lambda: _StubRowDb({'path': str(raw_file),
+                                                'sequence_kind': 'bracket'}))
+
+        response = TestClient(create_app()).get('/image', params={'path': str(raw_file)})
+
+        assert response.status_code == 200
+        assert response.content == b'jpeg-payload'
+        assert seen['sequence_kind'] == 'bracket'
+
+    def test_the_conversion_cache_is_keyed_on_the_sequence_kind(self, monkeypatch, tmp_path):
+        """A frame relabelled by a later detection pass must not keep serving
+        the preview render cached before it."""
+        from api.routers import thumbnails
+
+        calls = []
+        monkeypatch.setattr('api.raw_processing.convert_raw_to_jpeg',
+                            lambda p, q, kind: calls.append(kind) or b'jpeg')
+        thumbnails._convert_raw_cached.cache_clear()
+
+        thumbnails._convert_raw_cached('/disk/frame.CR3', 1.0, 96, None)
+        thumbnails._convert_raw_cached('/disk/frame.CR3', 1.0, 96, 'bracket')
+        thumbnails._convert_raw_cached('/disk/frame.CR3', 1.0, 96, 'bracket')
+
+        assert calls == [None, 'bracket']
+        thumbnails._convert_raw_cached.cache_clear()
+
+    def test_the_cli_refresh_renders_each_row_with_its_own_sequence_kind(
+            self, monkeypatch, tmp_path):
+        import sqlite3
+
+        import facet
+        from db.schema import init_database
+
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.executemany(
+            "INSERT INTO photos (path, filename, sequence_kind) VALUES (?, ?, ?)",
+            [('/photos/a.CR2', 'a.CR2', 'bracket'),
+             ('/photos/b.CR2', 'b.CR2', None),
+             ('/photos/c.CR2', 'c.CR2', 'panorama')])
+        conn.commit()
+        conn.close()
+
+        seen = {}
+
+        def _record(path, size, quality, sequence_kind):
+            seen[path] = sequence_kind
+            return b'thumb'
+
+        monkeypatch.setattr(facet, '_display_thumbnail_bytes', _record)
+
+        facet.refresh_thumbnails(db_path, ScoringConfig(validate=False), workers=2)
+
+        assert seen == {'/photos/a.CR2': 'bracket', '/photos/b.CR2': None,
+                        '/photos/c.CR2': 'panorama'}
+
+    def test_the_download_resolver_returns_the_rows_sequence_kind(self, monkeypatch):
+        """Folded into the visibility query the download already runs, so the
+        rendering decision costs no extra round trip."""
+        from api.routers import comparison
+
+        queried = {}
+
+        class _Db:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def execute(self, sql, params):
+                queried['sql'] = sql
+                return types.SimpleNamespace(
+                    fetchone=lambda: {'path': '/photos/a.CR2', 'sequence_kind': 'bracket'})
+
+        monkeypatch.setattr(comparison, 'get_db', _Db)
+        monkeypatch.setattr(comparison, 'get_visibility_clause', lambda uid: ('1=1', []))
+        monkeypatch.setattr(comparison, 'resolve_photo_disk_path', lambda p: '/disk/a.CR2')
+
+        db_path, real_disk, kind = comparison._validate_and_resolve('/photos/a.CR2', None)
+
+        assert (db_path, real_disk, kind) == ('/photos/a.CR2', '/disk/a.CR2', 'bracket')
+        assert queried['sql'].count('SELECT') == 1
+
+    @pytest.mark.parametrize("kind", ['bracket', 'hdr_panorama', 'panorama', None])
+    def test_the_download_converts_with_the_rows_sequence_kind(self, monkeypatch, kind):
+        """A downloaded bracket frame is on its way to an HDR merge, so it must
+        carry the same uncorrected render the loupe showed."""
+        from api.routers import comparison
+
+        seen = {}
+
+        def _record(path, quality, sequence_kind):
+            seen['kind'] = sequence_kind
+            return b'jpeg'
+
+        monkeypatch.setattr('api.raw_processing.convert_raw_to_jpeg', _record)
+
+        comparison._serve_original('/disk/a.CR2', '/photos/a.CR2', 96, kind)
+
+        assert seen['kind'] == kind
+

--- a/tests/test_raw_decode.py
+++ b/tests/test_raw_decode.py
@@ -549,6 +549,41 @@ class TestEverySurfaceAgrees:
         assert seen == {'/photos/a.CR2': 'bracket', '/photos/b.CR2': None,
                         '/photos/c.CR2': 'panorama'}
 
+    def test_the_cli_refresh_stamps_the_render_each_row_was_given(self, monkeypatch, tmp_path):
+        """The stamp is what the migration counts, so a bracket refreshed
+        uncorrected must record THAT render — stamping it like a preview render
+        would put the frame straight back in the pending set."""
+        import sqlite3
+
+        import facet
+        from db.render_version import DISPLAY_RENDER_VERSION, FAITHFUL_RENDER_VERSION, count_pending_render
+        from db.schema import init_database
+
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.executemany(
+            "INSERT INTO photos (path, filename, sequence_kind) VALUES (?, ?, ?)",
+            [('/photos/a.CR2', 'a.CR2', 'bracket'),
+             ('/photos/b.CR2', 'b.CR2', None),
+             ('/photos/c.CR2', 'c.CR2', 'hdr_panorama')])
+        conn.commit()
+        assert count_pending_render(conn) == 3
+        conn.close()
+
+        monkeypatch.setattr(facet, '_display_thumbnail_bytes',
+                            lambda path, size, quality, sequence_kind: b'thumb')
+
+        facet.refresh_thumbnails(db_path, ScoringConfig(validate=False), workers=2)
+
+        conn = sqlite3.connect(db_path)
+        stamps = dict(conn.execute("SELECT path, render_version FROM photos"))
+        assert stamps == {'/photos/a.CR2': FAITHFUL_RENDER_VERSION,
+                          '/photos/b.CR2': DISPLAY_RENDER_VERSION,
+                          '/photos/c.CR2': FAITHFUL_RENDER_VERSION}
+        assert count_pending_render(conn) == 0
+        conn.close()
+
     def test_the_download_resolver_returns_the_rows_sequence_kind(self, monkeypatch):
         """Folded into the visibility query the download already runs, so the
         rendering decision costs no extra round trip."""
@@ -595,3 +630,51 @@ class TestEverySurfaceAgrees:
 
         assert seen['kind'] == kind
 
+
+class TestRefreshThumbnailsPool:
+    """``--refresh-thumbnails`` renders through ``load_display_image``, which
+    hands a RAW demosaic to the shared decode pool and waits on its future. The
+    refresh must therefore dispatch its own work somewhere else: a pool whose
+    every worker is blocked on a future queued behind the work those same
+    workers still have to run can never make progress, and a bounded pool turns
+    that into a hang rather than an error."""
+
+    def test_the_refresh_completes_when_every_row_demosaics(self, monkeypatch, tmp_path):
+        import sqlite3
+
+        import facet
+        from db.schema import init_database
+
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.executemany(
+            "INSERT INTO photos (path, filename, sequence_kind) VALUES (?, ?, 'bracket')",
+            [(f'/photos/{i:02d}.CR2', f'{i:02d}.CR2') for i in range(12)])
+        conn.commit()
+        conn.close()
+
+        def _fake_decode(photo, use_thumbnail, started_event=None,
+                         decode_budget='library', bright=None):
+            if started_event is not None:
+                started_event.set()
+            return Image.fromarray(np.full((120, 160, 3), 200, dtype=np.uint8))
+
+        monkeypatch.setattr(image_loading, '_decode_raw', _fake_decode)
+
+        outcome = {}
+        finished = threading.Event()
+
+        def _refresh():
+            try:
+                outcome['result'] = facet.refresh_thumbnails(
+                    db_path, ScoringConfig(validate=False), workers=2)
+            finally:
+                finished.set()
+
+        runner = threading.Thread(target=_refresh, daemon=True)
+        runner.start()
+        assert finished.wait(timeout=60), (
+            "refresh_thumbnails never returned: its tasks are waiting on futures "
+            "from the pool they are running in")
+        assert outcome['result'] == (12, 0, False)

--- a/tests/test_render_version.py
+++ b/tests/test_render_version.py
@@ -274,6 +274,28 @@ class TestMigrationStatus:
         monkeypatch.setattr('db.stats_cache.count_pending_render', _forbidden)
         assert get_pending_render_count(library_db) == 5
 
+    def test_a_persist_failure_does_not_rescan_photos(self, library_db, monkeypatch):
+        """The scan that already ran must not be discarded and re-run just
+        because caching its result failed (e.g. a read-only database)."""
+        from db.stats_cache import get_pending_render_count
+        import db.stats_cache as stats_cache_mod
+
+        real_count_pending_render = stats_cache_mod.count_pending_render
+        calls = []
+
+        def _counting(conn):
+            calls.append(1)
+            return real_count_pending_render(conn)
+
+        def _raise(*args, **kwargs):
+            raise sqlite3.OperationalError("attempt to write a readonly database")
+
+        monkeypatch.setattr(stats_cache_mod, 'count_pending_render', _counting)
+        monkeypatch.setattr(stats_cache_mod, '_cache_stat', _raise)
+
+        assert get_pending_render_count(library_db) == 1
+        assert len(calls) == 1
+
     def test_a_stale_entry_is_recomputed_and_re_cached(self, library_db):
         from db.stats_cache import PENDING_RENDER_KEY, get_pending_render_count
 

--- a/tests/test_render_version.py
+++ b/tests/test_render_version.py
@@ -1,0 +1,212 @@
+"""The render-version stamp that drives the thumbnail-migration banner.
+
+A stored thumbnail is baked at scan time, so the RAW display-profile fix left
+every existing row rendering the old, exposure-equalizing way.
+``photos.render_version`` is what says which rows are still on it; these tests
+pin the three things that make the stamp trustworthy — a rescanned row ends up
+stamped current rather than NULL, a render that comes back black never
+overwrites a good thumbnail, and the count the banner reads comes from the
+statistics cache rather than a scan of ``photos`` per request.
+"""
+
+import sqlite3
+import sys
+from unittest import mock
+
+import pytest
+
+from db.render_version import CURRENT_RENDER_VERSION, count_pending_render
+from db.schema import init_database
+
+_RAW_PATH = '/photos/raw/frame.CR3'
+
+
+@pytest.fixture()
+def library_db(tmp_path):
+    """A schema-current database holding one unstamped RAW row."""
+    db_path = str(tmp_path / 'library.db')
+    init_database(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO photos (path, filename, thumbnail, histogram_data) VALUES (?, ?, ?, ?)",
+        (_RAW_PATH, 'frame.CR3', b'old-thumb', b'\x00' * 1024))
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# 1. The stamp survives the writer that rewrites `photos` wholesale
+# ---------------------------------------------------------------------------
+
+class TestScanStampsCurrentVersion:
+    """``save_photos_batch`` INSERT-OR-REPLACEs the row, so an unstamped column
+    would be silently NULLed on every rescan. The stamp is derived state that
+    must be rewritten with the thumbnail it describes."""
+
+    def test_scanned_row_is_stamped_current_not_null(self, tmp_path):
+        from tests.test_rescan_preservation import _base_result
+        from processing.scorer import Facet
+
+        db_path = str(tmp_path / 'scan.db')
+        init_database(db_path)
+        facet = Facet.__new__(Facet)
+        facet.db_path = db_path
+        with mock.patch('processing.scorer.generate_photo_thumbnail', return_value=b'thumb'), \
+             mock.patch('processing.scorer.thumbnail_source', return_value=None), \
+             mock.patch('processing.scorer.get_plugin_manager', return_value=None, create=True):
+            facet.save_photos_batch([(_base_result(_RAW_PATH, 7.0), None)])
+
+        conn = sqlite3.connect(db_path)
+        stamp = conn.execute(
+            "SELECT render_version FROM photos WHERE path = ?", (_RAW_PATH,)).fetchone()[0]
+        conn.close()
+        assert stamp == CURRENT_RENDER_VERSION
+
+    def test_rescan_restamps_a_row_written_before_the_stamp_existed(self, library_db):
+        from tests.test_rescan_preservation import _base_result
+        from processing.scorer import Facet
+
+        conn = sqlite3.connect(library_db)
+        assert conn.execute("SELECT render_version FROM photos").fetchone()[0] is None
+        assert count_pending_render(conn) == 1
+        conn.close()
+
+        facet = Facet.__new__(Facet)
+        facet.db_path = library_db
+        with mock.patch('processing.scorer.generate_photo_thumbnail', return_value=b'new-thumb'), \
+             mock.patch('processing.scorer.thumbnail_source', return_value=None), \
+             mock.patch('processing.scorer.get_plugin_manager', return_value=None, create=True):
+            facet.save_photos_batch([(_base_result(_RAW_PATH, 8.0), None)])
+
+        conn = sqlite3.connect(library_db)
+        assert conn.execute("SELECT render_version FROM photos").fetchone()[0] == CURRENT_RENDER_VERSION
+        assert count_pending_render(conn) == 0
+        conn.close()
+
+    def test_a_restricted_pass_does_not_stamp_an_existing_row(self):
+        """A ``--recompute-*`` pass rebuilds no thumbnail, so it must not claim one."""
+        from processing.scorer import _photos_partial_upsert
+
+        sql = _photos_partial_upsert(('aesthetic',))
+        assert 'render_version' in sql.split('ON CONFLICT')[0]
+        assert 'render_version' not in sql.split('ON CONFLICT')[1]
+
+
+# ---------------------------------------------------------------------------
+# 2. A decode that "succeeds" into a black frame must not overwrite anything
+# ---------------------------------------------------------------------------
+
+def _black_frame(height=1200, width=1800):
+    import numpy as np
+    from PIL import Image
+
+    return Image.fromarray(np.zeros((height, width, 3), dtype=np.uint8))
+
+
+class TestDegenerateDecodeIsRefused:
+    """LibRaw zero-fills a severely truncated Panasonic RW2 and returns a valid,
+    full-size, entirely black image — it does NOT return None. The CLI migration
+    is unattended, which is the worst place for that to pass unnoticed."""
+
+    def test_the_cli_refresh_discards_a_black_render(self, monkeypatch, caplog):
+        import facet
+
+        monkeypatch.setattr('utils.load_display_image',
+                            lambda path, sequence_kind=None: _black_frame())
+        with caplog.at_level('WARNING'):
+            blob = facet._display_thumbnail_bytes('/disk/frame.RW2', 640, 80)
+        assert blob is None
+        assert any('black' in r.message for r in caplog.records), caplog.text
+
+    def test_a_real_render_is_not_mistaken_for_a_black_one(self, monkeypatch):
+        import numpy as np
+        from PIL import Image
+
+        import facet
+
+        scene = np.zeros((1200, 1800, 3), dtype=np.uint8)
+        scene[600:620, 900:920] = 255
+        monkeypatch.setattr('utils.load_display_image',
+                            lambda path, sequence_kind=None: Image.fromarray(scene))
+        assert facet._display_thumbnail_bytes('/disk/frame.CR3', 640, 80) is not None
+
+
+class TestThumbnailSignalPredicate:
+
+    def test_a_zero_filled_frame_has_no_signal(self):
+        from utils import generate_photo_thumbnail, thumbnail_has_signal
+
+        assert thumbnail_has_signal(generate_photo_thumbnail(_black_frame(2000, 3000))) is False
+
+    def test_a_night_frame_with_one_small_highlight_has_signal(self):
+        """The predicate reads the MAXIMUM, so an intentionally dark photo passes."""
+        import numpy as np
+        from PIL import Image
+
+        from utils import generate_photo_thumbnail, thumbnail_has_signal
+
+        scene = np.zeros((2000, 3000, 3), dtype=np.uint8)
+        scene[990:1010, 1490:1510] = 255
+        assert thumbnail_has_signal(generate_photo_thumbnail(Image.fromarray(scene))) is True
+
+    def test_missing_bytes_have_no_signal(self):
+        from utils import thumbnail_has_signal
+
+        assert thumbnail_has_signal(None) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. The status count is served from cache, never from a scan per request
+# ---------------------------------------------------------------------------
+
+class TestMigrationStatus:
+
+    def test_config_reports_the_pending_count(self, client, monkeypatch):
+        monkeypatch.setattr('db.stats_cache.get_pending_render_count', lambda *a, **k: 42)
+        payload = client.get('/api/config').json()
+        assert payload['render_migration'] == {'pending': 42}
+
+    def test_a_fresh_cache_entry_answers_without_touching_photos(self, library_db, monkeypatch):
+        from db.stats_cache import PENDING_RENDER_KEY, get_pending_render_count
+        import db.render_version as render_version_mod
+
+        conn = sqlite3.connect(library_db)
+        conn.execute("INSERT OR REPLACE INTO stats_cache (key, value, updated_at) "
+                     "VALUES (?, '5', ?)", (PENDING_RENDER_KEY, _now()))
+        conn.commit()
+        conn.close()
+
+        def _forbidden(_conn):
+            raise AssertionError("the cached count must not rescan photos")
+
+        monkeypatch.setattr(render_version_mod, 'count_pending_render', _forbidden)
+        monkeypatch.setattr('db.stats_cache.count_pending_render', _forbidden)
+        assert get_pending_render_count(library_db) == 5
+
+    def test_a_stale_entry_is_recomputed_and_re_cached(self, library_db):
+        from db.stats_cache import PENDING_RENDER_KEY, get_pending_render_count
+
+        conn = sqlite3.connect(library_db)
+        conn.execute("INSERT OR REPLACE INTO stats_cache (key, value, updated_at) "
+                     "VALUES (?, '999', 0)", (PENDING_RENDER_KEY,))
+        conn.commit()
+        conn.close()
+
+        assert get_pending_render_count(library_db) == 1
+        conn = sqlite3.connect(library_db)
+        assert conn.execute("SELECT value FROM stats_cache WHERE key = ?",
+                            (PENDING_RENDER_KEY,)).fetchone()[0] == '1'
+        conn.close()
+
+
+def _now():
+    import time
+
+    return time.time()
+
+
+@pytest.fixture(autouse=True)
+def _drop_stub_modules():
+    yield
+    sys.modules.pop('rawpy', None)

--- a/tests/test_render_version.py
+++ b/tests/test_render_version.py
@@ -3,8 +3,9 @@
 A stored thumbnail is baked at scan time, so the RAW display-profile fix left
 every existing row rendering the old, exposure-equalizing way.
 ``photos.render_version`` is what says which rows are still on it; these tests
-pin the three things that make the stamp trustworthy — a rescanned row ends up
-stamped current rather than NULL, a render that comes back black never
+pin the four things that make the stamp trustworthy — a rescanned row ends up
+stamped rather than NULL, a frame a later pass groups into a bracket stops
+matching the render its kind now demands, a render that comes back black never
 overwrites a good thumbnail, and the count the banner reads comes from the
 statistics cache rather than a scan of ``photos`` per request.
 """
@@ -15,7 +16,7 @@ from unittest import mock
 
 import pytest
 
-from db.render_version import CURRENT_RENDER_VERSION, count_pending_render
+from db.render_version import DISPLAY_RENDER_VERSION, FAITHFUL_RENDER_VERSION, count_pending_render
 from db.schema import init_database
 
 _RAW_PATH = '/photos/raw/frame.CR3'
@@ -61,7 +62,7 @@ class TestScanStampsCurrentVersion:
         stamp = conn.execute(
             "SELECT render_version FROM photos WHERE path = ?", (_RAW_PATH,)).fetchone()[0]
         conn.close()
-        assert stamp == CURRENT_RENDER_VERSION
+        assert stamp == DISPLAY_RENDER_VERSION
 
     def test_rescan_restamps_a_row_written_before_the_stamp_existed(self, library_db):
         from tests.test_rescan_preservation import _base_result
@@ -80,7 +81,7 @@ class TestScanStampsCurrentVersion:
             facet.save_photos_batch([(_base_result(_RAW_PATH, 8.0), None)])
 
         conn = sqlite3.connect(library_db)
-        assert conn.execute("SELECT render_version FROM photos").fetchone()[0] == CURRENT_RENDER_VERSION
+        assert conn.execute("SELECT render_version FROM photos").fetchone()[0] == DISPLAY_RENDER_VERSION
         assert count_pending_render(conn) == 0
         conn.close()
 
@@ -94,7 +95,96 @@ class TestScanStampsCurrentVersion:
 
 
 # ---------------------------------------------------------------------------
-# 2. A decode that "succeeds" into a black frame must not overwrite anything
+# 2. The stamp is read against the row's CURRENT sequence kind
+# ---------------------------------------------------------------------------
+
+def _stamped_raw_row(db_path, path, stamp, sequence_kind=None):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO photos (path, filename, thumbnail, render_version, sequence_kind) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (path, path.rsplit('/', 1)[-1], b'thumb', stamp, sequence_kind))
+    conn.commit()
+    conn.close()
+
+
+def _pending(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return count_pending_render(conn)
+    finally:
+        conn.close()
+
+
+class TestABracketedFrameIsFoundByTheMigration:
+    """Sequence detection runs AFTER a scan, so a bracket's frames are baked
+    with the preview rendering and stamped for it before anything knows they
+    are bracketed. Left as a version number alone the stamp would read as
+    "current" and the whole migration would skip the very photos the faithful
+    rendering exists for, so it is compared against the kind the row carries
+    now."""
+
+    def test_a_scanned_row_is_settled_until_a_later_pass_brackets_it(self, tmp_path):
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', DISPLAY_RENDER_VERSION)
+        assert _pending(db_path) == 0
+
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE photos SET sequence_kind = 'bracket'")
+        conn.commit()
+        conn.close()
+        assert _pending(db_path) == 1
+
+    def test_a_refreshed_bracket_is_settled(self, tmp_path):
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', FAITHFUL_RENDER_VERSION, 'bracket')
+        assert _pending(db_path) == 0
+
+    def test_an_hdr_panorama_frame_is_bracketed_too(self, tmp_path):
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', DISPLAY_RENDER_VERSION, 'hdr_panorama')
+        assert _pending(db_path) == 1
+
+    def test_a_plain_panorama_frame_keeps_the_display_render(self, tmp_path):
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', DISPLAY_RENDER_VERSION, 'panorama')
+        assert _pending(db_path) == 0
+
+    def test_a_frame_that_leaves_its_bracket_is_pending_again(self, tmp_path):
+        """Detection can un-group a frame, and its uncorrected thumbnail is then
+        as wrong as an equalized one is inside a bracket."""
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', FAITHFUL_RENDER_VERSION)
+        assert _pending(db_path) == 1
+
+    def test_a_bracketed_jpeg_is_never_pending(self, tmp_path):
+        """Only RAW rendering ever changed."""
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.jpg', DISPLAY_RENDER_VERSION, 'bracket')
+        assert _pending(db_path) == 0
+
+    def test_turning_the_faithful_render_off_settles_brackets(self, tmp_path, monkeypatch):
+        """With the behaviour disabled nothing will ever bake the uncorrected
+        render, so demanding it would leave the banner up forever."""
+        from utils import image_loading
+
+        db_path = str(tmp_path / 'library.db')
+        init_database(db_path)
+        _stamped_raw_row(db_path, '/photos/frame.CR3', DISPLAY_RENDER_VERSION, 'bracket')
+        monkeypatch.setattr(image_loading, '_raw_decode_settings',
+                            dict(image_loading.get_raw_decode_settings(),
+                                 faithful_bracket_render=False))
+        assert _pending(db_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. A decode that "succeeds" into a black frame must not overwrite anything
 # ---------------------------------------------------------------------------
 
 def _black_frame(height=1200, width=1800):
@@ -157,7 +247,7 @@ class TestThumbnailSignalPredicate:
 
 
 # ---------------------------------------------------------------------------
-# 3. The status count is served from cache, never from a scan per request
+# 4. The status count is served from cache, never from a scan per request
 # ---------------------------------------------------------------------------
 
 class TestMigrationStatus:

--- a/tests/test_samp_net_checkpoint.py
+++ b/tests/test_samp_net_checkpoint.py
@@ -1,0 +1,74 @@
+"""How SAMP-Net's checkpoint is fetched and loaded.
+
+``torch.load`` unpickles, and unpickling runs whatever the file says. The
+checkpoint is auto-downloaded on first use, so the fetch is pinned to one asset
+of this project's own GitHub release and verified against its SHA-256 before it
+is installed, and the load refuses any payload that is not plain tensors.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from models import samp_net  # noqa: E402
+from models.samp_net import SAMPNetScorer  # noqa: E402
+
+
+class _NotATensor:
+    """A payload only an arbitrary-code unpickler would accept."""
+
+
+class TestTheDownloadIsVerified:
+
+    def test_it_goes_through_the_shared_checksum_verified_fetch(self, tmp_path, monkeypatch):
+        seen = {}
+
+        def _record(url, destination, sha256=None):
+            seen.update(url=url, destination=destination, sha256=sha256)
+
+        monkeypatch.setattr(samp_net, 'download_weights', _record)
+        scorer = SAMPNetScorer.__new__(SAMPNetScorer)
+        scorer.model_path = str(tmp_path / 'samp_net.pth')
+
+        scorer._download_weights()
+
+        assert seen['url'] == samp_net.SAMPNET_WEIGHTS_URL
+        assert seen['sha256'] == samp_net.SAMPNET_WEIGHTS_SHA256
+        assert str(seen['destination']) == scorer.model_path
+
+    def test_the_url_is_pinned_to_a_release_asset_and_the_digest_is_a_sha256(self):
+        assert samp_net.SAMPNET_WEIGHTS_URL.startswith(
+            'https://github.com/ncoevoet/facet/releases/download/')
+        assert len(samp_net.SAMPNET_WEIGHTS_SHA256) == 64
+        assert set(samp_net.SAMPNET_WEIGHTS_SHA256) <= set('0123456789abcdef')
+
+    def test_a_present_file_is_never_re_fetched(self, tmp_path, monkeypatch):
+        weights_path = tmp_path / 'samp_net.pth'
+        weights_path.write_bytes(b'already here')
+        monkeypatch.setattr(samp_net, 'download_weights',
+                            lambda *a, **k: pytest.fail("re-downloaded an installed checkpoint"))
+        scorer = SAMPNetScorer.__new__(SAMPNetScorer)
+        scorer.model_path = str(weights_path)
+
+        scorer._download_weights()
+
+
+class TestTheLoadRefusesArbitraryPickles:
+
+    def test_a_checkpoint_carrying_more_than_tensors_is_rejected(self, tmp_path):
+        weights_path = tmp_path / 'samp_net.pth'
+        torch.save({'payload': _NotATensor()}, weights_path)
+
+        with pytest.raises(RuntimeError, match='could not be loaded'):
+            SAMPNetScorer(model_path=str(weights_path), device='cpu')
+
+    def test_a_plain_state_dict_still_loads(self, tmp_path):
+        from models.samp_net import SAMPNet
+
+        weights_path = tmp_path / 'samp_net.pth'
+        torch.save(SAMPNet(num_patterns=8, num_attributes=6, num_scores=5).state_dict(),
+                   weights_path)
+
+        scorer = SAMPNetScorer(model_path=str(weights_path), device='cpu')
+
+        assert scorer.model is not None

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1624,13 +1624,15 @@ _JOB_MODIFIERS = frozenset({
     "apply_recommendations", "config", "db", "discover_min_cluster_size", "dry_run",
     "dry_run_count", "embed_originals", "force", "force_library_lock", "force_low_space",
     "force_since", "limit", "merge_threshold", "optimize_category", "optimize_force",
-    "optimize_sources", "ranker_category", "resume", "retry_failed", "score_to_stars",
+    "optimize_sources", "ranker_category", "refresh_thumbnails_workers", "resume",
+    "retry_failed", "score_to_stars",
     "simulate", "simulate_gpu", "simulate_vram", "single_pass", "single_pass_name",
     "train_keeper_force", "train_ranker_force", "user", "verbose", "watch_debounce",
 })
 
 _READ_ONLY_LIBRARY_COMMANDS = frozenset({
-    "auto_tune_categories", "comparison_stats", "doctor", "eval_iqa_srcc", "export_csv",
+    "auto_tune_categories", "check_raw_rendering", "comparison_stats", "doctor",
+    "eval_iqa_srcc", "export_csv",
     "export_json", "export_manifest", "immich_sync", "immich_test", "list_models",
     "mine_insights", "report_unreviewed_bursts", "suggest_person_merges",
     "sweep_dedup_thresholds", "validate_categories",

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -615,3 +615,43 @@ class TestScorePhotoFromPilHonorsOverride:
         assert recorded_metrics['scoring_context'] == 'action_stage'
         assert recorded_metrics['category_override'] == 'sports'
         assert res['category'] == 'sports'
+
+
+class TestAestheticHeadWeights:
+    """The scorer loads the shared head from ``pretrained_models/``, not the CWD.
+
+    The weights were previously written to the process working directory, which
+    is not a mounted volume in Docker and differs between a facet.py scan and a
+    viewer.py run, so the same 3.7 MB file was downloaded again and again.
+    """
+
+    def test_head_is_read_from_the_pretrained_dir_not_the_cwd(self, tmp_path, monkeypatch):
+        import torch
+        import processing.scorer as scorer_module
+        from models import weights
+        from models.aesthetic_head import AestheticMLP
+        from models.aesthetic_head import AESTHETIC_HEAD_WEIGHTS_FILENAME
+        from processing.scorer import Facet
+
+        pretrained_dir = tmp_path / 'pretrained_models'
+        pretrained_dir.mkdir()
+        torch.manual_seed(5)
+        checkpoint = AestheticMLP().state_dict()
+        torch.save(checkpoint, pretrained_dir / AESTHETIC_HEAD_WEIGHTS_FILENAME)
+        monkeypatch.setattr(weights, 'PRETRAINED_MODELS_DIR', pretrained_dir)
+
+        scorer = Facet(db_path=':memory:', lightweight=True)
+        scorer.device = 'cpu'
+        scorer.config.config['models']['vram_profile'] = 'legacy'
+        monkeypatch.setattr(scorer_module, 'torch', torch)
+        from models.aesthetic_head import load_aesthetic_head
+        monkeypatch.setattr(scorer_module, 'load_aesthetic_head', load_aesthetic_head)
+        # Only now: the head must come from pretrained_models/, whatever the CWD is
+        monkeypatch.chdir(tmp_path)
+
+        scorer._load_aesthetic_head()
+
+        assert scorer.aesthetic_head is not None
+        for key, tensor in scorer.aesthetic_head.state_dict().items():
+            assert torch.equal(tensor, checkpoint[key]), key
+        assert not (tmp_path / AESTHETIC_HEAD_WEIGHTS_FILENAME).exists()

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -626,7 +626,7 @@ class TestAestheticHeadWeights:
     """
 
     def test_head_is_read_from_the_pretrained_dir_not_the_cwd(self, tmp_path, monkeypatch):
-        import torch
+        torch = pytest.importorskip("torch")
         import processing.scorer as scorer_module
         from models import weights
         from models.aesthetic_head import AestheticMLP

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -135,3 +135,49 @@ class TestImage:
             resp = client.get("/image", params={"path": "/etc/passwd"})
 
         assert resp.status_code == 404
+
+    def test_image_raw_decode_failure_falls_back_to_thumbnail(self, client, jpeg_bytes, tmp_path):
+        """fallback=thumbnail degrades to the stored thumbnail on a RuntimeError, not a 500."""
+        raw_file = tmp_path / "photo.cr2"
+        raw_file.write_bytes(b"not a real raw file")
+
+        mock_conn = mock.MagicMock()
+        photo_row = {"path": "/library/photo.cr2", "sequence_kind": None}
+        thumbnail_row = {"thumbnail": jpeg_bytes}
+        mock_conn.execute.side_effect = [
+            mock.Mock(fetchone=mock.Mock(return_value=photo_row)),
+            mock.Mock(fetchone=mock.Mock(return_value=thumbnail_row)),
+        ]
+
+        with mock.patch("api.routers.thumbnails.get_db", _cm(mock_conn)), \
+             mock.patch("api.routers.thumbnails.resolve_photo_disk_path", return_value=str(raw_file)), \
+             mock.patch(
+                 "api.routers.thumbnails._convert_raw_cached",
+                 side_effect=RuntimeError(f"RAW decode failed: {raw_file}"),
+             ):
+            resp = client.get(
+                "/image", params={"path": "/library/photo.cr2", "fallback": "thumbnail"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        assert resp.content == jpeg_bytes
+
+    def test_image_raw_decode_failure_without_fallback_returns_500(self, client, tmp_path):
+        """Without fallback=thumbnail, a RAW decode failure still surfaces as a 500."""
+        raw_file = tmp_path / "photo.cr2"
+        raw_file.write_bytes(b"not a real raw file")
+
+        mock_conn = mock.MagicMock()
+        photo_row = {"path": "/library/photo.cr2", "sequence_kind": None}
+        mock_conn.execute.return_value.fetchone.return_value = photo_row
+
+        with mock.patch("api.routers.thumbnails.get_db", _cm(mock_conn)), \
+             mock.patch("api.routers.thumbnails.resolve_photo_disk_path", return_value=str(raw_file)), \
+             mock.patch(
+                 "api.routers.thumbnails._convert_raw_cached",
+                 side_effect=RuntimeError(f"RAW decode failed: {raw_file}"),
+             ):
+            resp = client.get("/image", params={"path": "/library/photo.cr2"})
+
+        assert resp.status_code == 500

--- a/tests/test_thumbnails_visibility.py
+++ b/tests/test_thumbnails_visibility.py
@@ -39,7 +39,7 @@ def _jpeg() -> bytes:
 
 
 _SCHEMA = """
-    CREATE TABLE photos (path TEXT PRIMARY KEY, thumbnail BLOB);
+    CREATE TABLE photos (path TEXT PRIMARY KEY, thumbnail BLOB, sequence_kind TEXT);
     CREATE TABLE persons (id INTEGER PRIMARY KEY, face_thumbnail BLOB,
                           representative_face_id INTEGER);
     CREATE TABLE faces (id INTEGER PRIMARY KEY, photo_path TEXT, person_id INTEGER,
@@ -54,7 +54,7 @@ def db_path(tmp_path):
     path = str(tmp_path / "thumbs.db")
     conn = sqlite3.connect(path)
     conn.executescript(_SCHEMA)
-    conn.executemany("INSERT INTO photos VALUES (?, ?)",
+    conn.executemany("INSERT INTO photos (path, thumbnail) VALUES (?, ?)",
                      [(ALICE_PHOTO, jpeg), (BOB_PHOTO, jpeg)])
     conn.executemany(
         "INSERT INTO faces VALUES (?, ?, ?, ?, ?, ?, ?, ?)",

--- a/tests/test_viewer_db_export.py
+++ b/tests/test_viewer_db_export.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from db.maintenance import export_viewer_db
 from db.schema import init_database
+from utils.histogram import HISTOGRAM_BLOB_SIZE, pack_histogram
 
 _A = '/photos/a.jpg'
 _B = '/photos/b.jpg'
@@ -38,6 +39,64 @@ def _make_source_db(path):
         )
     conn.commit()
     conn.close()
+
+
+def _spike_histogram(index):
+    counts = [0.0] * 256
+    counts[index] = 1000.0
+    return pack_histogram(counts, counts, counts, counts)
+
+
+def test_full_export_keeps_the_histogram_the_viewer_draws(tmp_path):
+    """The viewer's RGB histogram widget reads photos.histogram_data through
+    /api/photo/histogram, so the export must stop stripping it — a stripped
+    column silently downgrades every NAS deployment to thumbnail sampling."""
+    src = str(tmp_path / 'scan.db')
+    out = str(tmp_path / 'viewer.db')
+    _make_source_db(src)
+    sconn = sqlite3.connect(src)
+    sconn.execute("UPDATE photos SET histogram_data = ?, clip_embedding = ?",
+                  (sqlite3.Binary(_spike_histogram(42)), sqlite3.Binary(b'\x01' * 128)))
+    sconn.commit()
+    sconn.close()
+
+    export_viewer_db(src, out, thumbnail_size=320, verbose=False, force=True)
+
+    vconn = sqlite3.connect(out)
+    hist, clip = vconn.execute(
+        "SELECT histogram_data, clip_embedding FROM photos WHERE path = ?", (_A,)
+    ).fetchone()
+    vconn.close()
+    assert len(hist) == HISTOGRAM_BLOB_SIZE
+    assert clip is None
+
+
+def test_incremental_export_carries_the_histogram_to_new_and_existing_photos(tmp_path):
+    src = str(tmp_path / 'scan.db')
+    out = str(tmp_path / 'viewer.db')
+    _make_source_db(src)
+    export_viewer_db(src, out, thumbnail_size=320, verbose=False)
+
+    sconn = sqlite3.connect(src)
+    sconn.execute("UPDATE photos SET histogram_data = ? WHERE path = ?",
+                  (sqlite3.Binary(_spike_histogram(7)), _A))
+    sconn.execute(
+        "INSERT INTO photos (path, filename, thumbnail, histogram_data) VALUES (?, ?, ?, ?)",
+        ('/photos/c.jpg', 'c.jpg', _thumb_bytes(), sqlite3.Binary(_spike_histogram(9))),
+    )
+    sconn.commit()
+    sconn.close()
+
+    export_viewer_db(src, out, thumbnail_size=320, verbose=False)
+
+    vconn = sqlite3.connect(out)
+    existing = vconn.execute(
+        "SELECT histogram_data FROM photos WHERE path = ?", (_A,)).fetchone()[0]
+    added = vconn.execute(
+        "SELECT histogram_data FROM photos WHERE path = ?", ('/photos/c.jpg',)).fetchone()[0]
+    vconn.close()
+    assert len(existing) == HISTOGRAM_BLOB_SIZE
+    assert len(added) == HISTOGRAM_BLOB_SIZE
 
 
 def test_incremental_export_preserves_viewer_ratings(tmp_path):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,8 +4,14 @@ Facet utilities package.
 Re-exports all public functions and classes for backwards-compatible imports.
 """
 
-from utils.image_loading import load_image_from_path, load_image_for_face_crop, configure_raw_decoding, RAW_EXTENSIONS
-from utils.image_transforms import generate_photo_thumbnail, crop_face_with_padding
+from utils.image_loading import (
+    load_image_from_path, load_image_for_face_crop, load_display_image, thumbnail_source,
+    configure_raw_decoding, configure_raw_decode_profile, raw_postprocess_kwargs,
+    RAW_EXTENSIONS,
+)
+from utils.image_transforms import (
+    generate_photo_thumbnail, crop_face_with_padding, thumbnail_has_signal,
+)
 from utils.embedding import embedding_to_bytes, bytes_to_embedding
 from utils.tags import tags_to_string, string_to_tags, get_tag_params
 from utils.detection import (

--- a/utils/histogram.py
+++ b/utils/histogram.py
@@ -1,0 +1,168 @@
+"""Packing and decoding for the per-photo histogram BLOB (``photos.histogram_data``).
+
+Two formats coexist on disk and every reader must accept both until a library has
+been fully rescanned:
+
+* **legacy, 1024 bytes** — 256 ``float32`` luminance bins already normalised to
+  sum 1. Written by every scan before the RGB histogram landed.
+* **current, 2048 bytes** — four ``uint16`` channels of 256 bins each, in the
+  order luma, R, G, B. Bin counts are scaled by ONE factor shared by all four
+  channels, so the height relationship between them survives the round trip;
+  per-channel scaling would stretch a near-empty channel to full height and
+  invent a colour cast that is not in the photo.
+
+The format is detected by blob length — there is no version byte, because the
+legacy blobs already in the wild do not have one.
+
+Both formats are computed from the *metrics* decode of a RAW (see
+``utils.image_loading.load_image_from_path``), never from the embedded camera
+preview: the preview carries a baked-in tone curve and in-camera DR/HTP/ALO
+modes lift dark frames non-linearly, which is fine for display and wrong for
+measuring exposure.
+"""
+
+import numpy as np
+
+HISTOGRAM_BINS = 256
+HISTOGRAM_CHANNELS = ('luma', 'r', 'g', 'b')
+LEGACY_HISTOGRAM_BLOB_SIZE = HISTOGRAM_BINS * 4
+HISTOGRAM_BLOB_SIZE = HISTOGRAM_BINS * len(HISTOGRAM_CHANNELS) * 2
+
+# "Clipped" is the pixel that reached the end of the scale and lost its value:
+# exactly bin 0 or exactly bin 255, never a band around them. That is a
+# different measurement from ``photos.shadow_clipped`` /
+# ``highlight_clipped``, which are binary flags over the luminance bands 0-30
+# and 225-255 and feed exposure_score and redundant-bracket culling. The two
+# must not be read as versions of each other.
+SHADOW_CLIP_BIN = 0
+HIGHLIGHT_CLIP_BIN = HISTOGRAM_BINS - 1
+
+# Channels a clipping percentage is measured on. Luma is excluded from the
+# per-photo maximum: it is a weighted mix, so it only saturates once the real
+# channels already have, and including it could never raise the answer.
+CLIP_MEASURED_CHANNELS = ('r', 'g', 'b')
+
+_UINT16_MAX = 65535
+
+
+def pack_histogram(luma, red, green, blue):
+    """Pack four 256-bin count arrays into the 2048-byte ``uint16`` BLOB.
+
+    Counts are scaled by ``65535 / peak`` where ``peak`` is the largest bin
+    across all four channels, so the packed values stay directly comparable
+    between channels.
+    """
+    stacked = np.stack([
+        np.asarray(c, dtype=np.float64).reshape(HISTOGRAM_BINS)
+        for c in (luma, red, green, blue)
+    ])
+    peak = float(stacked.max())
+    if peak > 0:
+        stacked = stacked * (_UINT16_MAX / peak)
+    return np.rint(stacked).astype('<u2').tobytes()
+
+
+def unpack_histogram(blob):
+    """Decode a stored BLOB into ``{'luma': ndarray, 'rgb': (r, g, b) | None}``.
+
+    ``rgb`` is ``None`` for a legacy blob, which only ever held luminance.
+    Returns ``None`` for a missing blob or one whose length matches neither
+    format. Values are the stored magnitudes, not a distribution: callers
+    normalise for their own purpose (by sum for histogram intersection, by the
+    global max for drawing).
+    """
+    if not blob:
+        return None
+    size = len(blob)
+    if size == HISTOGRAM_BLOB_SIZE:
+        channels = np.frombuffer(blob, dtype='<u2').astype(np.float64)
+        channels = channels.reshape(len(HISTOGRAM_CHANNELS), HISTOGRAM_BINS)
+        return {'luma': channels[0], 'rgb': (channels[1], channels[2], channels[3])}
+    if size == LEGACY_HISTOGRAM_BLOB_SIZE:
+        return {'luma': np.frombuffer(blob, dtype='<f4').astype(np.float64), 'rgb': None}
+    return None
+
+
+def downsample_bins(values, bins):
+    """Sum adjacent bins down to ``bins`` buckets. ``bins`` must divide 256."""
+    if bins == HISTOGRAM_BINS:
+        return np.asarray(values, dtype=np.float64)
+    if HISTOGRAM_BINS % bins:
+        raise ValueError(f"bins must divide {HISTOGRAM_BINS}, got {bins}")
+    return np.asarray(values, dtype=np.float64).reshape(bins, HISTOGRAM_BINS // bins).sum(axis=1)
+
+
+def clip_percents(decoded, decimals=4):
+    """Percentage of pixels sitting exactly on bin 0 / bin 255, per channel.
+
+    Returns ``{'shadow': {...}, 'highlight': {...}}`` keyed by luma/r/g/b, or
+    ``None`` for a legacy blob — which never held the channels, so its answer
+    is *unknown* and must never be rendered as zero.
+
+    Derivable from the stored BLOB with no image decode because
+    ``pack_histogram`` scales all four channels by ONE factor: it cancels in
+    ``bin / total``, so the ratio survives the uint16 round trip even though
+    the counts themselves do not.
+    """
+    if decoded is None or decoded['rgb'] is None:
+        return None
+    channels = dict(zip(HISTOGRAM_CHANNELS, (decoded['luma'],) + tuple(decoded['rgb'])))
+    out = {'shadow': {}, 'highlight': {}}
+    for name, counts in channels.items():
+        total = float(np.asarray(counts, dtype=np.float64).sum())
+        for direction, index in (('shadow', SHADOW_CLIP_BIN), ('highlight', HIGHLIGHT_CLIP_BIN)):
+            share = float(counts[index]) / total * 100.0 if total > 0 else 0.0
+            out[direction][name] = round(share, decimals)
+    return out
+
+
+def max_clip_percents(decoded, decimals=4):
+    """``(shadow_pct, highlight_pct)`` for the worst of R/G/B in each direction.
+
+    ``(None, None)`` for a legacy blob. Max-across-channels is what the stored
+    columns hold: a single channel blowing out is the case luminance alone
+    cannot see, and "any channel above N%" needs no more than the worst one.
+    """
+    percents = clip_percents(decoded, decimals=decimals)
+    if percents is None:
+        return None, None
+    return tuple(
+        round(max(percents[direction][c] for c in CLIP_MEASURED_CHANNELS), decimals)
+        for direction in ('shadow', 'highlight')
+    )
+
+
+def _interior_bins(counts):
+    """The counts with both clipping bins zeroed, for drawing.
+
+    A clipped frame puts a large share of its pixels in one bin, and that spike
+    becomes the global maximum — normalising against it flattens the whole
+    tonal curve into a hairline at the baseline and destroys the only thing the
+    curve is for. The spikes are reported separately as clipping percentages
+    and drawn as end markers instead.
+    """
+    interior = np.asarray(counts, dtype=np.float64).copy()
+    interior[SHADOW_CLIP_BIN] = 0.0
+    interior[HIGHLIGHT_CLIP_BIN] = 0.0
+    return interior
+
+
+def display_channels(decoded, bins=HISTOGRAM_BINS, decimals=4):
+    """Turn a decoded histogram into draw-ready lists in ``[0, 1]``.
+
+    Scaled over the interior bins (1..254) only, and every channel is divided
+    by the single largest interior bin across all channels — per-channel
+    maxima would stretch a near-empty channel to full height and invent a
+    colour cast the photo does not have. Returns
+    ``{'luma': [...], 'r': [...] | None, 'g': ..., 'b': ...}``.
+    """
+    rgb = decoded['rgb']
+    channels = [decoded['luma']] if rgb is None else [decoded['luma'], *rgb]
+    series = [downsample_bins(_interior_bins(c), bins) for c in channels]
+    peak = max(float(s.max()) for s in series)
+    if peak > 0:
+        series = [s / peak for s in series]
+    rounded = [np.round(s, decimals).tolist() for s in series]
+    if rgb is None:
+        return {'luma': rounded[0], 'r': None, 'g': None, 'b': None}
+    return dict(zip(HISTOGRAM_CHANNELS, rounded))

--- a/utils/image_loading.py
+++ b/utils/image_loading.py
@@ -34,6 +34,185 @@ RAW_EXTENSIONS = {'.cr2', '.cr3', '.nef', '.arw', '.raf', '.rw2', '.dng', '.orf'
 HEIF_EXTENSIONS = {'.heic', '.heif'} if _heif_available else set()
 
 
+RAW_DECODE_DEFAULTS = {
+    'bright': 1.62,
+    'prefer_embedded_preview': True,
+    'preview_min_sensor_ratio': 0.5,
+    'viewer_concurrency': 3,
+    'faithful_bracket_render': True,
+}
+
+# A bracket exists to capture highlight headroom in its +EV frames, and an HDR
+# panorama is bracketed at every position. Both the camera preview's tone curve
+# and the uniform `bright` gain compress those highlights — which is exactly the
+# information the user is trying to judge — so a frame of one of these kinds
+# renders with neither. A plain 'panorama' is not bracketed and is excluded.
+BRACKETED_SEQUENCE_KINDS = frozenset({'bracket', 'hdr_panorama'})
+
+# No gain at all: LibRaw's own output level, the rendering a bracketed frame gets.
+FAITHFUL_BRIGHT = 1.0
+
+# LibRaw replaces the camera white level with the frame's own maximum when that
+# maximum lands above this fraction of it. Restored only to reproduce the
+# pre-fix rendering side by side.
+_LIBRAW_AUTO_BRIGHT_MAXIMUM_THR = 0.75
+
+# Smallest embedded preview worth serving: the stored thumbnail's long edge.
+DISPLAY_PREVIEW_MIN_LONG_EDGE = 640
+
+_EXIF_ORIENTATION_TAG = 274
+
+# LibRaw sizes.flip -> counter-clockwise degrees that make the frame upright.
+_LIBRAW_FLIP_ROTATIONS = {3: 180, 5: 90, 6: 270}
+
+_raw_decode_settings = None
+
+
+def configure_raw_decode_profile(settings=None):
+    """Set the RAW decode profile for this process; missing keys keep defaults."""
+    global _raw_decode_settings
+    merged = dict(RAW_DECODE_DEFAULTS)
+    merged.update(settings or {})
+    _raw_decode_settings = merged
+    return merged
+
+
+def _raw_decode_settings_from_config():
+    """Read the profile straight off disk, without validating or rewriting it.
+
+    A decode can run inside a viewer request or a worker thread, where
+    ScoringConfig's default validation would re-save a corrected config behind
+    the write lock's back. The path is resolved absolutely because a decode
+    must not depend on the process's working directory.
+    """
+    try:
+        from config import ScoringConfig, default_config_path
+        return ScoringConfig(default_config_path(), validate=False).get_raw_decode_settings()
+    except Exception as ex:
+        logger.warning("Using default RAW decode settings (%s)", ex)
+        return {}
+
+
+def get_raw_decode_settings():
+    """RAW decode profile, read from scoring_config.json on first use."""
+    if _raw_decode_settings is None:
+        return configure_raw_decode_profile(_raw_decode_settings_from_config())
+    return _raw_decode_settings
+
+
+def raw_postprocess_kwargs(auto_bright=False, bright=None):
+    """LibRaw postprocess parameters for a faithful, exposure-preserving demosaic.
+
+    ``no_auto_bright`` and ``adjust_maximum_thr`` are per-frame adaptive terms.
+    The first rescales a frame until roughly 1% of *its own* pixels clip; the
+    second substitutes that same frame's brightest pixel for the camera white
+    level. Together they equalise exposure across a bracket, erasing the very
+    ladder the scoring engine measures, so this profile disables both and
+    applies one fixed ``bright`` gain to every frame instead.
+
+    ``bright`` overrides that configured gain; ``FAITHFUL_BRIGHT`` renders with
+    no gain at all, which is what a bracketed frame gets.
+
+    ``auto_bright=True`` restores LibRaw's adaptive terms so
+    ``--check-raw-rendering`` can render the pre-fix result alongside.
+    """
+    import rawpy
+    if auto_bright:
+        gain = 1.0
+    elif bright is None:
+        gain = float(get_raw_decode_settings()['bright'])
+    else:
+        gain = float(bright)
+    return {
+        'use_camera_wb': True,
+        'no_auto_bright': not auto_bright,
+        'adjust_maximum_thr': _LIBRAW_AUTO_BRIGHT_MAXIMUM_THR if auto_bright else 0.0,
+        'bright': gain,
+        'output_color': rawpy.ColorSpace.sRGB,
+        'output_bps': 8,
+    }
+
+
+def renders_faithfully(sequence_kind):
+    """Whether a frame of this sequence kind must render with no correction.
+
+    Bracket membership is only known once sequence detection has run, which is
+    after a scan — so this is a display-time decision, never a scan-time one.
+    """
+    if not get_raw_decode_settings()['faithful_bracket_render']:
+        return False
+    return sequence_kind in BRACKETED_SEQUENCE_KINDS
+
+
+def _upright_preview(pil_img, libraw_flip):
+    """Rotate an embedded preview upright.
+
+    ``unpack_thumb`` hands back the preview exactly as the camera wrote it, so
+    nothing has been rotated yet. Most previews carry their own EXIF
+    orientation; those that do not inherit the host RAW's, which LibRaw exposes
+    as ``sizes.flip`` and applies itself when demosaicing.
+    """
+    _, ImageOps = _ensure_pil()
+    exif = pil_img.getexif()
+    if exif and exif.get(_EXIF_ORIENTATION_TAG):
+        return ImageOps.exif_transpose(pil_img)
+    angle = _LIBRAW_FLIP_ROTATIONS.get(libraw_flip)
+    return pil_img.rotate(angle, expand=True) if angle else pil_img
+
+
+def extract_raw_preview(photo_path, min_long_edge=0, min_sensor_ratio=0.0):
+    """Decode the camera-embedded preview of a RAW file, or None if unusable.
+
+    The camera preview carries the model's own tone curve, DR modes and
+    exposure, which is what keeps a bracket's frames distinguishable, and reads
+    a fraction of the bytes a demosaic does.
+
+    None is returned whenever the preview cannot stand in for a decode: the
+    file has none, LibRaw cannot unpack its codec (recent Canon CR3 embed
+    H.265), the bytes fail to decode, or it is smaller than the caller accepts.
+
+    Args:
+        photo_path: Path to a RAW file (str or Path)
+        min_long_edge: Reject a preview whose long edge is under this
+        min_sensor_ratio: Reject a preview whose long edge is under this
+                          fraction of the sensor's
+    """
+    import rawpy
+    Image, _ = _ensure_pil()
+    try:
+        with rawpy.imread(str(photo_path)) as raw:
+            thumb = raw.extract_thumb()
+            sizes = raw.sizes
+            sensor_long_edge = max(sizes.width, sizes.height)
+            flip = sizes.flip
+            if thumb.format == rawpy.ThumbFormat.JPEG:
+                preview = Image.open(BytesIO(thumb.data))
+                preview.load()
+            else:
+                preview = Image.fromarray(np.array(thumb.data))
+    except Exception as ex:
+        logger.debug("No usable embedded preview in %s: %s", photo_path, ex)
+        return None
+
+    preview = _upright_preview(preview, flip)
+    long_edge = max(preview.size)
+    if long_edge < min_long_edge:
+        return None
+    if sensor_long_edge > 0 and long_edge < min_sensor_ratio * sensor_long_edge:
+        return None
+    return preview if preview.mode == 'RGB' else preview.convert('RGB')
+
+
+def _display_preview(photo_path, min_sensor_ratio):
+    if not get_raw_decode_settings()['prefer_embedded_preview']:
+        return None
+    return extract_raw_preview(
+        photo_path,
+        min_long_edge=DISPLAY_PREVIEW_MIN_LONG_EDGE,
+        min_sensor_ratio=min_sensor_ratio,
+    )
+
+
 # RAW decode concurrency. LibRaw is reentrant when each decode uses its own
 # rawpy.imread() instance (which every call site here does), so a global mutex
 # is unnecessary for correctness. The semaphore acts as a memory governor:
@@ -68,6 +247,11 @@ _abandoned_decodes = 0
 _hung_decodes = 0
 _state_lock = threading.Lock()
 
+# A second, independent budget for the /image viewer path: a viewer request
+# must never queue behind library decode work holding _raw_semaphore. Built
+# lazily since its size comes from disk config, not a CPU/RAM heuristic.
+_viewer_semaphore = None
+
 
 def configure_raw_decoding(concurrency=None, timeout_seconds=None):
     """Configure RAW decode concurrency and timeout for a scan run.
@@ -78,7 +262,7 @@ def configure_raw_decoding(concurrency=None, timeout_seconds=None):
         timeout_seconds: Abandon a decode after this many seconds
                          (None = keep current, 0 = disabled)
     """
-    global _decode_concurrency, _raw_semaphore, _decode_timeout, _decode_executor, _hung_decodes
+    global _decode_concurrency, _raw_semaphore, _decode_timeout, _decode_executor, _hung_decodes, _viewer_semaphore
     with _state_lock:
         if concurrency:
             _decode_concurrency = max(1, int(concurrency))
@@ -87,6 +271,8 @@ def configure_raw_decoding(concurrency=None, timeout_seconds=None):
             if _decode_executor is not None:
                 _decode_executor.shutdown(wait=False)
                 _decode_executor = None
+            _viewer_semaphore = threading.BoundedSemaphore(
+                max(1, int(get_raw_decode_settings()['viewer_concurrency'])))
         if timeout_seconds is not None:
             _decode_timeout = max(0.0, float(timeout_seconds))
     logger.info(
@@ -106,41 +292,39 @@ def _get_decode_executor():
         return _decode_executor
 
 
-def _decode_raw(photo, use_thumbnail, started_event=None):
-    """Decode a RAW file to a PIL image. Runs under the decode semaphore.
+def _get_viewer_semaphore():
+    """Lazily build the viewer decode budget from config on first real use.
+
+    The viewer process never calls configure_raw_decoding, so this is the
+    only path that sizes it from the user's scoring_config.json.
+    """
+    global _viewer_semaphore
+    with _state_lock:
+        if _viewer_semaphore is None:
+            _viewer_semaphore = threading.BoundedSemaphore(
+                max(1, int(get_raw_decode_settings()['viewer_concurrency'])))
+        return _viewer_semaphore
+
+
+def _decode_raw(photo, use_thumbnail, started_event=None, decode_budget='library', bright=None):
+    """Decode a RAW file to a PIL image. Runs under the given decode budget's semaphore.
 
     started_event, when supplied, is set the moment the semaphore is acquired
     so the caller can time only the decode, never the queue wait for a slot.
     """
     import rawpy
-    Image, ImageOps = _ensure_pil()
+    Image, _ = _ensure_pil()
     pil_img = None
-    with _raw_semaphore:
+    semaphore = _get_viewer_semaphore() if decode_budget == 'viewer' else _raw_semaphore
+    with semaphore:
         if started_event is not None:
             started_event.set()
         if use_thumbnail:
-            # Try thumbnail extraction first (faster, lower quality)
-            with rawpy.imread(str(photo)) as raw:
-                try:
-                    thumb = raw.extract_thumb()
-                    if thumb.format == rawpy.ThumbFormat.JPEG:
-                        pil_img = Image.open(BytesIO(thumb.data))
-                        pil_img = ImageOps.exif_transpose(pil_img)
-                    else:
-                        pil_img = Image.fromarray(thumb.data)
-                except Exception:
-                    pass  # Will fall back to demosaic below
+            pil_img = extract_raw_preview(photo)
 
-        # Full demosaic (default, best quality)
         if pil_img is None:
             with rawpy.imread(str(photo)) as raw:
-                rgb = raw.postprocess(
-                    use_camera_wb=True,
-                    no_auto_bright=False,
-                    output_color=rawpy.ColorSpace.sRGB,
-                    output_bps=8
-                )
-                pil_img = Image.fromarray(rgb)
+                pil_img = Image.fromarray(raw.postprocess(**raw_postprocess_kwargs(bright=bright)))
     return pil_img
 
 
@@ -151,7 +335,7 @@ def _on_hung_decode_done(_future):
         _hung_decodes = max(0, _hung_decodes - 1)
 
 
-def _decode_raw_with_timeout(photo, use_thumbnail):
+def _decode_raw_with_timeout(photo, use_thumbnail, decode_budget='library', bright=None):
     """Decode a RAW file, timing only the decode itself.
 
     The wait for a free decode slot (semaphore/executor queueing) is excluded
@@ -162,7 +346,8 @@ def _decode_raw_with_timeout(photo, use_thumbnail):
     """
     global _abandoned_decodes, _hung_decodes
     started = threading.Event()
-    future = _get_decode_executor().submit(_decode_raw, photo, use_thumbnail, started)
+    future = _get_decode_executor().submit(_decode_raw, photo, use_thumbnail, started,
+                                           decode_budget, bright)
     while not started.wait(timeout=_decode_timeout):
         if future.done():
             break
@@ -188,11 +373,95 @@ def _decode_raw_with_timeout(photo, use_thumbnail):
         return None
 
 
+def _decode_raw_bounded(photo, use_thumbnail=False, decode_budget='library', bright=None):
+    """Decode a RAW file under the configured concurrency and timeout policy."""
+    if _decode_timeout > 0:
+        return _decode_raw_with_timeout(photo, use_thumbnail, decode_budget, bright)
+    return _decode_raw(photo, use_thumbnail, decode_budget=decode_budget, bright=bright)
+
+
+def submit_decode(fn, *args):
+    """Schedule storage-bound decode work on the shared RAW decode pool.
+
+    Keeps bulk maintenance jobs on the one pool ``configure_raw_decoding``
+    sizes, so a run can never open more concurrent decodes than the memory
+    governor allows.
+    """
+    return _get_decode_executor().submit(fn, *args)
+
+
+def load_display_image(photo_path, min_preview_sensor_ratio=0.0, decode_budget='library',
+                       sequence_kind=None):
+    """Load an image in display space: what a viewer or a thumbnail should show.
+
+    A RAW file renders from its camera-embedded preview when one is usable,
+    which keeps the camera's tone curve and exposure — the reason a bracket's
+    frames stay distinguishable — and reads far less of the file than a
+    demosaic. Anything else, and any RAW whose preview is missing or too small,
+    falls back to the metrics-profile demosaic.
+
+    A RAW belonging to a bracketed set is the exception: it demosaics with no
+    gain at all (see ``renders_faithfully``), because the preview's tone curve
+    and the ``bright`` gain both compress the highlight headroom the bracket
+    was shot to capture.
+
+    This is deliberately not ``load_image_from_path``: stored face bboxes and
+    ``image_width``/``image_height`` are expressed in the demosaic's pixel
+    space, so neither a preview-sourced nor a bracket-specific buffer must ever
+    reach them.
+
+    Args:
+        photo_path: Path to image file (str or Path)
+        min_preview_sensor_ratio: Smallest preview-to-sensor long-edge ratio
+                                  worth serving instead of a demosaic
+        decode_budget: Which semaphore a demosaic fallback draws from —
+                       ``'library'`` (default) for scan/CLI work, ``'viewer'``
+                       for the /image endpoint, which must never queue behind it
+        sequence_kind: The row's ``photos.sequence_kind``, or None when it
+                       belongs to no detected set
+
+    Returns:
+        PIL Image in RGB, or None on error.
+    """
+    Image, ImageOps = _ensure_pil()
+    try:
+        photo = Path(photo_path)
+        if photo.suffix.lower() in RAW_EXTENSIONS:
+            if renders_faithfully(sequence_kind):
+                return _decode_raw_bounded(photo, decode_budget=decode_budget,
+                                           bright=FAITHFUL_BRIGHT)
+            preview = _display_preview(photo, min_preview_sensor_ratio)
+            return preview if preview is not None else _decode_raw_bounded(photo, decode_budget=decode_budget)
+        pil_img = ImageOps.exif_transpose(Image.open(photo))
+        return pil_img if pil_img.mode == 'RGB' else pil_img.convert('RGB')
+    except RuntimeError:
+        raise
+    except Exception as e:
+        logger.error("Error loading display image %s: %s", photo_path, e)
+        return None
+
+
+def thumbnail_source(photo_path, decoded_img):
+    """Pick the buffer a stored thumbnail should be generated from.
+
+    Non-RAW files are already in display space. For RAW the embedded preview is
+    preferred, and the caller's own demosaic stands in when there is none — a
+    second full decode would cost far more than the thumbnail is worth.
+    """
+    if Path(photo_path).suffix.lower() not in RAW_EXTENSIONS:
+        return decoded_img
+    preview = _display_preview(photo_path, 0.0)
+    return preview if preview is not None else decoded_img
+
+
 def load_image_from_path(photo_path, use_thumbnail=False):
     """
     Load image from path, handling RAW files (CR2/CR3) and JPEGs.
 
-    For RAW files, uses full demosaic by default for maximum quality.
+    For RAW files, uses the metrics-profile demosaic by default: faithful
+    exposure, no per-frame auto-brightness (see raw_postprocess_kwargs). This
+    is the pixel space every stored face bbox and image_width/image_height is
+    expressed in — display buffers come from load_display_image instead.
     Set use_thumbnail=True for faster loading when lower quality is acceptable.
     Applies EXIF transpose for proper orientation.
 
@@ -215,10 +484,7 @@ def load_image_from_path(photo_path, use_thumbnail=False):
         photo = Path(photo_path)
 
         if photo.suffix.lower() in RAW_EXTENSIONS:
-            if _decode_timeout > 0:
-                pil_img = _decode_raw_with_timeout(photo, use_thumbnail)
-            else:
-                pil_img = _decode_raw(photo, use_thumbnail)
+            pil_img = _decode_raw_bounded(photo, use_thumbnail)
             if pil_img is None:
                 return None, None
         else:

--- a/utils/image_loading.py
+++ b/utils/image_loading.py
@@ -184,7 +184,7 @@ def extract_raw_preview(photo_path, min_long_edge=0, min_sensor_ratio=0.0):
             else:
                 preview = Image.fromarray(np.array(thumb.data))
     except Exception as ex:
-        logger.debug("No usable embedded preview in %s: %s", photo_path, ex)
+        logger.debug("No usable embedded preview in %s: %s", os.path.basename(photo_path), ex)
         return None
 
     preview = _upright_preview(preview, flip)
@@ -420,7 +420,7 @@ def load_display_image(photo_path, min_preview_sensor_ratio=0.0, decode_budget='
     except RuntimeError:
         raise
     except Exception as e:
-        logger.error("Error loading display image %s: %s", photo_path, e)
+        logger.error("Error loading display image %s: %s", os.path.basename(photo_path), e)
         return None
 
 

--- a/utils/image_loading.py
+++ b/utils/image_loading.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import numpy as np
 
+from config.scoring_config import RAW_DECODE_DEFAULTS
 from utils._lazy import ensure_cv2 as _ensure_cv2, ensure_pil as _ensure_pil
 
 logger = logging.getLogger("facet.image_loading")
@@ -33,14 +34,6 @@ RAW_EXTENSIONS = {'.cr2', '.cr3', '.nef', '.arw', '.raf', '.rw2', '.dng', '.orf'
 # HEIF/HEIC formats (iPhone default since iOS 11) — empty when pillow-heif is missing
 HEIF_EXTENSIONS = {'.heic', '.heif'} if _heif_available else set()
 
-
-RAW_DECODE_DEFAULTS = {
-    'bright': 1.62,
-    'prefer_embedded_preview': True,
-    'preview_min_sensor_ratio': 0.5,
-    'viewer_concurrency': 3,
-    'faithful_bracket_render': True,
-}
 
 # A bracket exists to capture highlight headroom in its +EV frames, and an HDR
 # panorama is bracketed at every position. Both the camera preview's tone curve

--- a/utils/image_loading.py
+++ b/utils/image_loading.py
@@ -373,16 +373,6 @@ def _decode_raw_bounded(photo, use_thumbnail=False, decode_budget='library', bri
     return _decode_raw(photo, use_thumbnail, decode_budget=decode_budget, bright=bright)
 
 
-def submit_decode(fn, *args):
-    """Schedule storage-bound decode work on the shared RAW decode pool.
-
-    Keeps bulk maintenance jobs on the one pool ``configure_raw_decoding``
-    sizes, so a run can never open more concurrent decodes than the memory
-    governor allows.
-    """
-    return _get_decode_executor().submit(fn, *args)
-
-
 def load_display_image(photo_path, min_preview_sensor_ratio=0.0, decode_budget='library',
                        sequence_kind=None):
     """Load an image in display space: what a viewer or a thumbnail should show.

--- a/utils/image_transforms.py
+++ b/utils/image_transforms.py
@@ -15,6 +15,38 @@ def _ensure_pil():
     return Image
 
 
+# Brightest pixel a regenerated thumbnail must reach to count as a real render.
+#
+# A severely truncated Panasonic RW2 does not fail to decode: LibRaw zero-fills
+# the missing buffer and hands back a valid, full-size, entirely black frame
+# (pinned by tests/test_raw_brands.py). A `is None` check does not see that, so
+# a corrupt file would silently overwrite a good stored thumbnail with a black
+# one. Measured behaviour picks the bound: a zero-filled buffer encodes to a
+# thumbnail whose peak is exactly 0, while a night frame with a highlight over
+# even 0.1% of the area measures 83+. Four leaves the guard clear of both.
+#
+# The test is the MAXIMUM, never the mean: a real night shot is mostly black by
+# intent and a mean-based bound would reject it. Content dim enough to fail this
+# renders as black in the grid anyway, so keeping the previous thumbnail costs
+# the user nothing.
+DEGENERATE_THUMBNAIL_PEAK = 4
+
+
+def thumbnail_has_signal(thumbnail_bytes):
+    """Whether a freshly generated thumbnail carries any image signal at all.
+
+    Deliberately measured on the encoded thumbnail rather than the
+    full-resolution buffer: it is three orders of magnitude smaller and it is
+    the artifact actually about to be stored.
+    """
+    Image = _ensure_pil()
+    if not thumbnail_bytes:
+        return False
+    with Image.open(BytesIO(thumbnail_bytes)) as img:
+        peak = img.convert('L').getextrema()[1]
+    return peak >= DEGENERATE_THUMBNAIL_PEAK
+
+
 def generate_photo_thumbnail(pil_img, size=640, quality=80):
     """
     Generate JPEG thumbnail from PIL image.

--- a/validation/database_validator.py
+++ b/validation/database_validator.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 
 from db import get_connection
+from utils.histogram import HISTOGRAM_BLOB_SIZE, LEGACY_HISTOGRAM_BLOB_SIZE
 from validation.validation_result import ValidationResult
 
 logger = logging.getLogger("facet.validator")
@@ -375,24 +376,27 @@ class DatabaseValidator:
         self.results.append(result2)
         self._print_result(result2)
 
-        # Check 3: histogram_data BLOB size
+        # Check 3: histogram_data BLOB size. Two formats are valid on disk —
+        # the legacy 256 float32 luminance bins and the current four uint16
+        # channels (see utils.histogram) — so both lengths pass.
         result3 = ValidationResult(
             "histogram_blob_size",
-            "histogram_data BLOB incorrect size (should be 1024 bytes)"
+            f"histogram_data BLOB incorrect size (should be "
+            f"{LEGACY_HISTOGRAM_BLOB_SIZE} or {HISTOGRAM_BLOB_SIZE} bytes)"
         )
 
         cursor.execute("""
             SELECT path, filename, LENGTH(histogram_data) as len
             FROM photos
             WHERE histogram_data IS NOT NULL
-              AND LENGTH(histogram_data) != 1024
+              AND LENGTH(histogram_data) NOT IN (?, ?)
             LIMIT 100
-        """)
+        """, (LEGACY_HISTOGRAM_BLOB_SIZE, HISTOGRAM_BLOB_SIZE))
 
         for row in cursor.fetchall():
             result3.add_issue(
                 {'path': row[0], 'filename': row[1], 'blob_size': row[2]},
-                f"size={row[2]} bytes (expected 1024)"
+                f"size={row[2]} bytes (expected {LEGACY_HISTOGRAM_BLOB_SIZE} or {HISTOGRAM_BLOB_SIZE})"
             )
 
         self.results.append(result3)


### PR DESCRIPTION
Closes #105.

RAW frames of an exposure bracket rendered at nearly the same brightness. Every decode passed `no_auto_bright=False` to LibRaw, enabling a per-frame gain that scales each image until ~1% of *its own* pixels clip. That gain is always ≥ 1, so applied independently to each frame it pulls the dark rungs up toward the base exposure and leaves the bright ones alone. A second per-frame term, `adjust_maximum_thr`, was never passed either, so its 0.75 default replaced the camera's white level with whatever the brightest pixel in that frame happened to be.

Measured on a real five-frame EOS 6D bracket spanning 6.7 stops, the −3.42 EV, −1.74 EV and 0.00 EV frames rendered at means of **56.3, 55.2 and 54.1** — indistinguishable. The ladder now spans **17.57×**, or **24.03×** for the uncorrected bracket rendering.

## What changed

- **Display and measurement are separated.** Viewers get the camera's embedded preview where one is large enough — it carries the per-model tone curve and DR modes no global constant reproduces, and reads far less of the file. Scorers get a faithful demosaic with both adaptive terms off. Bracketed frames bypass both the preview and the display gain, since a bracket exists to capture the headroom either would clip.
- **Per-channel clipping and an RGB histogram.** Stored histograms carry luma plus three channels; true clipped fractions are derived from that blob without decoding again. Clipping shows as markers, and as a gallery badge above a threshold chosen from measurement — at 0.1% a badge fires on 54% of a real library, at 5% on 4%.
- **Set membership.** Photo details name the bracket, panorama, burst or duplicate a frame belongs to, with siblings and EV offsets, and can scope the gallery to that set.
- **Migration without a rescan.** `--refresh-thumbnails` rewrites stored thumbnails from each file's embedded preview; `--backfill-clipping` derives the new percentages from histograms already stored.

## Defects found along the way

- **The CLIP-MLP aesthetic score was an untrained random projection** on `legacy`/`8gb`. The scorer built a 768-256-1 network for a 1024/128/64/16 checkpoint and `strict=False` swallowed all fourteen mismatched keys; the correct definition sat in a code path nothing calls. Values tracked the scan process's RNG seed — the same 200 photos gave 4.870/5.344/5.347 under three seeds. Rank correlation against an independent aesthetic model rises from 0.072 to 0.297.
- **The `24gb` profile ran no composition model.** It was configured for a VLM the default multi-pass scan never dispatches, so those users silently got rule-based CPU composition and no `composition_pattern`. Rule-based and SAMP-Net are uncorrelated on real data (Spearman 0.025), so this was a different signal, not an offset.
- **`--refresh-thumbnails` deadlocked**, and **cull-to-folder refusals were undiagnosable** — the server's actionable message was unreachable and the client discarded it anyway.

## Upgrade notes

- Existing libraries are not invalidated. The full-size view corrects itself on upgrade; stored thumbnails need `--refresh-thumbnails`, and photos are flagged in a banner until then.
- **`--recompute-average` does not repair the aesthetic column** — verified: it builds `Facet(lightweight=True)`, which disables embeddings. `legacy`/`8gb` users need `facet.py <dir> --pass embeddings --force` then `--recompute-average`.
- `24gb` users should run `--recompute-composition-gpu` then `--recompute-average`.

## Still unverified

- **Bracket frames render near-black at the dark end** (−3.42 EV → mean 5.8/255). Literally correct, unjudged in practice. `raw_decode.faithful_bracket_render` reverts it.
- **Non-Canon RAW** is covered by 8 sample files, not a real library; the EXIF-absent preview-orientation fallback has never run on a real file.
- **The final review round's fixes are themselves unreviewed** — the budget for this branch was spent. Four review passes ran (12 → 8 → 2 → 7 findings, all fixed); the fifth was not affordable.
- The client/API contract audit that found several of these was only partly completed.
